### PR TITLE
Fix RSC chunk mapping for .server/.client paired components

### DIFF
--- a/src/client.node.ts
+++ b/src/client.node.ts
@@ -1,10 +1,16 @@
 import { createFromNodeStream } from './react-server-dom-webpack/client.node';
 import { BundleManifest } from './types';
+import { aliasServerToClientEntries } from './manifestUtils';
 
 const createSSRManifest = (clientManifest: BundleManifest, serverManifest: BundleManifest) => {
   const { filePathToModuleMetadata: clientFilePathToModuleMetadata, moduleLoading: clientModuleLoading } = clientManifest;
 
   const { filePathToModuleMetadata: serverFilePathToModuleMetadata } = serverManifest;
+
+  // Alias .server entries to .client entries in both manifests so that the
+  // join produces consistent mappings for paired .server/.client components.
+  aliasServerToClientEntries(clientFilePathToModuleMetadata);
+  aliasServerToClientEntries(serverFilePathToModuleMetadata);
 
   const moduleMap: Record<string, unknown> = {};
   Object.entries(clientFilePathToModuleMetadata).forEach(([aboluteFileUrl, clientFileBundlingInfo]) => {

--- a/src/manifestUtils.ts
+++ b/src/manifestUtils.ts
@@ -1,0 +1,23 @@
+import { BundleManifest } from './types';
+
+/**
+ * When both Component.server.ext and Component.client.ext exist with
+ * "use client", the RSC bundle creates proxies whose $$id points to the
+ * .server file URL. The client manifest has separate entries for both
+ * variants, so serializeClientReference would resolve to the wrong
+ * .server chunk.
+ *
+ * This function overwrites each .server entry with the corresponding
+ * .client entry's data (module ID + chunks) when both exist, so the RSC
+ * payload references the correct .client chunk.
+ */
+export function aliasServerToClientEntries(
+  filePathToModuleMetadata: BundleManifest['filePathToModuleMetadata'],
+): void {
+  for (const fileUrl of Object.keys(filePathToModuleMetadata)) {
+    const clientUrl = fileUrl.replace(/\.server(\.[^./]+)$/, '.client$1');
+    if (clientUrl !== fileUrl && filePathToModuleMetadata[clientUrl] !== undefined) {
+      filePathToModuleMetadata[fileUrl] = filePathToModuleMetadata[clientUrl];
+    }
+  }
+}

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -290,15 +290,6 @@ class ReactFlightWebpackPlugin {
                 });
               });
             });
-            var serverFileUrls = Object.keys(filePathToModuleMetadata);
-            for (let i = 0; i < serverFileUrls.length; i++) {
-              const fileUrl = serverFileUrls[i],
-                clientUrl = fileUrl.replace(/\.server(\.[^./]+)$/, ".client$1");
-              clientUrl !== fileUrl &&
-                void 0 !== filePathToModuleMetadata[clientUrl] &&
-                (filePathToModuleMetadata[fileUrl] =
-                  filePathToModuleMetadata[clientUrl]);
-            }
             configuredCrossOriginLoading = JSON.stringify(
               configuredCrossOriginLoading,
               null,

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -290,6 +290,15 @@ class ReactFlightWebpackPlugin {
                 });
               });
             });
+            var serverFileUrls = Object.keys(filePathToModuleMetadata);
+            for (let i = 0; i < serverFileUrls.length; i++) {
+              const fileUrl = serverFileUrls[i],
+                clientUrl = fileUrl.replace(/\.server(\.[^./]+)$/, ".client$1");
+              clientUrl !== fileUrl &&
+                void 0 !== filePathToModuleMetadata[clientUrl] &&
+                (filePathToModuleMetadata[fileUrl] =
+                  filePathToModuleMetadata[clientUrl]);
+            }
             configuredCrossOriginLoading = JSON.stringify(
               configuredCrossOriginLoading,
               null,

--- a/src/server.node.ts
+++ b/src/server.node.ts
@@ -1,4 +1,5 @@
 import { BundleManifest } from './types';
+import { aliasServerToClientEntries } from './manifestUtils';
 import { renderToPipeableStream as renderToPipeableStreamReact } from './react-server-dom-webpack/server.node';
 
 export interface Options {
@@ -15,6 +16,7 @@ export interface PipeableStream {
 
 export const buildServerRenderer = (clientManifest: BundleManifest) => {
   const { filePathToModuleMetadata } = clientManifest;
+  aliasServerToClientEntries(filePathToModuleMetadata);
   return {
     renderToPipeableStream: (
       // Note: ReactClientValue is likely what React uses internally for RSC
@@ -29,5 +31,6 @@ export const buildServerRenderer = (clientManifest: BundleManifest) => {
 
 export const renderToPipeableStream = (model: unknown, clientManifest: BundleManifest, options?: Options) => {
   const { filePathToModuleMetadata } = clientManifest;
+  aliasServerToClientEntries(filePathToModuleMetadata);
   return renderToPipeableStreamReact(model, filePathToModuleMetadata, options) as PipeableStream;
 }


### PR DESCRIPTION
## Summary
- Adds `aliasServerToClientEntries()` utility in `src/manifestUtils.ts` that overwrites `.server` manifest entries with corresponding `.client` entry data when both variants exist
- Applies aliasing in `src/server.node.ts` before React's `serializeClientReference` consumes the client manifest
- Applies aliasing in `src/client.node.ts` before the SSR manifest join

Closes #2509

## Context
When both `Component.server.ext` and `Component.client.ext` exist with `"use client"`, the RSC bundle creates proxies whose `$$id` points to the `.server` file URL. The client manifest has separate entries for both variants, so `serializeClientReference` resolves to the wrong `.server` chunk instead of the `.client` chunk.

## Decision
After investigation, this use case (having both `.server` and `.client` variants of the same component with `"use client"`) is an anti-pattern and should not be supported. Closing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in module mapping for paired server and client components during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->