### PR TITLE
Fix RSCRspackPlugin default splitChunks behavior

### DIFF
--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -312,7 +312,7 @@ export class RSCRspackPlugin {
             if (typeof origChunks === 'function') return origChunks(chunk);
             if (origChunks === 'initial') return !!(chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
             if (origChunks === 'async') return !(chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
-            return true;
+            return true; // 'all' intentionally includes every non-generated chunk.
           };
         }
       }

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -312,7 +312,7 @@ export class RSCRspackPlugin {
             if (typeof origChunks === 'function') return origChunks(chunk);
             if (origChunks === 'initial') return !!(chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
             if (origChunks === 'async') return !(chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
-            return true; // 'all' intentionally includes every non-generated chunk.
+            return true; // origChunks === 'all': include every non-generated chunk.
           };
         }
       }

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -306,7 +306,7 @@ export class RSCRspackPlugin {
         const optimization = (compiler.options as { optimization?: { splitChunks?: SplitChunksConfig } }).optimization;
         const splitChunks = optimization?.splitChunks;
         if (splitChunks) {
-          const origChunks = splitChunks.chunks;
+          const origChunks = splitChunks.chunks ?? 'async';
           splitChunks.chunks = (chunk: { name?: string }) => {
             if (chunk.name != null && getGeneratedChunkNames().has(chunk.name)) return false;
             if (typeof origChunks === 'function') return origChunks(chunk);

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -310,8 +310,11 @@ export class RSCRspackPlugin {
           splitChunks.chunks = (chunk: { name?: string }) => {
             if (chunk.name != null && getGeneratedChunkNames().has(chunk.name)) return false;
             if (typeof origChunks === 'function') return origChunks(chunk);
-            if (origChunks === 'initial') return !!(chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
-            if (origChunks === 'async') return !(chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
+            // Rspack/Webpack chunks expose canBeInitial(); keep the historical
+            // fallback for non-standard chunk shapes explicit.
+            const canBeInitial = (chunk as { canBeInitial?: () => boolean }).canBeInitial?.();
+            if (origChunks === 'initial') return !!canBeInitial;
+            if (origChunks === 'async') return !canBeInitial;
             return true; // origChunks === 'all': include every non-generated chunk.
           };
         }

--- a/tests/rspack-plugin/fixtures/default-splitchunks/ClientWidget.js
+++ b/tests/rspack-plugin/fixtures/default-splitchunks/ClientWidget.js
@@ -1,0 +1,7 @@
+'use client';
+
+import { clientLabel } from './clientlib';
+
+export default function ClientWidget() {
+  return clientLabel;
+}

--- a/tests/rspack-plugin/fixtures/default-splitchunks/biglib.js
+++ b/tests/rspack-plugin/fixtures/default-splitchunks/biglib.js
@@ -1,0 +1,1 @@
+export const label = 'biglib';

--- a/tests/rspack-plugin/fixtures/default-splitchunks/clientlib.js
+++ b/tests/rspack-plugin/fixtures/default-splitchunks/clientlib.js
@@ -1,0 +1,1 @@
+export const clientLabel = 'clientlib';

--- a/tests/rspack-plugin/fixtures/default-splitchunks/index.js
+++ b/tests/rspack-plugin/fixtures/default-splitchunks/index.js
@@ -1,3 +1,4 @@
+// Initial entry: biglib must stay in main.js when splitChunks uses default async chunks.
 import { label } from './biglib';
 
 export default function readInitialDependency() {

--- a/tests/rspack-plugin/fixtures/default-splitchunks/index.js
+++ b/tests/rspack-plugin/fixtures/default-splitchunks/index.js
@@ -1,0 +1,5 @@
+import { label } from './biglib';
+
+export default function readInitialDependency() {
+  return label;
+}

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -307,6 +307,42 @@ describe('RSCRspackPlugin', () => {
       );
       expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
     });
+
+    it('preserves explicit all chunk selection for non-generated chunks', () => {
+      const result = run('default-splitchunks', {
+        configExtra: {
+          optimization: {
+            chunkIds: 'named',
+            moduleIds: 'named',
+            minimize: false,
+            splitChunks: {
+              chunks: 'all',
+              minSize: 0,
+              cacheGroups: {
+                forcedVendor: {
+                  name: 'vendors-biglib',
+                  minChunks: 1,
+                  enforce: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      const jsAssets = result.assets.filter((asset) => asset.endsWith('.js')).sort();
+
+      expect(jsAssets).toContain('vendors-biglib.js');
+
+      const clientEntryKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientWidget.js'),
+      );
+      expect(clientEntryKey).toBeTruthy();
+
+      const clientChunkFiles = manifestChunkFiles(
+        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks,
+      );
+      expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
+    });
   });
 
   describe('publicPath handling', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -271,6 +271,8 @@ describe('RSCRspackPlugin', () => {
               minSize: 0,
               cacheGroups: {
                 forcedVendor: {
+                  // No `test` filter: match all eligible modules so the old
+                  // undefined-as-all bug extracts biglib from the initial chunk.
                   name: 'vendors-biglib',
                   minChunks: 1,
                   enforce: true,
@@ -291,6 +293,7 @@ describe('RSCRspackPlugin', () => {
       );
       expect(clientEntryKey).toBeTruthy();
 
+      // Manifest chunks are [id, file, id, file, ...]; odd indices are files.
       const clientChunkFiles = result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks
         .filter((_chunk, index) => index % 2 === 1)
         .map(String);

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -19,6 +19,13 @@ const run = (fixture: string, options?: Parameters<typeof compile>[1]): CompileR
   return r;
 };
 
+type ManifestChunks =
+  CompileResult['manifest']['filePathToModuleMetadata'][string]['chunks'];
+
+// Manifest chunks are encoded as [id, file, id, file, ...].
+const manifestChunkFiles = (chunks: ManifestChunks): string[] =>
+  chunks.filter((_chunk, index) => index % 2 === 1).map(String);
+
 afterAll(() => cleanupOutputDirs(created));
 
 const DIST_PLUGIN = path.resolve(__dirname, '../../dist/react-server-dom-rspack/plugin.js');
@@ -156,9 +163,7 @@ describe('RSCRspackPlugin', () => {
       expect(key).toBeTruthy();
 
       const entry = result.manifest.filePathToModuleMetadata[key!]!;
-      const chunkFiles = entry.chunks
-        .filter((_chunk, index) => index % 2 === 1)
-        .map(String);
+      const chunkFiles = manifestChunkFiles(entry.chunks);
       const initialAssets = new Set(
         result.assets.filter((asset) => asset === 'main.js' || asset.startsWith('vendors-')),
       );
@@ -293,10 +298,9 @@ describe('RSCRspackPlugin', () => {
       );
       expect(clientEntryKey).toBeTruthy();
 
-      // Manifest chunks are [id, file, id, file, ...]; odd indices are files.
-      const clientChunkFiles = result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks
-        .filter((_chunk, index) => index % 2 === 1)
-        .map(String);
+      const clientChunkFiles = manifestChunkFiles(
+        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks,
+      );
       expect(clientChunkFiles).toEqual(
         expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)]),
       );

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -290,6 +290,7 @@ describe('RSCRspackPlugin', () => {
       const jsAssets = result.assets.filter((asset) => asset.endsWith('.js')).sort();
 
       expect(jsAssets).toContain('main.js');
+      // Generated client-reference chunks use the default `client[index]` chunkName.
       expect(jsAssets.some((asset) => /^client\d+\.chunk\.js$/.test(asset))).toBe(true);
       expect(jsAssets.filter((asset) => /vendors|biglib|clientlib/.test(asset))).toEqual([]);
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -259,6 +259,48 @@ describe('RSCRspackPlugin', () => {
     });
   });
 
+  describe('splitChunks integration', () => {
+    it('preserves default async chunk selection while excluding generated client-reference chunks', () => {
+      const result = run('default-splitchunks', {
+        configExtra: {
+          optimization: {
+            chunkIds: 'named',
+            moduleIds: 'named',
+            minimize: false,
+            splitChunks: {
+              minSize: 0,
+              cacheGroups: {
+                forcedVendor: {
+                  name: 'vendors-biglib',
+                  minChunks: 1,
+                  enforce: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      const jsAssets = result.assets.filter((asset) => asset.endsWith('.js')).sort();
+
+      expect(jsAssets).toContain('main.js');
+      expect(jsAssets.some((asset) => /^client\d+\.chunk\.js$/.test(asset))).toBe(true);
+      expect(jsAssets.filter((asset) => /vendors|biglib|clientlib/.test(asset))).toEqual([]);
+
+      const clientEntryKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientWidget.js'),
+      );
+      expect(clientEntryKey).toBeTruthy();
+
+      const clientChunkFiles = result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks
+        .filter((_chunk, index) => index % 2 === 1)
+        .map(String);
+      expect(clientChunkFiles).toEqual(
+        expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)]),
+      );
+      expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
+    });
+  });
+
   describe('publicPath handling', () => {
     it('passes publicPath "auto" through verbatim (matches webpack)', () => {
       const result = run('basic-client', { publicPath: 'auto' });


### PR DESCRIPTION
## Summary

- Fixes the `react-on-rails-rsc@19.0.5-rc.2` regression where `RSCRspackPlugin` broadened default client `splitChunks` behavior when `optimization.splitChunks.chunks` was unset.
- Root cause: the plugin wrapped `splitChunks.chunks` before Rspack/Webpack had defaulted the unset value, so `undefined` fell through to the wrapper's `true` path and behaved like `all`.
- Fix: default an unset `splitChunks.chunks` value to `async` before applying the generated RSC client-reference chunk exclusion.
- Adds real Rspack regression coverage proving ordinary initial chunks are not split just because `RSCRspackPlugin` is present, while generated RSC client-reference chunks remain excluded from splitChunks extraction.
- Adds explicit coverage that `chunks: "all"` still takes the wrapper fallthrough path for non-generated chunks.

After merge, this should be released as `react-on-rails-rsc@19.0.5-rc.3`.

## Starter Compatibility

Verified against `shakacode/react-on-rails-starter-tanstack` `origin/main` (`ac3d897`) by applying the one-line `splitChunks.chunks ?? 'async'` change directly to the installed `react-on-rails-rsc@19.0.5-rc.2` package in a temp worktree.

- The starter currently receives `optimization.splitChunks.chunks: "all"` from ShakaPacker's base config, so this PR does not change the starter's normal emitted asset list.
- Stock rc.2 and patched rc.2 both emitted 20 JS entries in development, including the intentional ShakaPacker vendor chunks.
- The RSC client manifest stayed correct, listing only generated client-reference chunks for the RSC client islands:
  - `RscShowcaseReaction.tsx` -> `client1`
  - `LikeButton.tsx` -> `client0`
- Production boot passed with the React on Rails Pro node renderer and Rspack assets.

Starter validation commands:

- `bin/shakapacker`
- `REQUIRE_RSC_MANIFESTS=true pnpm run repro:rspack-rsc`
- `bin/test playwright test/playwright/rsc_showcase.spec.ts`
- `bin/test hello-server-rsc`
- `bin/test production-boot` with local PostgreSQL URLs

## Verification

- `yarn build`
- Red check: temporarily restored old `splitChunks.chunks` handling; `yarn jest tests/rspack-plugin/plugin.test.ts -t splitChunks --runInBand` failed by emitting `vendors-biglib.js`.
- `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand` - 50 passed
- `yarn test:non-rsc` - 9 suites / 83 tests passed
- `yarn test:rsc` - 2 suites / 6 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-bundle-only splitChunks wrapper change with targeted regression tests; no auth or data paths touched.
>
> **Overview**
> Fixes a **regression** where `RSCRspackPlugin` wrapped `optimization.splitChunks.chunks` before Rspack/Webpack applied their default, so an **unset** value fell through to the wrapper’s final `return true` and behaved like **`all`**—pulling modules such as initial-entry dependencies into vendor splits when only default async splitting was intended.
>
> The plugin now treats missing `splitChunks.chunks` as **`async`** (`origChunks = splitChunks.chunks ?? 'async'`) before excluding generated RSC client-reference chunk names, and clarifies **`initial` / `async` / `all`** handling via a shared `canBeInitial` read.
>
> Adds a **`default-splitchunks`** fixture and **`splitChunks integration`** tests: default config keeps `biglib` in `main.js` (no spurious `vendors-biglib.js`) while generated `client*.chunk.js` assets and manifest entries stay self-contained; explicit `chunks: 'all'` still allows vendor extraction but not from generated client chunks. Refactors manifest chunk file extraction into **`manifestChunkFiles`** in the test suite.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00bb7f72e6c8227219cbb75a8a761ccb6ce8aace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved chunk splitting configuration handling in the RSC build plugin to correctly preserve default async chunk selection while excluding generated client-reference chunks, resulting in more optimized bundle outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
