### PR TITLE
Fix chunk-merge bug in ReactFlightWebpackPlugin (v19.2.1)

### DIFF
--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -240,14 +240,25 @@ class ReactFlightWebpackPlugin {
             });
             compilation.chunkGroups.forEach(function (chunkGroup) {
               function recordModule(id, module) {
-                resolvedClientFiles.has(module.resource) &&
+                if (
+                  resolvedClientFiles.has(module.resource) &&
                   ((module = url.pathToFileURL(module.resource).href),
-                  void 0 !== module &&
-                    (filePathToModuleMetadata[module] = {
+                  void 0 !== module)
+                )
+                  if (filePathToModuleMetadata[module]) {
+                    id = filePathToModuleMetadata[module];
+                    module = new Set();
+                    for (var i = 0; i < id.chunks.length; i += 2)
+                      module.add(id.chunks[i]);
+                    for (i = 0; i < chunks.length; i += 2)
+                      module.has(chunks[i]) ||
+                        id.chunks.push(chunks[i], chunks[i + 1]);
+                  } else
+                    filePathToModuleMetadata[module] = {
                       id,
-                      chunks,
+                      chunks: chunks.slice(),
                       name: "*"
-                    }));
+                    };
               }
               const chunks = [];
               chunkGroup.chunks.forEach(function (c) {


### PR DESCRIPTION
## Summary
- Fix `recordModule()` in `ReactFlightWebpackPlugin` to **merge** chunk arrays instead of **overwriting** when the same module appears in multiple webpack chunk groups
- This fixes `TypeError: r[e] is not a function` errors during RSC hydration on slow networks (e.g., 3G + CPU throttling)
- Built from React fork `rsc-patches/v19.2.1` with the fix applied

## Root Cause
When webpack splits modules across multiple chunks (via chunk groups), the plugin's `recordModule()` was called multiple times for the same module. Each call overwrote the previous entry with only the current chunk group's chunks, losing earlier chunk references. The RSC flight client then failed to preload all necessary chunks, causing `__webpack_require__` to fail when a module factory hadn't been registered yet.

## The Fix
Changed from:
```javascript
filePathToModuleMetadata[href] = { id, chunks, name: '*' };
```

To merge logic that preserves chunks from all chunk groups:
```javascript
if (filePathToModuleMetadata[href]) {
  // Merge chunks from additional chunk groups
  const existing = filePathToModuleMetadata[href];
  const existingChunkIds = new Set();
  for (let i = 0; i < existing.chunks.length; i += 2) {
    existingChunkIds.add(existing.chunks[i]);
  }
  for (let j = 0; j < chunks.length; j += 2) {
    if (!existingChunkIds.has(chunks[j])) {
      existing.chunks.push(chunks[j], chunks[j + 1]);
    }
  }
} else {
  filePathToModuleMetadata[href] = { id, chunks: chunks.slice(), name: '*' };
}
```

## Test plan
- [x] Built from fixed React fork branch
- [ ] Verify with localhub-demo-search under Slow 3G + 6x CPU throttling
- [ ] Confirm zero `TypeError` errors after 3+ hard reloads

Resolves #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)