### PR TITLE
[Flight] Walk parsed JSON instead of using reviver for parsing RSC payload

### DIFF
--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
@@ -1038,7 +1038,7 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+        var value = parseModel(chunk._response, resolvedModel),
           resolveListeners = chunk.value;
         null !== resolveListeners &&
           ((chunk.value = null),
@@ -1470,6 +1470,7 @@
                 get: function () {
                   return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
                 },
+                set: function () {},
                 enumerable: !0,
                 configurable: !1
               }),
@@ -1510,7 +1511,6 @@
       this._nonce = nonce;
       this._chunks = chunks;
       this._stringDecoder = new TextDecoder();
-      this._fromJSON = null;
       this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
       this._buffer = [];
       this._tempRefs = temporaryReferences;
@@ -1525,7 +1525,6 @@
       this._replayConsole = replayConsole;
       this._rootEnvironmentName =
         void 0 === environmentName ? "Server" : environmentName;
-      this._fromJSON = createFromJSONCallback(this);
     }
     function resolveModel(response, id, model) {
       var chunks = response._chunks,
@@ -1554,7 +1553,7 @@
     function resolveModule(response, id, model) {
       var chunks = response._chunks,
         chunk = chunks.get(id);
-      model = JSON.parse(model, response._fromJSON);
+      model = parseModel(response, model);
       var clientReference = resolveClientReference(
         response._bundlerConfig,
         model
@@ -1801,7 +1800,7 @@
       return response;
     }
     function resolveHint(response, code, model) {
-      response = JSON.parse(model, response._fromJSON);
+      response = parseModel(response, model);
       model = ReactDOMSharedInternals.d;
       switch (code) {
         case "D":
@@ -1959,7 +1958,7 @@
     }
     function resolveConsoleEntry(response, value) {
       if (response._replayConsole) {
-        var payload = JSON.parse(value, response._fromJSON);
+        var payload = parseModel(response, value);
         value = payload[0];
         var stackTrace = payload[1],
           owner = payload[2],
@@ -2120,67 +2119,90 @@
           resolveModel(response, id, row);
       }
     }
-    function createFromJSONCallback(response) {
-      return function (key, value) {
-        if ("string" === typeof value)
-          return parseModelString(response, this, key, value);
-        if ("object" === typeof value && null !== value) {
+    function parseModel(response, json) {
+      json = JSON.parse(json);
+      return reviveModel(response, json, { "": json }, "");
+    }
+    function reviveModel(response, value, parentObject, key) {
+      if ("string" === typeof value)
+        return "$" === value[0]
+          ? parseModelString(response, parentObject, key, value)
+          : value;
+      if ("object" !== typeof value || null === value) return value;
+      if (isArrayImpl(value)) {
+        for (var i = 0; i < value.length; i++)
+          value[i] = reviveModel(response, value[i], value, "" + i);
+        if (value[0] === REACT_ELEMENT_TYPE) {
           if (value[0] === REACT_ELEMENT_TYPE)
-            if (
-              ((key = value[4]),
-              (value = {
+            b: {
+              i = value[4];
+              value = {
                 $$typeof: REACT_ELEMENT_TYPE,
                 type: value[1],
                 key: value[2],
                 props: value[3],
-                _owner: null === key ? response._debugRootOwner : key
-              }),
+                _owner: null === i ? response._debugRootOwner : i
+              };
               Object.defineProperty(value, "ref", {
                 enumerable: !1,
                 get: nullRefGetter
-              }),
-              (value._store = {}),
+              });
+              value._store = {};
               Object.defineProperty(value._store, "validated", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: 1
-              }),
+              });
               Object.defineProperty(value, "_debugInfo", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: null
-              }),
-              null !== initializingHandler)
-            ) {
-              var handler = initializingHandler;
-              initializingHandler = handler.parent;
-              handler.errored
-                ? ((key = new ReactPromise(
+              });
+              if (null !== initializingHandler) {
+                i = initializingHandler;
+                initializingHandler = i.parent;
+                if (i.errored) {
+                  response = new ReactPromise(
                     "rejected",
                     null,
-                    handler.value,
+                    i.value,
                     response
-                  )),
-                  (value = {
+                  );
+                  value = {
                     name: getComponentNameFromType(value.type) || "",
                     owner: value._owner
-                  }),
-                  (key._debugInfo = [value]),
-                  (value = createLazyChunkWrapper(key)))
-                : 0 < handler.deps &&
-                  ((key = new ReactPromise("blocked", null, null, response)),
-                  (handler.value = value),
-                  (handler.chunk = key),
-                  (value = Object.freeze.bind(Object, value.props)),
-                  key.then(value, value),
-                  (value = createLazyChunkWrapper(key)));
-            } else Object.freeze(value.props);
-          return value;
+                  };
+                  response._debugInfo = [value];
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+                if (0 < i.deps) {
+                  response = new ReactPromise("blocked", null, null, response);
+                  i.value = value;
+                  i.chunk = response;
+                  value = Object.freeze.bind(Object, value.props);
+                  response.then(value, value);
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+              } else Object.freeze(value.props);
+              response = value;
+            }
+          else response = value;
+          return response;
         }
         return value;
-      };
+      }
+      for (i in value)
+        "__proto__" === i
+          ? delete value[i]
+          : ((parentObject = reviveModel(response, value[i], value, i)),
+            void 0 !== parentObject
+              ? (value[i] = parentObject)
+              : delete value[i]);
+      return value;
     }
     function createResponseFromOptions(options) {
       return new ResponseInstance(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js
@@ -665,7 +665,7 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+    var value = parseModel(chunk._response, resolvedModel),
       resolveListeners = chunk.value;
     null !== resolveListeners &&
       ((chunk.value = null),
@@ -1033,11 +1033,9 @@ function ResponseInstance(
   this._nonce = nonce;
   this._chunks = chunks;
   this._stringDecoder = new TextDecoder();
-  this._fromJSON = null;
   this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
   this._buffer = [];
   this._tempRefs = temporaryReferences;
-  this._fromJSON = createFromJSONCallback(this);
 }
 function resolveBuffer(response, id, buffer) {
   var chunks = response._chunks,
@@ -1049,7 +1047,7 @@ function resolveBuffer(response, id, buffer) {
 function resolveModule(response, id, model) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
-  model = JSON.parse(model, response._fromJSON);
+  model = parseModel(response, model);
   var clientReference = resolveClientReference(response._bundlerConfig, model);
   if ((model = preloadModule(clientReference))) {
     if (chunk) {
@@ -1357,7 +1355,7 @@ function processFullBinaryRow(response, id, tag, buffer, chunk) {
     case 72:
       id = buffer[0];
       buffer = buffer.slice(1);
-      response = JSON.parse(buffer, response._fromJSON);
+      response = parseModel(response, buffer);
       buffer = ReactDOMSharedInternals.d;
       switch (id) {
         case "D":
@@ -1447,45 +1445,58 @@ function processFullBinaryRow(response, id, tag, buffer, chunk) {
             );
   }
 }
-function createFromJSONCallback(response) {
-  return function (key, value) {
-    if ("string" === typeof value)
-      return parseModelString(response, this, key, value);
-    if ("object" === typeof value && null !== value) {
-      if (value[0] === REACT_ELEMENT_TYPE) {
-        if (
-          ((key = {
+function parseModel(response, json) {
+  json = JSON.parse(json);
+  return reviveModel(response, json, { "": json }, "");
+}
+function reviveModel(response, value, parentObject, key) {
+  if ("string" === typeof value)
+    return "$" === value[0]
+      ? parseModelString(response, parentObject, key, value)
+      : value;
+  if ("object" !== typeof value || null === value) return value;
+  if (isArrayImpl(value)) {
+    for (var i = 0; i < value.length; i++)
+      value[i] = reviveModel(response, value[i], value, "" + i);
+    if (value[0] === REACT_ELEMENT_TYPE) {
+      if (value[0] === REACT_ELEMENT_TYPE)
+        b: {
+          value = {
             $$typeof: REACT_ELEMENT_TYPE,
             type: value[1],
             key: value[2],
             ref: null,
             props: value[3]
-          }),
-          null !== initializingHandler)
-        )
-          if (
-            ((value = initializingHandler),
-            (initializingHandler = value.parent),
-            value.errored)
-          )
-            (key = new ReactPromise("rejected", null, value.value, response)),
-              (key = createLazyChunkWrapper(key));
-          else if (0 < value.deps) {
-            var blockedChunk = new ReactPromise(
-              "blocked",
-              null,
-              null,
-              response
-            );
-            value.value = key;
-            value.chunk = blockedChunk;
-            key = createLazyChunkWrapper(blockedChunk);
+          };
+          if (null !== initializingHandler) {
+            i = initializingHandler;
+            initializingHandler = i.parent;
+            if (i.errored) {
+              response = new ReactPromise("rejected", null, i.value, response);
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
+            if (0 < i.deps) {
+              response = new ReactPromise("blocked", null, null, response);
+              i.value = value;
+              i.chunk = response;
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
           }
-      } else key = value;
-      return key;
+          response = value;
+        }
+      else response = value;
+      return response;
     }
     return value;
-  };
+  }
+  for (i in value)
+    "__proto__" === i
+      ? delete value[i]
+      : ((parentObject = reviveModel(response, value[i], value, i)),
+        void 0 !== parentObject ? (value[i] = parentObject) : delete value[i]);
+  return value;
 }
 function createResponseFromOptions(options) {
   return new ResponseInstance(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
@@ -1242,7 +1242,7 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+        var value = parseModel(chunk._response, resolvedModel),
           resolveListeners = chunk.value;
         null !== resolveListeners &&
           ((chunk.value = null),
@@ -1674,6 +1674,7 @@
                 get: function () {
                   return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
                 },
+                set: function () {},
                 enumerable: !0,
                 configurable: !1
               }),
@@ -1714,7 +1715,6 @@
       this._nonce = nonce;
       this._chunks = chunks;
       this._stringDecoder = new TextDecoder();
-      this._fromJSON = null;
       this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
       this._buffer = [];
       this._tempRefs = temporaryReferences;
@@ -1729,7 +1729,6 @@
       this._replayConsole = replayConsole;
       this._rootEnvironmentName =
         void 0 === environmentName ? "Server" : environmentName;
-      this._fromJSON = createFromJSONCallback(this);
     }
     function resolveModel(response, id, model) {
       var chunks = response._chunks,
@@ -1758,7 +1757,7 @@
     function resolveModule(response, id, model) {
       var chunks = response._chunks,
         chunk = chunks.get(id);
-      model = JSON.parse(model, response._fromJSON);
+      model = parseModel(response, model);
       var clientReference = resolveClientReference(
         response._bundlerConfig,
         model
@@ -2010,7 +2009,7 @@
       return response;
     }
     function resolveHint(response, code, model) {
-      response = JSON.parse(model, response._fromJSON);
+      response = parseModel(response, model);
       model = ReactDOMSharedInternals.d;
       switch (code) {
         case "D":
@@ -2168,7 +2167,7 @@
     }
     function resolveConsoleEntry(response, value) {
       if (response._replayConsole) {
-        var payload = JSON.parse(value, response._fromJSON);
+        var payload = parseModel(response, value);
         value = payload[0];
         var stackTrace = payload[1],
           owner = payload[2],
@@ -2329,67 +2328,90 @@
           resolveModel(response, id, row);
       }
     }
-    function createFromJSONCallback(response) {
-      return function (key, value) {
-        if ("string" === typeof value)
-          return parseModelString(response, this, key, value);
-        if ("object" === typeof value && null !== value) {
+    function parseModel(response, json) {
+      json = JSON.parse(json);
+      return reviveModel(response, json, { "": json }, "");
+    }
+    function reviveModel(response, value, parentObject, key) {
+      if ("string" === typeof value)
+        return "$" === value[0]
+          ? parseModelString(response, parentObject, key, value)
+          : value;
+      if ("object" !== typeof value || null === value) return value;
+      if (isArrayImpl(value)) {
+        for (var i = 0; i < value.length; i++)
+          value[i] = reviveModel(response, value[i], value, "" + i);
+        if (value[0] === REACT_ELEMENT_TYPE) {
           if (value[0] === REACT_ELEMENT_TYPE)
-            if (
-              ((key = value[4]),
-              (value = {
+            b: {
+              i = value[4];
+              value = {
                 $$typeof: REACT_ELEMENT_TYPE,
                 type: value[1],
                 key: value[2],
                 props: value[3],
-                _owner: null === key ? response._debugRootOwner : key
-              }),
+                _owner: null === i ? response._debugRootOwner : i
+              };
               Object.defineProperty(value, "ref", {
                 enumerable: !1,
                 get: nullRefGetter
-              }),
-              (value._store = {}),
+              });
+              value._store = {};
               Object.defineProperty(value._store, "validated", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: 1
-              }),
+              });
               Object.defineProperty(value, "_debugInfo", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: null
-              }),
-              null !== initializingHandler)
-            ) {
-              var handler = initializingHandler;
-              initializingHandler = handler.parent;
-              handler.errored
-                ? ((key = new ReactPromise(
+              });
+              if (null !== initializingHandler) {
+                i = initializingHandler;
+                initializingHandler = i.parent;
+                if (i.errored) {
+                  response = new ReactPromise(
                     "rejected",
                     null,
-                    handler.value,
+                    i.value,
                     response
-                  )),
-                  (value = {
+                  );
+                  value = {
                     name: getComponentNameFromType(value.type) || "",
                     owner: value._owner
-                  }),
-                  (key._debugInfo = [value]),
-                  (value = createLazyChunkWrapper(key)))
-                : 0 < handler.deps &&
-                  ((key = new ReactPromise("blocked", null, null, response)),
-                  (handler.value = value),
-                  (handler.chunk = key),
-                  (value = Object.freeze.bind(Object, value.props)),
-                  key.then(value, value),
-                  (value = createLazyChunkWrapper(key)));
-            } else Object.freeze(value.props);
-          return value;
+                  };
+                  response._debugInfo = [value];
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+                if (0 < i.deps) {
+                  response = new ReactPromise("blocked", null, null, response);
+                  i.value = value;
+                  i.chunk = response;
+                  value = Object.freeze.bind(Object, value.props);
+                  response.then(value, value);
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+              } else Object.freeze(value.props);
+              response = value;
+            }
+          else response = value;
+          return response;
         }
         return value;
-      };
+      }
+      for (i in value)
+        "__proto__" === i
+          ? delete value[i]
+          : ((parentObject = reviveModel(response, value[i], value, i)),
+            void 0 !== parentObject
+              ? (value[i] = parentObject)
+              : delete value[i]);
+      return value;
     }
     function noServerCall() {
       throw Error(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
@@ -819,7 +819,7 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+    var value = parseModel(chunk._response, resolvedModel),
       resolveListeners = chunk.value;
     null !== resolveListeners &&
       ((chunk.value = null),
@@ -1191,11 +1191,9 @@ function ResponseInstance(
   this._nonce = nonce;
   this._chunks = chunks;
   this._stringDecoder = new TextDecoder();
-  this._fromJSON = null;
   this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
   this._buffer = [];
   this._tempRefs = temporaryReferences;
-  this._fromJSON = createFromJSONCallback(this);
 }
 function resolveBuffer(response, id, buffer) {
   var chunks = response._chunks,
@@ -1207,7 +1205,7 @@ function resolveBuffer(response, id, buffer) {
 function resolveModule(response, id, model) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
-  model = JSON.parse(model, response._fromJSON);
+  model = parseModel(response, model);
   var clientReference = resolveClientReference(response._bundlerConfig, model);
   prepareDestinationWithChunks(
     response._moduleLoading,
@@ -1520,7 +1518,7 @@ function processFullBinaryRow(response, id, tag, buffer, chunk) {
     case 72:
       id = buffer[0];
       buffer = buffer.slice(1);
-      response = JSON.parse(buffer, response._fromJSON);
+      response = parseModel(response, buffer);
       buffer = ReactDOMSharedInternals.d;
       switch (id) {
         case "D":
@@ -1610,45 +1608,58 @@ function processFullBinaryRow(response, id, tag, buffer, chunk) {
             );
   }
 }
-function createFromJSONCallback(response) {
-  return function (key, value) {
-    if ("string" === typeof value)
-      return parseModelString(response, this, key, value);
-    if ("object" === typeof value && null !== value) {
-      if (value[0] === REACT_ELEMENT_TYPE) {
-        if (
-          ((key = {
+function parseModel(response, json) {
+  json = JSON.parse(json);
+  return reviveModel(response, json, { "": json }, "");
+}
+function reviveModel(response, value, parentObject, key) {
+  if ("string" === typeof value)
+    return "$" === value[0]
+      ? parseModelString(response, parentObject, key, value)
+      : value;
+  if ("object" !== typeof value || null === value) return value;
+  if (isArrayImpl(value)) {
+    for (var i = 0; i < value.length; i++)
+      value[i] = reviveModel(response, value[i], value, "" + i);
+    if (value[0] === REACT_ELEMENT_TYPE) {
+      if (value[0] === REACT_ELEMENT_TYPE)
+        b: {
+          value = {
             $$typeof: REACT_ELEMENT_TYPE,
             type: value[1],
             key: value[2],
             ref: null,
             props: value[3]
-          }),
-          null !== initializingHandler)
-        )
-          if (
-            ((value = initializingHandler),
-            (initializingHandler = value.parent),
-            value.errored)
-          )
-            (key = new ReactPromise("rejected", null, value.value, response)),
-              (key = createLazyChunkWrapper(key));
-          else if (0 < value.deps) {
-            var blockedChunk = new ReactPromise(
-              "blocked",
-              null,
-              null,
-              response
-            );
-            value.value = key;
-            value.chunk = blockedChunk;
-            key = createLazyChunkWrapper(blockedChunk);
+          };
+          if (null !== initializingHandler) {
+            i = initializingHandler;
+            initializingHandler = i.parent;
+            if (i.errored) {
+              response = new ReactPromise("rejected", null, i.value, response);
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
+            if (0 < i.deps) {
+              response = new ReactPromise("blocked", null, null, response);
+              i.value = value;
+              i.chunk = response;
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
           }
-      } else key = value;
-      return key;
+          response = value;
+        }
+      else response = value;
+      return response;
     }
     return value;
-  };
+  }
+  for (i in value)
+    "__proto__" === i
+      ? delete value[i]
+      : ((parentObject = reviveModel(response, value[i], value, i)),
+        void 0 !== parentObject ? (value[i] = parentObject) : delete value[i]);
+  return value;
 }
 function noServerCall() {
   throw Error(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
@@ -1242,7 +1242,7 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+        var value = parseModel(chunk._response, resolvedModel),
           resolveListeners = chunk.value;
         null !== resolveListeners &&
           ((chunk.value = null),
@@ -1674,6 +1674,7 @@
                 get: function () {
                   return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
                 },
+                set: function () {},
                 enumerable: !0,
                 configurable: !1
               }),
@@ -1714,7 +1715,6 @@
       this._nonce = nonce;
       this._chunks = chunks;
       this._stringDecoder = new util.TextDecoder();
-      this._fromJSON = null;
       this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
       this._buffer = [];
       this._tempRefs = temporaryReferences;
@@ -1729,7 +1729,6 @@
       this._replayConsole = replayConsole;
       this._rootEnvironmentName =
         void 0 === environmentName ? "Server" : environmentName;
-      this._fromJSON = createFromJSONCallback(this);
     }
     function resolveModel(response, id, model) {
       var chunks = response._chunks,
@@ -1758,7 +1757,7 @@
     function resolveModule(response, id, model) {
       var chunks = response._chunks,
         chunk = chunks.get(id);
-      model = JSON.parse(model, response._fromJSON);
+      model = parseModel(response, model);
       var clientReference = resolveClientReference(
         response._bundlerConfig,
         model
@@ -2010,7 +2009,7 @@
       return response;
     }
     function resolveHint(response, code, model) {
-      response = JSON.parse(model, response._fromJSON);
+      response = parseModel(response, model);
       model = ReactDOMSharedInternals.d;
       switch (code) {
         case "D":
@@ -2168,7 +2167,7 @@
     }
     function resolveConsoleEntry(response, value) {
       if (response._replayConsole) {
-        var payload = JSON.parse(value, response._fromJSON);
+        var payload = parseModel(response, value);
         value = payload[0];
         var stackTrace = payload[1],
           owner = payload[2],
@@ -2329,67 +2328,90 @@
           resolveModel(response, id, row);
       }
     }
-    function createFromJSONCallback(response) {
-      return function (key, value) {
-        if ("string" === typeof value)
-          return parseModelString(response, this, key, value);
-        if ("object" === typeof value && null !== value) {
+    function parseModel(response, json) {
+      json = JSON.parse(json);
+      return reviveModel(response, json, { "": json }, "");
+    }
+    function reviveModel(response, value, parentObject, key) {
+      if ("string" === typeof value)
+        return "$" === value[0]
+          ? parseModelString(response, parentObject, key, value)
+          : value;
+      if ("object" !== typeof value || null === value) return value;
+      if (isArrayImpl(value)) {
+        for (var i = 0; i < value.length; i++)
+          value[i] = reviveModel(response, value[i], value, "" + i);
+        if (value[0] === REACT_ELEMENT_TYPE) {
           if (value[0] === REACT_ELEMENT_TYPE)
-            if (
-              ((key = value[4]),
-              (value = {
+            b: {
+              i = value[4];
+              value = {
                 $$typeof: REACT_ELEMENT_TYPE,
                 type: value[1],
                 key: value[2],
                 props: value[3],
-                _owner: null === key ? response._debugRootOwner : key
-              }),
+                _owner: null === i ? response._debugRootOwner : i
+              };
               Object.defineProperty(value, "ref", {
                 enumerable: !1,
                 get: nullRefGetter
-              }),
-              (value._store = {}),
+              });
+              value._store = {};
               Object.defineProperty(value._store, "validated", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: 1
-              }),
+              });
               Object.defineProperty(value, "_debugInfo", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: null
-              }),
-              null !== initializingHandler)
-            ) {
-              var handler = initializingHandler;
-              initializingHandler = handler.parent;
-              handler.errored
-                ? ((key = new ReactPromise(
+              });
+              if (null !== initializingHandler) {
+                i = initializingHandler;
+                initializingHandler = i.parent;
+                if (i.errored) {
+                  response = new ReactPromise(
                     "rejected",
                     null,
-                    handler.value,
+                    i.value,
                     response
-                  )),
-                  (value = {
+                  );
+                  value = {
                     name: getComponentNameFromType(value.type) || "",
                     owner: value._owner
-                  }),
-                  (key._debugInfo = [value]),
-                  (value = createLazyChunkWrapper(key)))
-                : 0 < handler.deps &&
-                  ((key = new ReactPromise("blocked", null, null, response)),
-                  (handler.value = value),
-                  (handler.chunk = key),
-                  (value = Object.freeze.bind(Object, value.props)),
-                  key.then(value, value),
-                  (value = createLazyChunkWrapper(key)));
-            } else Object.freeze(value.props);
-          return value;
+                  };
+                  response._debugInfo = [value];
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+                if (0 < i.deps) {
+                  response = new ReactPromise("blocked", null, null, response);
+                  i.value = value;
+                  i.chunk = response;
+                  value = Object.freeze.bind(Object, value.props);
+                  response.then(value, value);
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+              } else Object.freeze(value.props);
+              response = value;
+            }
+          else response = value;
+          return response;
         }
         return value;
-      };
+      }
+      for (i in value)
+        "__proto__" === i
+          ? delete value[i]
+          : ((parentObject = reviveModel(response, value[i], value, i)),
+            void 0 !== parentObject
+              ? (value[i] = parentObject)
+              : delete value[i]);
+      return value;
     }
     function noServerCall() {
       throw Error(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
@@ -820,7 +820,7 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+    var value = parseModel(chunk._response, resolvedModel),
       resolveListeners = chunk.value;
     null !== resolveListeners &&
       ((chunk.value = null),
@@ -1192,11 +1192,9 @@ function ResponseInstance(
   this._nonce = nonce;
   this._chunks = chunks;
   this._stringDecoder = new util.TextDecoder();
-  this._fromJSON = null;
   this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
   this._buffer = [];
   this._tempRefs = temporaryReferences;
-  this._fromJSON = createFromJSONCallback(this);
 }
 function resolveBuffer(response, id, buffer) {
   var chunks = response._chunks,
@@ -1208,7 +1206,7 @@ function resolveBuffer(response, id, buffer) {
 function resolveModule(response, id, model) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
-  model = JSON.parse(model, response._fromJSON);
+  model = parseModel(response, model);
   var clientReference = resolveClientReference(response._bundlerConfig, model);
   prepareDestinationWithChunks(
     response._moduleLoading,
@@ -1524,7 +1522,7 @@ function processFullStringRow(response, id, tag, row) {
     case 72:
       id = row[0];
       row = row.slice(1);
-      response = JSON.parse(row, response._fromJSON);
+      response = parseModel(response, row);
       row = ReactDOMSharedInternals.d;
       switch (id) {
         case "D":
@@ -1613,45 +1611,58 @@ function processFullStringRow(response, id, tag, row) {
             );
   }
 }
-function createFromJSONCallback(response) {
-  return function (key, value) {
-    if ("string" === typeof value)
-      return parseModelString(response, this, key, value);
-    if ("object" === typeof value && null !== value) {
-      if (value[0] === REACT_ELEMENT_TYPE) {
-        if (
-          ((key = {
+function parseModel(response, json) {
+  json = JSON.parse(json);
+  return reviveModel(response, json, { "": json }, "");
+}
+function reviveModel(response, value, parentObject, key) {
+  if ("string" === typeof value)
+    return "$" === value[0]
+      ? parseModelString(response, parentObject, key, value)
+      : value;
+  if ("object" !== typeof value || null === value) return value;
+  if (isArrayImpl(value)) {
+    for (var i = 0; i < value.length; i++)
+      value[i] = reviveModel(response, value[i], value, "" + i);
+    if (value[0] === REACT_ELEMENT_TYPE) {
+      if (value[0] === REACT_ELEMENT_TYPE)
+        b: {
+          value = {
             $$typeof: REACT_ELEMENT_TYPE,
             type: value[1],
             key: value[2],
             ref: null,
             props: value[3]
-          }),
-          null !== initializingHandler)
-        )
-          if (
-            ((value = initializingHandler),
-            (initializingHandler = value.parent),
-            value.errored)
-          )
-            (key = new ReactPromise("rejected", null, value.value, response)),
-              (key = createLazyChunkWrapper(key));
-          else if (0 < value.deps) {
-            var blockedChunk = new ReactPromise(
-              "blocked",
-              null,
-              null,
-              response
-            );
-            value.value = key;
-            value.chunk = blockedChunk;
-            key = createLazyChunkWrapper(blockedChunk);
+          };
+          if (null !== initializingHandler) {
+            i = initializingHandler;
+            initializingHandler = i.parent;
+            if (i.errored) {
+              response = new ReactPromise("rejected", null, i.value, response);
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
+            if (0 < i.deps) {
+              response = new ReactPromise("blocked", null, null, response);
+              i.value = value;
+              i.chunk = response;
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
           }
-      } else key = value;
-      return key;
+          response = value;
+        }
+      else response = value;
+      return response;
     }
     return value;
-  };
+  }
+  for (i in value)
+    "__proto__" === i
+      ? delete value[i]
+      : ((parentObject = reviveModel(response, value[i], value, i)),
+        void 0 !== parentObject ? (value[i] = parentObject) : delete value[i]);
+  return value;
 }
 function noServerCall() {
   throw Error(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
@@ -1205,7 +1205,7 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+        var value = parseModel(chunk._response, resolvedModel),
           resolveListeners = chunk.value;
         null !== resolveListeners &&
           ((chunk.value = null),
@@ -1637,6 +1637,7 @@
                 get: function () {
                   return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
                 },
+                set: function () {},
                 enumerable: !0,
                 configurable: !1
               }),
@@ -1677,7 +1678,6 @@
       this._nonce = nonce;
       this._chunks = chunks;
       this._stringDecoder = new util.TextDecoder();
-      this._fromJSON = null;
       this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
       this._buffer = [];
       this._tempRefs = temporaryReferences;
@@ -1692,7 +1692,6 @@
       this._replayConsole = replayConsole;
       this._rootEnvironmentName =
         void 0 === environmentName ? "Server" : environmentName;
-      this._fromJSON = createFromJSONCallback(this);
     }
     function resolveModel(response, id, model) {
       var chunks = response._chunks,
@@ -1721,7 +1720,7 @@
     function resolveModule(response, id, model) {
       var chunks = response._chunks,
         chunk = chunks.get(id);
-      model = JSON.parse(model, response._fromJSON);
+      model = parseModel(response, model);
       var clientReference = resolveClientReference(
         response._bundlerConfig,
         model
@@ -1973,7 +1972,7 @@
       return response;
     }
     function resolveHint(response, code, model) {
-      response = JSON.parse(model, response._fromJSON);
+      response = parseModel(response, model);
       model = ReactDOMSharedInternals.d;
       switch (code) {
         case "D":
@@ -2131,7 +2130,7 @@
     }
     function resolveConsoleEntry(response, value) {
       if (response._replayConsole) {
-        var payload = JSON.parse(value, response._fromJSON);
+        var payload = parseModel(response, value);
         value = payload[0];
         var stackTrace = payload[1],
           owner = payload[2],
@@ -2292,67 +2291,90 @@
           resolveModel(response, id, row);
       }
     }
-    function createFromJSONCallback(response) {
-      return function (key, value) {
-        if ("string" === typeof value)
-          return parseModelString(response, this, key, value);
-        if ("object" === typeof value && null !== value) {
+    function parseModel(response, json) {
+      json = JSON.parse(json);
+      return reviveModel(response, json, { "": json }, "");
+    }
+    function reviveModel(response, value, parentObject, key) {
+      if ("string" === typeof value)
+        return "$" === value[0]
+          ? parseModelString(response, parentObject, key, value)
+          : value;
+      if ("object" !== typeof value || null === value) return value;
+      if (isArrayImpl(value)) {
+        for (var i = 0; i < value.length; i++)
+          value[i] = reviveModel(response, value[i], value, "" + i);
+        if (value[0] === REACT_ELEMENT_TYPE) {
           if (value[0] === REACT_ELEMENT_TYPE)
-            if (
-              ((key = value[4]),
-              (value = {
+            b: {
+              i = value[4];
+              value = {
                 $$typeof: REACT_ELEMENT_TYPE,
                 type: value[1],
                 key: value[2],
                 props: value[3],
-                _owner: null === key ? response._debugRootOwner : key
-              }),
+                _owner: null === i ? response._debugRootOwner : i
+              };
               Object.defineProperty(value, "ref", {
                 enumerable: !1,
                 get: nullRefGetter
-              }),
-              (value._store = {}),
+              });
+              value._store = {};
               Object.defineProperty(value._store, "validated", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: 1
-              }),
+              });
               Object.defineProperty(value, "_debugInfo", {
                 configurable: !1,
                 enumerable: !1,
                 writable: !0,
                 value: null
-              }),
-              null !== initializingHandler)
-            ) {
-              var handler = initializingHandler;
-              initializingHandler = handler.parent;
-              handler.errored
-                ? ((key = new ReactPromise(
+              });
+              if (null !== initializingHandler) {
+                i = initializingHandler;
+                initializingHandler = i.parent;
+                if (i.errored) {
+                  response = new ReactPromise(
                     "rejected",
                     null,
-                    handler.value,
+                    i.value,
                     response
-                  )),
-                  (value = {
+                  );
+                  value = {
                     name: getComponentNameFromType(value.type) || "",
                     owner: value._owner
-                  }),
-                  (key._debugInfo = [value]),
-                  (value = createLazyChunkWrapper(key)))
-                : 0 < handler.deps &&
-                  ((key = new ReactPromise("blocked", null, null, response)),
-                  (handler.value = value),
-                  (handler.chunk = key),
-                  (value = Object.freeze.bind(Object, value.props)),
-                  key.then(value, value),
-                  (value = createLazyChunkWrapper(key)));
-            } else Object.freeze(value.props);
-          return value;
+                  };
+                  response._debugInfo = [value];
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+                if (0 < i.deps) {
+                  response = new ReactPromise("blocked", null, null, response);
+                  i.value = value;
+                  i.chunk = response;
+                  value = Object.freeze.bind(Object, value.props);
+                  response.then(value, value);
+                  response = createLazyChunkWrapper(response);
+                  break b;
+                }
+              } else Object.freeze(value.props);
+              response = value;
+            }
+          else response = value;
+          return response;
         }
         return value;
-      };
+      }
+      for (i in value)
+        "__proto__" === i
+          ? delete value[i]
+          : ((parentObject = reviveModel(response, value[i], value, i)),
+            void 0 !== parentObject
+              ? (value[i] = parentObject)
+              : delete value[i]);
+      return value;
     }
     function noServerCall() {
       throw Error(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
@@ -786,7 +786,7 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var value = JSON.parse(resolvedModel, chunk._response._fromJSON),
+    var value = parseModel(chunk._response, resolvedModel),
       resolveListeners = chunk.value;
     null !== resolveListeners &&
       ((chunk.value = null),
@@ -1158,11 +1158,9 @@ function ResponseInstance(
   this._nonce = nonce;
   this._chunks = chunks;
   this._stringDecoder = new util.TextDecoder();
-  this._fromJSON = null;
   this._rowLength = this._rowTag = this._rowID = this._rowState = 0;
   this._buffer = [];
   this._tempRefs = temporaryReferences;
-  this._fromJSON = createFromJSONCallback(this);
 }
 function resolveBuffer(response, id, buffer) {
   var chunks = response._chunks,
@@ -1174,7 +1172,7 @@ function resolveBuffer(response, id, buffer) {
 function resolveModule(response, id, model) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
-  model = JSON.parse(model, response._fromJSON);
+  model = parseModel(response, model);
   var clientReference = resolveClientReference(response._bundlerConfig, model);
   prepareDestinationWithChunks(
     response._moduleLoading,
@@ -1490,7 +1488,7 @@ function processFullStringRow(response, id, tag, row) {
     case 72:
       id = row[0];
       row = row.slice(1);
-      response = JSON.parse(row, response._fromJSON);
+      response = parseModel(response, row);
       row = ReactDOMSharedInternals.d;
       switch (id) {
         case "D":
@@ -1579,45 +1577,58 @@ function processFullStringRow(response, id, tag, row) {
             );
   }
 }
-function createFromJSONCallback(response) {
-  return function (key, value) {
-    if ("string" === typeof value)
-      return parseModelString(response, this, key, value);
-    if ("object" === typeof value && null !== value) {
-      if (value[0] === REACT_ELEMENT_TYPE) {
-        if (
-          ((key = {
+function parseModel(response, json) {
+  json = JSON.parse(json);
+  return reviveModel(response, json, { "": json }, "");
+}
+function reviveModel(response, value, parentObject, key) {
+  if ("string" === typeof value)
+    return "$" === value[0]
+      ? parseModelString(response, parentObject, key, value)
+      : value;
+  if ("object" !== typeof value || null === value) return value;
+  if (isArrayImpl(value)) {
+    for (var i = 0; i < value.length; i++)
+      value[i] = reviveModel(response, value[i], value, "" + i);
+    if (value[0] === REACT_ELEMENT_TYPE) {
+      if (value[0] === REACT_ELEMENT_TYPE)
+        b: {
+          value = {
             $$typeof: REACT_ELEMENT_TYPE,
             type: value[1],
             key: value[2],
             ref: null,
             props: value[3]
-          }),
-          null !== initializingHandler)
-        )
-          if (
-            ((value = initializingHandler),
-            (initializingHandler = value.parent),
-            value.errored)
-          )
-            (key = new ReactPromise("rejected", null, value.value, response)),
-              (key = createLazyChunkWrapper(key));
-          else if (0 < value.deps) {
-            var blockedChunk = new ReactPromise(
-              "blocked",
-              null,
-              null,
-              response
-            );
-            value.value = key;
-            value.chunk = blockedChunk;
-            key = createLazyChunkWrapper(blockedChunk);
+          };
+          if (null !== initializingHandler) {
+            i = initializingHandler;
+            initializingHandler = i.parent;
+            if (i.errored) {
+              response = new ReactPromise("rejected", null, i.value, response);
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
+            if (0 < i.deps) {
+              response = new ReactPromise("blocked", null, null, response);
+              i.value = value;
+              i.chunk = response;
+              response = createLazyChunkWrapper(response);
+              break b;
+            }
           }
-      } else key = value;
-      return key;
+          response = value;
+        }
+      else response = value;
+      return response;
     }
     return value;
-  };
+  }
+  for (i in value)
+    "__proto__" === i
+      ? delete value[i]
+      : ((parentObject = reviveModel(response, value[i], value, i)),
+        void 0 !== parentObject ? (value[i] = parentObject) : delete value[i]);
+  return value;
 }
 function noServerCall() {
   throw Error(

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -267,10 +267,13 @@ class ReactFlightWebpackPlugin {
                 try {
                   for (_iterator.s(); !(_step = _iterator.n()).done; ) {
                     const file = _step.value;
-                    if (!file.endsWith(".js")) break;
-                    if (file.endsWith(".hot-update.js")) break;
-                    chunks.push(c.id, file);
-                    break;
+                    if (
+                      file.endsWith(".js") &&
+                      !file.endsWith(".hot-update.js")
+                    ) {
+                      chunks.push(c.id, file);
+                      break;
+                    }
                   }
                 } catch (err) {
                   _iterator.e(err);


### PR DESCRIPTION
## Summary

Closes #34

Backport of [facebook/react#35776](https://github.com/facebook/react/pull/35776) — ~75% speedup in RSC chunk deserialization.

Rebuilt `react-server-dom-webpack` from React fork [`rsc-patches/v19.0.3`](https://github.com/AbanoubGhadban/react/tree/rsc-patches/v19.0.3) with the optimization applied ([fork PR](https://github.com/AbanoubGhadban/react/pull/4)).

### The optimization

Replaces `JSON.parse(json, reviver)` with a two-step approach:
1. **`JSON.parse(json)`** — runs entirely in V8's C++ engine, no callbacks
2. **`reviveModel()`** — recursive pure-JS walk that applies RSC transformations

The reviver callback was the bottleneck: V8's `JSON.parse` is C++, and calling back into JS for every key-value pair incurs ~4x overhead even with a no-op reviver.

### Benchmark results (from upstream PR)

| Payload | Speedup |
|---------|---------|
| Small (142B) | +72% |
| Medium (914B) | +73% |
| Large (16.7KB) | +75% |
| XL (25.7KB) | +76% |
| Table (1000 rows, 110KB) | +78% |

### Additional changes in this rebuild

The plugin file also picks up the compiled form of `[RSC-PATCH] Fix client manifest chunk scan when non-JS assets precede JS` from source (previously patched manually on main via #23).

## Test plan
- [ ] Verify RSC payload parsing works correctly
- [ ] Test with nested Suspense boundaries
- [ ] Test with client/server component mix
- [ ] Benchmark deserialization on a real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data deserialization process for React Server Components across multiple runtime environments (browser, edge, Node.js).
  * Refined chunk file selection logic in the build plugin to correctly exclude hot-update files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->