### PR TITLE
Fix Rspack RSC client manifest generation

### DIFF
--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -9,13 +9,10 @@
  * Discovery technique: a small loader (`loader.ts`) tags modules containing
  * a `"use client"` directive during parse by adding the module's resource
  * path to a per-compilation Set keyed under the `CLIENT_MODULES_KEY`
- * Symbol. This plugin:
- *   1. Eagerly creates the shared Set in `thisCompilation` (before any
- *      loader runs, to prevent a check-then-set race across workers).
- *   2. At `processAssets` stage `PROCESS_ASSETS_STAGE_REPORT`, reads the
- *      Set, iterates `compilation.modules`, looks up each tagged module's
- *      chunks via `compilation.chunkGraph.getModuleChunks(module)`, and
- *      emits a manifest JSON asset via `compilation.emitAsset`.
+ * Symbol. A second loader prepends dynamic imports to the Flight client
+ * runtime so file-system-discovered client references become async chunk
+ * groups. At `processAssets`, the plugin walks chunk groups and emits the
+ * React on Rails client-manifest JSON schema.
  *
  * Output schema matches RoR's existing webpack-side plugin so
  * `buildServerRenderer` / `buildClientRenderer` in server.node.ts /
@@ -70,6 +67,11 @@ type AnyChunkGroup = {
   chunks: Iterable<unknown>;
 };
 
