### PR TITLE
Add checks/statuses read permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,8 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      checks: read
+      statuses: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,11 +36,14 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+            checks: read
+            statuses: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
Applies the workflow update from [shakacode/react_on_rails#2487](https://github.com/shakacode/react_on_rails/pull/2487):

- add `checks: read` and `statuses: read` to job permissions
- pass `github_token: ${{ github.token }}` to `anthropics/claude-code-action`
- add `checks: read` and `statuses: read` to `additional_permissions`

Admin merge requested to keep rollout fast across repos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that broadens the GitHub token’s read permissions to include `checks` and `statuses` and passes the default `github.token` into the Claude action.
> 
> **Overview**
> The `Claude Code` GitHub Actions workflow now passes `github_token: ${{ github.token }}` to `anthropics/claude-code-action`.
> 
> It also expands the job and `additional_permissions` to include `checks: read` and `statuses: read`, enabling Claude to read check runs/statuses when operating on PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad33710164057ba2581ad98ade3149ccaa6fc717. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->