+type AnyEntrypoint = {
+  chunks?: Iterable<unknown>;
+  getChunks?: () => Iterable<unknown>;
+};
+
 type AnyCompilation = {
   hooks: {
     processAssets: {
@@ -86,7 +88,7 @@ type AnyCompilation = {
     publicPath?: string;
     crossOriginLoading?: false | 'anonymous' | 'use-credentials';
   };
-  entrypoints?: ReadonlyMap<string, unknown>;
+  entrypoints?: ReadonlyMap<string, AnyEntrypoint>;
   emitAsset(filename: string, source: unknown): void;
   warnings: unknown[];
   compiler: AnyCompiler;
@@ -112,6 +114,7 @@ type AnyModule = {
 type AnyChunk = {
   id: string | number | null;
   files: Set<string> | string[];
+  canBeInitial?: () => boolean;
 };
 
 type Bundler = {
@@ -155,8 +158,8 @@ export interface Options {
    * The plugin FS-walks each descriptor at `beforeCompile` time, reads
    * every matching file, checks for the `"use client"` directive, and
    * injects the discovered files into the bundle as named async chunks
-   * (via `compilation.addInclude`). This ensures the client/SSR bundle
-   * includes every client component even if nothing in the entry graph
+   * through the Flight runtime injection loader. This ensures the client/SSR
+   * bundle includes every client component even if nothing in the entry graph
    * explicitly imports it — matching the webpack plugin's behavior.
    *
    * Default: `[{ directory: ".", recursive: true, include: /\.(js|ts|jsx|tsx)$/ }]`
@@ -175,6 +178,7 @@ export interface Options {
 // sees every user module.
 export const RSC_LOADER_RULE = {
   test: /\.[cm]?[jt]sx?$/,
+  exclude: /node_modules/,
   // `enforce: 'pre'` ensures we run before any transpiling loader, so we see
   // the original source text and can detect "use client" even in TS/JSX files
   // that other loaders will later transform.
@@ -277,14 +281,16 @@ export class RSCRspackPlugin {
 
       const moduleConfig = (compiler.options.module ??= {}) as { rules?: unknown[] };
       const rules = (moduleConfig.rules ??= []) as unknown[];
+      const injectionLoaderPath = path.resolve(__dirname, './injection-loader.js');
+      const runtimeTest = exactResourceRegexp(clientRuntimePath);
 
-      rules.push({
-        test: (resource: string) => resource === clientRuntimePath,
-        enforce: 'pre' as const,
-        use: [{
-          loader: path.resolve(__dirname, './injection-loader.js'),
-        }],
-      });
+      if (!this.hasLoaderRule(rules, injectionLoaderPath, runtimeTest)) {
+        rules.push({
+          test: runtimeTest,
+          enforce: 'pre' as const,
+          use: [{ loader: injectionLoaderPath }],
+        });
+      }
 
       // Prevent splitChunks from extracting modules out of the async
       // chunks created by the injection-loader. The RSC streaming HTML
@@ -327,17 +333,17 @@ export class RSCRspackPlugin {
           stage: bundler.Compilation.PROCESS_ASSETS_STAGE_REPORT,
         },
         () => {
-          const taggedPaths = getTagSet(compilation) ?? new Set<string>();
+          const resolvedClientCount = this._resolvedClientFiles.length;
           const logger = compilation.getLogger?.('RSCRspackPlugin');
-          if (taggedPaths.size === 0) {
+          if (resolvedClientCount === 0) {
             logger?.info(
-              'No "use client" modules detected; emitting empty manifest. ' +
-                'If this is unexpected, ensure the RSC loader rule runs on your source files.',
+              'No RSC client references resolved; emitting empty manifest. ' +
+                'If this is unexpected, check the RSCRspackPlugin clientReferences option.',
             );
           } else {
-            logger?.debug(`Tagged ${taggedPaths.size} "use client" module(s)`);
+            logger?.debug(`Resolved ${resolvedClientCount} RSC client reference(s)`);
           }
-          const manifest = this.buildManifest(compilation, taggedPaths, bundler, logger);
+          const manifest = this.buildManifest(compilation, bundler);
           logger?.debug(
             `Emitting ${manifestFilename} with ` +
               `${Object.keys(manifest.filePathToModuleMetadata).length} entries`,
@@ -358,7 +364,7 @@ export class RSCRspackPlugin {
   //     the webpack plugin's behavior — no "use client" check)
   //   - search descriptor → walk directory, read files, check for directive
   private resolveAllClientFiles(compilerContext: string): string[] {
-    const results: string[] = [];
+    const results = new Set<string>();
     for (const ref of this.clientReferences) {
       if (typeof ref === 'string') {
         // String = direct file reference. The webpack plugin wraps it in
@@ -366,7 +372,7 @@ export class RSCRspackPlugin {
         // the same: include it without checking for "use client".
         const resolved = path.resolve(compilerContext, ref);
         try {
-          if (fs.statSync(resolved).isFile()) results.push(resolved);
+          if (fs.statSync(resolved).isFile()) this.addResolvedClientFile(results, resolved);
         } catch { /* not found — skip */ }
         continue;
       }
@@ -376,14 +382,14 @@ export class RSCRspackPlugin {
       } catch { continue; }
       this.walkDir(dir, dir, ref, results);
     }
-    return results;
+    return [...results];
   }
 
   private walkDir(
     dir: string,
     walkRoot: string,
     ref: ClientReferenceSearchPath,
-    out: string[],
+    out: Set<string>,
   ): void {
     let entries: fs.Dirent[];
     try {
@@ -411,11 +417,23 @@ export class RSCRspackPlugin {
         if (ref.exclude && ref.exclude.test(relPath)) continue;
         try {
           const source = fs.readFileSync(full, 'utf-8');
-          if (hasUseClientDirective(source)) out.push(full);
+          if (hasUseClientDirective(source)) this.addResolvedClientFile(out, full);
         } catch {
           // unreadable file — skip
         }
       }
+    }
+  }
+
+  private addResolvedClientFile(out: Set<string>, filePath: string): void {
+    out.add(this.normalizeResourcePath(filePath));
+  }
+
+  private normalizeResourcePath(filePath: string): string {
+    try {
+      return fs.realpathSync.native(filePath);
+    } catch {
+      return filePath;
     }
   }
 
@@ -455,17 +473,27 @@ export class RSCRspackPlugin {
     const rules = (moduleConfig.rules ??= []) as unknown[];
     // Detect duplicate injection by checking for our loader path.
     const ourLoaderPath = require.resolve('./loader');
-    const alreadyInjected = rules.some((r) => {
+    const alreadyInjected = this.hasLoaderRule(rules, ourLoaderPath);
+    if (!alreadyInjected) rules.unshift(RSC_LOADER_RULE);
+  }
+
+  private hasLoaderRule(rules: unknown[], loaderPath: string, test?: RegExp): boolean {
+    return rules.some((r) => {
       if (!r || typeof r !== 'object') return false;
-      const rule = r as { use?: unknown };
+      const rule = r as { use?: unknown; test?: unknown };
       if (!Array.isArray(rule.use)) return false;
-      return rule.use.some((u) => {
-        if (typeof u === 'string') return u === ourLoaderPath;
-        if (u && typeof u === 'object') return (u as { loader?: string }).loader === ourLoaderPath;
+      const hasLoader = rule.use.some((u) => {
+        if (typeof u === 'string') return u === loaderPath;
+        if (u && typeof u === 'object') return (u as { loader?: string }).loader === loaderPath;
         return false;
       });
+      if (!hasLoader || !test) return hasLoader;
+      return (
+        rule.test instanceof RegExp &&
+        rule.test.source === test.source &&
+        rule.test.flags === test.flags
+      );
     });
-    if (!alreadyInjected) rules.unshift(RSC_LOADER_RULE);
   }
 
   /**
@@ -479,9 +507,7 @@ export class RSCRspackPlugin {
    */
   private buildManifest(
     compilation: AnyCompilation,
-    taggedPaths: Set<string>,
     bundler: Bundler,
-    logger?: AnyLogger,
   ): {
     moduleLoading: { prefix: string; crossOrigin: string | null };
     filePathToModuleMetadata: Record<string, { id: string | number | null; chunks: (string | number | null)[]; name: string }>;
@@ -494,35 +520,20 @@ export class RSCRspackPlugin {
     const expectedRuntime = this.options.isServer ? clientFileNameOnServer : clientFileNameOnClient;
     let clientFileNameFound = false;
 
-    const resolvedClientFiles = new Set(
-      (this._resolvedClientFiles ?? []).map((f: string) => f),
-    );
+    const resolvedClientFiles = new Set(this._resolvedClientFiles ?? []);
+    const initialChunks = this.getInitialChunks(compilation);
 
     const filePathToModuleMetadata: Record<
       string,
       { id: string | number | null; chunks: (string | number | null)[]; name: string }
     > = {};
 
-    // Collect entrypoint names so we can skip entry chunk groups below.
-    // In rspack, entry chunk groups include the runtime chunk and entry
-    // chunks that are NOT async-loadable. Including them in the manifest
-    // causes the Flight runtime to fail when it tries to
-    // __webpack_chunk_load__ an entry chunk. Async chunk groups (created
-    // by our injection-loader's import() statements) only contain
-    // async-loadable chunks and their splitChunks siblings.
-    const entryNames = new Set(
-      compilation.entrypoints ? [...compilation.entrypoints.keys()] : [],
-    );
-
     // Walk chunk groups using group-level chunks (matching the webpack
     // plugin, lines 241-294). Each module gets the full list of sibling
     // chunks in its group — this ensures splitChunks dependencies are
-    // included. We skip entry chunk groups since their chunks are loaded
-    // via <script> tags, not __webpack_chunk_load__.
+    // included.
     for (const chunkGroup of compilation.chunkGroups) {
-      if (chunkGroup.name && entryNames.has(chunkGroup.name)) continue;
-
-      const groupChunks = this.getGroupChunks(chunkGroup);
+      const groupChunks = this.getGroupChunks(chunkGroup, initialChunks);
 
       for (const chunkUnknown of chunkGroup.chunks) {
         const chunk = chunkUnknown as AnyChunk;
@@ -532,11 +543,11 @@ export class RSCRspackPlugin {
           if (mod.resource === expectedRuntime) clientFileNameFound = true;
 
           const moduleId = compilation.chunkGraph.getModuleId(mod);
-          this.recordModule(mod, moduleId, groupChunks, taggedPaths, resolvedClientFiles, filePathToModuleMetadata);
+          this.recordModule(mod, moduleId, groupChunks, resolvedClientFiles, filePathToModuleMetadata);
           if (mod.modules) {
             for (const inner of mod.modules) {
               if (inner.resource === expectedRuntime) clientFileNameFound = true;
-              this.recordModule(inner, moduleId, groupChunks, taggedPaths, resolvedClientFiles, filePathToModuleMetadata);
+              this.recordModule(inner, moduleId, groupChunks, resolvedClientFiles, filePathToModuleMetadata);
             }
           }
         }
@@ -577,17 +588,19 @@ export class RSCRspackPlugin {
   /** Stash resolved client files so buildManifest can filter by them. */
   private _resolvedClientFiles: string[] = [];
 
-  /** Build the chunks array from all chunks in a chunk group. */
+  /** Build the chunks array from all async-loadable chunks in a chunk group. */
   private getGroupChunks(
     chunkGroup: AnyChunkGroup,
+    initialChunks: Set<unknown>,
   ): (string | number | null)[] {
     const chunks: (string | number | null)[] = [];
     for (const chunkUnknown of chunkGroup.chunks) {
       const c = chunkUnknown as AnyChunk;
+      if (this.isInitialChunk(c, initialChunks)) continue;
       const files = c.files instanceof Set ? c.files : new Set(c.files);
       for (const file of files) {
-        if (!file.endsWith('.js')) break;
-        if (file.endsWith('.hot-update.js')) break;
+        if (!file.endsWith('.js')) continue;
+        if (file.endsWith('.hot-update.js')) continue;
         chunks.push(c.id, file);
         break;
       }
@@ -595,8 +608,26 @@ export class RSCRspackPlugin {
     return chunks;
   }
 
+  private getInitialChunks(compilation: AnyCompilation): Set<unknown> {
+    const initialChunks = new Set<unknown>();
+    for (const entrypoint of compilation.entrypoints?.values() ?? []) {
+      const chunks =
+        typeof entrypoint.getChunks === 'function'
+          ? entrypoint.getChunks()
+          : entrypoint.chunks;
+      if (!chunks) continue;
+      for (const chunk of chunks) initialChunks.add(chunk);
+    }
+    return initialChunks;
+  }
+
+  private isInitialChunk(chunk: AnyChunk, initialChunks: Set<unknown>): boolean {
+    if (typeof chunk.canBeInitial === 'function') return chunk.canBeInitial();
+    return initialChunks.has(chunk);
+  }
+
   /**
-   * Record a single module in the manifest if it's a tagged client file.
+   * Record a single module in the manifest if it is a resolved client reference.
    * `moduleId` and `chunks` come from the enclosing context (the chunk
    * group walk or the outer ConcatenatedModule).
    */
@@ -604,12 +635,11 @@ export class RSCRspackPlugin {
     module: AnyModule,
     moduleId: string | number | null,
     chunks: (string | number | null)[],
-    taggedPaths: Set<string>,
     resolvedClientFiles: Set<string>,
     filePathToModuleMetadata: Record<string, { id: string | number | null; chunks: (string | number | null)[]; name: string }>,
   ): void {
     if (!module.resource) return;
-    if (!resolvedClientFiles.has(module.resource) && !taggedPaths.has(module.resource)) return;
+    if (!resolvedClientFiles.has(module.resource)) return;
     if (moduleId === null || moduleId === undefined) return;
 
     const href = url.pathToFileURL(module.resource).href;
@@ -647,4 +677,9 @@ function isBundler(b: unknown): b is Bundler {
     typeof obj.Compilation === 'function' &&
     typeof (obj.Compilation as { PROCESS_ASSETS_STAGE_REPORT?: unknown }).PROCESS_ASSETS_STAGE_REPORT === 'number'
   );
+}
+
+function exactResourceRegexp(resourcePath: string): RegExp {
+  // Escape all regex metacharacters so an absolute file path is matched literally.
+  return new RegExp(`^${resourcePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
 }

--- a/tests/rspack-plugin/fixtures/symlink-client/index.js
+++ b/tests/rspack-plugin/fixtures/symlink-client/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/rspack-plugin/fixtures/symlink-target/SymlinkButton.js
+++ b/tests/rspack-plugin/fixtures/symlink-target/SymlinkButton.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function SymlinkButton() {
+  return 'symlink';
+}

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -21,6 +21,7 @@ export interface CompileOptions {
   clientManifestFilename?: string;
   publicPath?: string;
   crossOriginLoading?: false | 'anonymous' | 'use-credentials';
+  clientReferences?: unknown;
   /** Additional rspack config to merge. Use sparingly. */
   configExtra?: Record<string, unknown>;
 }
@@ -54,6 +55,7 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     outputPath,
     isServer: options.isServer ?? false,
     clientManifestFilename: options.clientManifestFilename,
+    clientReferences: serializeForRunner(options.clientReferences),
     publicPath: options.publicPath,
     crossOriginLoading: options.crossOriginLoading,
     configExtra: options.configExtra ?? {},
@@ -104,6 +106,21 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     assets: result.assets ?? [],
     outputPath,
   };
+};
+
+const serializeForRunner = (value: unknown): unknown => {
+  if (value instanceof RegExp) {
+    return { __type: 'RegExp', source: value.source, flags: value.flags };
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeForRunner);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, serializeForRunner(child)]),
+    );
+  }
+  return value;
 };
 
 /**

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -11,6 +11,7 @@
  *     outputPath: string,
  *     isServer: boolean,
  *     clientManifestFilename?: string,
+ *     clientReferences?: unknown,
  *     publicPath?: string,
  *     crossOriginLoading?: false|'anonymous'|'use-credentials',
  *     configExtra?: object,
@@ -40,16 +41,40 @@ const {
   outputPath,
   isServer,
   clientManifestFilename,
+  clientReferences: rawClientReferences,
   publicPath,
   crossOriginLoading,
   configExtra,
 } = args;
 
+if (configExtra && Object.prototype.hasOwnProperty.call(configExtra, 'entry')) {
+  throw new Error(
+    'configExtra.entry is not supported; the test runner must keep the Flight runtime entry.',
+  );
+}
+
+const runtimeEntries = {
+  server: path.resolve(__dirname, '../../../dist/client.node.js'),
+  client: path.resolve(__dirname, '../../../dist/client.browser.js'),
+};
+const missingRuntimeEntries = Object.values(runtimeEntries).filter((entry) => !fs.existsSync(entry));
+if (missingRuntimeEntries.length > 0) {
+  process.stdout.write(JSON.stringify({
+    ok: false,
+    errors: missingRuntimeEntries.map((entry) =>
+      `Missing ${path.relative(path.resolve(__dirname, '../../..'), entry)}. Run \`yarn build\` first.`,
+    ),
+  }));
+  process.exit(1);
+}
+const runtimeEntry = isServer ? runtimeEntries.server : runtimeEntries.client;
+const clientReferences = reviveFromRunner(rawClientReferences);
+
 const config = {
   mode: 'development',
-  target: 'web',
+  target: isServer ? 'node' : 'web',
   context,
-  entry: './index.js',
+  entry: [runtimeEntry, './index.js'],
   output: {
     path: outputPath,
     filename: '[name].js',
@@ -67,6 +92,7 @@ const config = {
     new RSCRspackPlugin({
       isServer: isServer,
       clientManifestFilename: clientManifestFilename,
+      clientReferences: clientReferences,
     }),
   ],
   ...(configExtra || {}),
@@ -100,3 +126,30 @@ rspack(config, (err, stats) => {
     }),
   );
 });
+
+function reviveFromRunner(value) {
+  if (value && typeof value === 'object' && value.__type === 'RegExp') {
+    if (
+      typeof value.source !== 'string' ||
+      typeof value.flags !== 'string' ||
+      /[^gimsuy]/.test(value.flags)
+    ) {
+      throw new TypeError('reviveFromRunner: invalid RegExp payload');
+    }
+    try {
+      return new RegExp(value.source, value.flags);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      throw new TypeError(`reviveFromRunner: invalid RegExp source "${value.source}": ${message}`);
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map(reviveFromRunner);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, reviveFromRunner(child)]),
+    );
+  }
+  return value;
+}

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -140,6 +140,51 @@ describe('RSCRspackPlugin', () => {
       const result = run('no-client');
       expect(result.manifest.filePathToModuleMetadata).toEqual({});
     });
+
+    it('honors explicit clientReferences instead of recording every imported "use client" file', () => {
+      const result = run('multiple-clients', { clientReferences: ['./A.js'] });
+      const paths = Object.keys(result.manifest.filePathToModuleMetadata);
+      expect(paths.length).toBe(1);
+      expect(paths[0]).toContain('/A.js');
+    });
+
+    it('does not preload initial entry chunks for statically imported client references', () => {
+      const result = run('basic-client');
+      const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientButton.js'),
+      );
+      expect(key).toBeTruthy();
+
+      const entry = result.manifest.filePathToModuleMetadata[key!]!;
+      const chunkFiles = entry.chunks
+        .filter((_chunk, index) => index % 2 === 1)
+        .map(String);
+      const initialAssets = new Set(
+        result.assets.filter((asset) => asset === 'main.js' || asset.startsWith('vendors-')),
+      );
+
+      expect(entry.id).toBe('./ClientButton.js');
+      expect(initialAssets.size).toBeGreaterThan(0);
+      expect(chunkFiles.filter((file) => initialAssets.has(file))).toEqual([]);
+    });
+
+    it('preserves client references discovered through symlinked directories', () => {
+      const fixtureRoot = path.join(__dirname, 'fixtures/symlink-client');
+      const targetPath = path.join(__dirname, 'fixtures/symlink-target');
+      const linkPath = path.join(fixtureRoot, 'linked');
+      fs.rmSync(linkPath, { force: true, recursive: true });
+      fs.symlinkSync(targetPath, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+
+      try {
+        const result = run('symlink-client', {
+          clientReferences: [{ directory: './linked', recursive: true, include: /\.js$/ }],
+        });
+        const paths = Object.keys(result.manifest.filePathToModuleMetadata);
+        expect(paths.some((p) => p.endsWith('/symlink-target/SymlinkButton.js'))).toBe(true);
+      } finally {
+        fs.rmSync(linkPath, { force: true, recursive: true });
+      }
+    });
   });
 
   describe('server manifest parity (isServer: true)', () => {
@@ -188,7 +233,6 @@ describe('RSCRspackPlugin', () => {
       const paths = Object.keys(result.manifest.filePathToModuleMetadata);
       expect(paths.some((p) => p.endsWith('ClientButton.js'))).toBe(true);
       for (const entry of Object.values(result.manifest.filePathToModuleMetadata)) {
-        expect(entry.chunks.length).toBeGreaterThan(0);
         expect(entry.chunks.length % 2).toBe(0);
       }
     });
@@ -336,7 +380,7 @@ describe('RSCRspackPlugin', () => {
   describe('plugin option validation', () => {
     // Importing from dist so we don't need TS types here.
     // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-    const { RSCRspackPlugin } = require(DIST_PLUGIN);
+    const { RSC_LOADER_RULE, RSCRspackPlugin } = require(DIST_PLUGIN);
 
     it('throws when options is null', () => {
       expect(() => new RSCRspackPlugin(null)).toThrow(/isServer/);
@@ -374,6 +418,10 @@ describe('RSCRspackPlugin', () => {
             clientManifestFilename: 'custom.json',
           }),
       ).not.toThrow();
+    });
+
+    it('does not attach the directive detector to node_modules', () => {
+      expect(RSC_LOADER_RULE.exclude.test('/app/node_modules/pkg/index.ts')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- attach the Rspack injection loader with a resource RegExp so it reliably matches the vendored Flight client runtime
- restore Webpack manifest parity by walking all chunk groups when recording client references
- record only resolved `clientReferences`, so unrelated app-level `use client` entries are not pulled into the RSC manifest
- exclude `node_modules` from the directive detector loader
- update the Rspack plugin fixture runner to compile the Flight client runtime entry, which is required for FS-discovered client references to become async chunks

## Verification
- YARN_CACHE_FOLDER=/private/tmp/yarn-cache yarn run build
- YARN_CACHE_FOLDER=/private/tmp/yarn-cache yarn jest tests/rspack-plugin tests/rspack-compat --runInBand
- YARN_CACHE_FOLDER=/private/tmp/yarn-cache yarn test
- Starter canary with `react-on-rails-rsc@file:/private/tmp/react_on_rails_rsc-upstream` + `RSCRspackPlugin`: `bin/shakapacker`
- Starter canary with manifests required: `REQUIRE_RSC_MANIFESTS=true pnpm run repro:rspack-rsc`

Context: PR #36 was merged with unit-tests failing because `filePathToModuleMetadata` was empty in the Rspack plugin tests. Starter validation also showed that broad app-level `use client` detection can pull TanStack app shells/devtools into the RSC manifest path, so this patch keeps manifest entries scoped to explicit `clientReferences`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect RSC manifest chunk lists and which modules are included—incorrect filtering could break hydration or omit client references, but scope is bundler plugin + tests rather than runtime auth/data paths.
> 
> **Overview**
> Fixes **Rspack RSC client manifest** generation so manifests stay scoped to configured references and match Webpack behavior.
> 
> The **Flight runtime injection loader** is matched with a literal path **RegExp** and registered idempotently via **`hasLoaderRule`**, so FS-discovered client references reliably become async chunks. Manifest entries are recorded only for **`clientReferences`** resolved at compile time—not every loader-tagged `"use client"` module—avoiding unrelated app shells from appearing in the manifest. **`RSC_LOADER_RULE`** now **excludes `node_modules`** from directive detection.
> 
> **Chunk metadata** walks all chunk groups but omits **initial/entry chunks** (via **`canBeInitial`** / entrypoint chunks), so statically imported client modules do not list **`main.js`** or vendor initial assets as preload targets. Resolved paths are **deduped** and **canonicalized** with **`realpathSync`** so symlinked discovery matches bundler module resources.
> 
> Test harness compiles with the **Flight client runtime entry**, passes **`clientReferences`** (including revived **RegExp**s), and adds coverage for explicit references, initial-chunk exclusion, symlinks, and the **`node_modules`** exclude.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ef203e3fbc3870ca797116f353bc6a386f07c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client reference discovery and manifest generation
  * Enhanced symlink support for client reference resolution
  * Made loader rule injection more robust and idempotent
  * Refined chunk computation for manifest entries

* **Tests**
  * Expanded coverage for client reference handling
  * Added symlink client reference scenario testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails_rsc/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->