### PR TITLE
Fix default client reference exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [19.0.5-rc.3] - 2026-05-30
 
 ### Fixed
+- Fixed default client reference discovery to skip dependency and generated asset directories such as `node_modules`, `vendor/bundle`, and `vendor/cache`.
 - Fixed `RSCRspackPlugin` so an unset `optimization.splitChunks.chunks` preserves the Rspack/Webpack default `async` behavior while still excluding generated RSC client-reference chunks from splitChunks extraction.
 
 ## [19.0.5-rc.2] - 2026-05-30

--- a/src/WebpackPlugin.ts
+++ b/src/WebpackPlugin.ts
@@ -1,4 +1,8 @@
 import { Compiler } from "webpack";
+import {
+  DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+  DEFAULT_CLIENT_REFERENCES_INCLUDE,
+} from "./clientReferences";
 import RSCWebpackPluginLib = require("./react-server-dom-webpack/plugin");
 
 type ReactFlightWebpackPlugin = {
@@ -30,7 +34,21 @@ export class RSCWebpackPlugin {
   private plugin: ReactFlightWebpackPlugin;
 
   constructor(options: Options) {
-    this.plugin = new (RSCWebpackPluginLib as ReactFlightWebpackPluginConstructor)(options);
+    const normalizedOptions =
+      options.clientReferences === undefined
+        ? {
+            ...options,
+            clientReferences: [
+              {
+                directory: '.',
+                recursive: true,
+                include: DEFAULT_CLIENT_REFERENCES_INCLUDE,
+                exclude: DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+              },
+            ],
+          }
+        : options;
+    this.plugin = new (RSCWebpackPluginLib as ReactFlightWebpackPluginConstructor)(normalizedOptions);
   }
 
   apply(compiler: Compiler) {

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
+  /(^|[/\\])(?:node_modules|vendor[/\\](?:bundle|cache)|public[/\\](?:assets|packs|vite|webpack|rspack|builds)|app[/\\]assets[/\\](?:builds|webpack|rspack))(?:[/\\]|$)/;
+
+export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -1,4 +1,12 @@
+/**
+ * Default directories skipped by client reference discovery.
+ * These are dependencies or generated asset outputs that can contain
+ * framework templates and stale bundles rather than application sources.
+ */
 export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
   /(^|[/\\])(?:node_modules|vendor[/\\](?:bundle|cache)|public[/\\](?:assets|packs|vite|webpack|rspack|builds)|app[/\\]assets[/\\](?:builds|webpack|rspack))(?:[/\\]|$)/;
 
+/**
+ * Default source-file extensions scanned for `"use client"` directives.
+ */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -2,11 +2,15 @@
  * Default directories skipped by client reference discovery.
  * These are dependencies or generated asset outputs that can contain
  * framework templates and stale bundles rather than application sources.
+ *
+ * The pattern matches path segment boundaries anywhere in the relative path
+ * and supports both POSIX and Windows separators.
  */
 export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
-  /(^|[/\\])(?:node_modules|vendor[/\\](?:bundle|cache)|public[/\\](?:assets|packs|vite|webpack|rspack|builds)|app[/\\]assets[/\\](?:builds|webpack|rspack))(?:[/\\]|$)/;
+  /(^|[/\\])(?:node_modules|vendor[/\\](?:bundle|cache)|public[/\\](?:assets|packs|vite|webpack|rspack|builds)|app[/\\]assets[/\\](?:builds|vite|webpack|rspack))(?:[/\\]|$)/;
 
 /**
  * Default source-file extensions scanned for `"use client"` directives.
+ * Matches JavaScript, TypeScript, JSX, TSX, and their CommonJS/ESM variants.
  */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -420,7 +420,7 @@ export class RSCRspackPlugin {
       try { stat = fs.statSync(full); } catch { continue; }
 
       if (stat.isDirectory()) {
-        const relPath = './' + path.relative(walkRoot, full);
+        const relPath = './' + path.relative(walkRoot, full).replace(/\\/g, '/');
         if (ref.exclude && ref.exclude.test(relPath)) continue;
         if (ref.recursive !== false) this.walkDir(full, walkRoot, ref, out);
       } else if (stat.isFile()) {
@@ -428,7 +428,7 @@ export class RSCRspackPlugin {
         // root (e.g. "./components/Button.tsx"), matching the webpack
         // plugin's contextModuleFactory behavior which tests against the
         // relative request path.
-        const relPath = './' + path.relative(walkRoot, full);
+        const relPath = './' + path.relative(walkRoot, full).replace(/\\/g, '/');
         if (!ref.include.test(relPath)) continue;
         if (ref.exclude && ref.exclude.test(relPath)) continue;
         try {

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -420,6 +420,8 @@ export class RSCRspackPlugin {
       try { stat = fs.statSync(full); } catch { continue; }
 
       if (stat.isDirectory()) {
+        const relPath = './' + path.relative(walkRoot, full);
+        if (ref.exclude && ref.exclude.test(relPath)) continue;
         if (ref.recursive !== false) this.walkDir(full, walkRoot, ref, out);
       } else if (stat.isFile()) {
         // Test include/exclude against the RELATIVE path from the walk

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -22,6 +22,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
+import {
+  DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+  DEFAULT_CLIENT_REFERENCES_INCLUDE,
+} from '../clientReferences';
 import { CLIENT_MODULES_KEY, hasUseClientDirective } from './shared';
 import type {} from './injection-loader';
 
@@ -162,8 +166,9 @@ export interface Options {
    * bundle includes every client component even if nothing in the entry graph
    * explicitly imports it — matching the webpack plugin's behavior.
    *
-   * Default: `[{ directory: ".", recursive: true, include: /\.(js|ts|jsx|tsx)$/ }]`
-   * (scan the entire compiler context directory).
+   * Default: scan the compiler context for JS/TS files while excluding
+   * dependency and generated asset directories such as `node_modules`,
+   * `vendor/bundle`, and `vendor/cache`.
    */
   clientReferences?: ClientReferencePath | ReadonlyArray<ClientReferencePath>;
   /**
@@ -200,7 +205,8 @@ export class RSCRspackPlugin {
     this.options = options;
 
     // Normalize clientReferences exactly like the webpack plugin.
-    // Default: scan the entire context directory for JS/TS files.
+    // Default: scan the context directory for JS/TS files, but skip dependency
+    // and generated asset directories that can contain Rails gem templates.
     //
     // When a string is passed, the webpack plugin treats it as a DIRECT
     // file reference (unconditionally included, no "use client" check).
@@ -216,7 +222,12 @@ export class RSCRspackPlugin {
       );
     } else {
       this.clientReferences = [
-        { directory: '.', recursive: true, include: /\.[cm]?[jt]sx?$/ },
+        {
+          directory: '.',
+          recursive: true,
+          include: DEFAULT_CLIENT_REFERENCES_INCLUDE,
+          exclude: DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+        },
       ];
     }
 

--- a/tests/rspack-plugin/fixtures/default-excludes/app/assets/vite/ViteClient.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/app/assets/vite/ViteClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function ViteClient() {
+  return null;
+}

--- a/tests/rspack-plugin/fixtures/default-excludes/app/javascript/AppClient.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/app/javascript/AppClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function AppClient() {
+  return null;
+}

--- a/tests/rspack-plugin/fixtures/default-excludes/index.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/index.js
@@ -1,0 +1,3 @@
+export default function App() {
+  return null;
+}

--- a/tests/rspack-plugin/fixtures/default-excludes/node_modules/example-package/PackageClient.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/node_modules/example-package/PackageClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function PackageClient() {
+  return null;
+}

--- a/tests/rspack-plugin/fixtures/default-excludes/public/assets/PublicClient.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/public/assets/PublicClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function PublicClient() {
+  return null;
+}

--- a/tests/rspack-plugin/fixtures/default-excludes/vendor/bundle/ruby/3.3.0/gems/example-gem/app/javascript/GemClient.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/vendor/bundle/ruby/3.3.0/gems/example-gem/app/javascript/GemClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function GemClient() {
+  return null;
+}

--- a/tests/rspack-plugin/fixtures/default-excludes/vendor/cache/CachedClient.js
+++ b/tests/rspack-plugin/fixtures/default-excludes/vendor/cache/CachedClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function CachedClient() {
+  return null;
+}

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -151,6 +151,8 @@ describe('RSCRspackPlugin', () => {
       expect(paths.some((p) => p.includes('/vendor/bundle/'))).toBe(false);
       expect(paths.some((p) => p.includes('/vendor/cache/'))).toBe(false);
       expect(paths.some((p) => p.includes('/node_modules/'))).toBe(false);
+      expect(paths.some((p) => p.includes('/public/assets/'))).toBe(false);
+      expect(paths.some((p) => p.includes('/app/assets/vite/'))).toBe(false);
     });
 
     it('produces an empty manifest when no client files exist', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -143,6 +143,16 @@ describe('RSCRspackPlugin', () => {
       expect(paths.some((p) => p.endsWith('Dead.js'))).toBe(true);
     });
 
+    it('excludes dependency and generated directories from the default FS walk', () => {
+      const result = run('default-excludes');
+      const paths = Object.keys(result.manifest.filePathToModuleMetadata);
+
+      expect(paths.some((p) => p.endsWith('/app/javascript/AppClient.js'))).toBe(true);
+      expect(paths.some((p) => p.includes('/vendor/bundle/'))).toBe(false);
+      expect(paths.some((p) => p.includes('/vendor/cache/'))).toBe(false);
+      expect(paths.some((p) => p.includes('/node_modules/'))).toBe(false);
+    });
+
     it('produces an empty manifest when no client files exist', () => {
       const result = run('no-client');
       expect(result.manifest.filePathToModuleMetadata).toEqual({});

--- a/tests/rspack-plugin/walk-dir.test.ts
+++ b/tests/rspack-plugin/walk-dir.test.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+  DEFAULT_CLIENT_REFERENCES_INCLUDE,
+} from '../../src/clientReferences';
+import {
+  RSCRspackPlugin,
+  type ClientReferenceSearchPath,
+} from '../../src/react-server-dom-rspack/plugin';
+
+type WalkDirCapable = {
+  walkDir(
+    dir: string,
+    walkRoot: string,
+    ref: ClientReferenceSearchPath,
+    out: Set<string>,
+  ): void;
+};
+
+describe('RSCRspackPlugin filesystem discovery', () => {
+  it('prunes excluded directories instead of only filtering files after traversal', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ror-rspack-walk-'));
+    const appDir = path.join(root, 'app/javascript');
+    const ignoredDir = path.join(root, 'node_modules/ignored-package');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.mkdirSync(ignoredDir, { recursive: true });
+    fs.writeFileSync(path.join(appDir, 'AppClient.js'), "'use client';\n");
+    fs.writeFileSync(path.join(ignoredDir, 'PackageClient.js'), "'use client';\n");
+
+    const readdirSpy = jest.spyOn(fs, 'readdirSync');
+
+    try {
+      const plugin = new RSCRspackPlugin({ isServer: false }) as unknown as WalkDirCapable;
+      const out = new Set<string>();
+      plugin.walkDir(
+        root,
+        root,
+        {
+          directory: '.',
+          recursive: true,
+          include: DEFAULT_CLIENT_REFERENCES_INCLUDE,
+          exclude: DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+        },
+        out,
+      );
+
+      const discoveredPaths = [...out];
+      expect(discoveredPaths.some((p) => p.endsWith('/app/javascript/AppClient.js'))).toBe(true);
+      expect(discoveredPaths.some((p) => p.includes('/node_modules/'))).toBe(false);
+
+      const visitedDirectories = readdirSpy.mock.calls.map(([visited]) =>
+        path.normalize(String(visited)),
+      );
+      expect(visitedDirectories).not.toContain(path.join(root, 'node_modules'));
+      expect(visitedDirectories).not.toContain(ignoredDir);
+    } finally {
+      readdirSpy.mockRestore();
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/rspack-plugin/walk-dir.test.ts
+++ b/tests/rspack-plugin/walk-dir.test.ts
@@ -32,6 +32,8 @@ describe('RSCRspackPlugin filesystem discovery', () => {
     const readdirSpy = jest.spyOn(fs, 'readdirSync');
 
     try {
+      // This intentionally reaches into the private helper because the behavior
+      // under test is traversal pruning, not only the final manifest contents.
       const plugin = new RSCRspackPlugin({ isServer: false }) as unknown as WalkDirCapable;
       const out = new Set<string>();
       plugin.walkDir(

--- a/tests/webpack-plugin-options.test.ts
+++ b/tests/webpack-plugin-options.test.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_CLIENT_REFERENCES_EXCLUDE } from '../src/clientReferences';
+import { RSCWebpackPlugin } from '../src/WebpackPlugin';
+
+describe('RSCWebpackPlugin clientReferences defaults', () => {
+  it('uses the shared dependency and generated directory exclusions by default', () => {
+    const wrapper = new RSCWebpackPlugin({ isServer: false });
+    const plugin = (wrapper as unknown as { plugin: { clientReferences: unknown[] } }).plugin;
+
+    expect(plugin.clientReferences).toEqual([
+      {
+        directory: '.',
+        recursive: true,
+        include: /\.[cm]?[jt]sx?$/,
+        exclude: DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+      },
+    ]);
+  });
+});

--- a/tests/webpack-plugin-options.test.ts
+++ b/tests/webpack-plugin-options.test.ts
@@ -7,8 +7,11 @@ import { RSCWebpackPlugin } from '../src/WebpackPlugin';
 describe('RSCWebpackPlugin clientReferences defaults', () => {
   it('uses the shared dependency and generated directory exclusions by default', () => {
     const wrapper = new RSCWebpackPlugin({ isServer: false });
+    // RSCWebpackPlugin delegates to the upstream webpack plugin, so this keeps
+    // the option normalization check focused without running a full compilation.
     const plugin = (wrapper as unknown as { plugin: { clientReferences: unknown[] } }).plugin;
 
+    expect(plugin).toBeDefined();
     expect(plugin.clientReferences).toEqual([
       {
         directory: '.',

--- a/tests/webpack-plugin-options.test.ts
+++ b/tests/webpack-plugin-options.test.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_CLIENT_REFERENCES_EXCLUDE } from '../src/clientReferences';
+import {
+  DEFAULT_CLIENT_REFERENCES_EXCLUDE,
+  DEFAULT_CLIENT_REFERENCES_INCLUDE,
+} from '../src/clientReferences';
 import { RSCWebpackPlugin } from '../src/WebpackPlugin';
 
 describe('RSCWebpackPlugin clientReferences defaults', () => {
@@ -10,7 +13,7 @@ describe('RSCWebpackPlugin clientReferences defaults', () => {
       {
         directory: '.',
         recursive: true,
-        include: /\.[cm]?[jt]sx?$/,
+        include: DEFAULT_CLIENT_REFERENCES_INCLUDE,
         exclude: DEFAULT_CLIENT_REFERENCES_EXCLUDE,
       },
     ]);


### PR DESCRIPTION
## Summary

- Adds shared default `clientReferences` include/exclude values for both Webpack and Rspack plugins.
- Excludes dependency/generated directories from the default filesystem walk, including `node_modules`, `vendor/bundle`, `vendor/cache`, generated public asset directories, and generated app asset directories.
- Adds regression coverage for Rspack discovery and Webpack wrapper defaults.

Fixes #37.

## Verification

- Red test before implementation: focused Rspack regression included `/vendor/bundle/`, and the Webpack defaults test failed because the shared defaults did not exist yet.
- `yarn build`
- `yarn jest tests/rspack-plugin/plugin.test.ts tests/webpack-plugin-options.test.ts --runInBand` — 2 suites, 52 tests passed.
- `git diff --check`
- `yarn test` — RSC suite: 2 suites, 6 tests passed; non-RSC suite: 10 suites, 85 tests passed.

Notes: Yarn emitted cache/global-folder warnings in the sandbox, and Jest emitted the existing `ts-jest` TS151002 warning plus existing console output from RSC streaming tests. All commands exited 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default RSC client manifest discovery behavior; apps that relied on picking up `"use client"` files under excluded paths may need explicit `clientReferences`, but the new defaults reduce false positives from gems and stale bundles.
> 
> **Overview**
> Default **client reference** filesystem discovery no longer scans the whole project tree blindly. When `clientReferences` is omitted, **Webpack** and **Rspack** plugins now share defaults from `clientReferences.ts`: JS/TS include patterns plus an **exclude** regex for `node_modules`, `vendor/bundle`, `vendor/cache`, generated **public** asset folders, and generated **app/assets** build outputs.
> 
> **Rspack** `walkDir` applies that exclude when entering subdirectories (pruning traversal, not only filtering files) and normalizes relative paths with forward slashes for Windows. **Webpack** gets the same descriptor via option normalization in `RSCWebpackPlugin` when callers do not override `clientReferences`.
> 
> Regression tests cover manifest output, directory pruning, and Webpack wrapper defaults; the changelog documents the fix for 19.0.5-rc.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef4dcd55adde92b437612ac90d1f2baacb0dba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved default client reference discovery to automatically exclude `node_modules`, `vendor/bundle`, `vendor/cache`, and other common dependency/generated asset directories.
  * Fixed plugin behavior to preserve default async module splitting while preventing client-reference chunk extraction conflicts.

* **Tests**
  * Added test coverage for default client reference discovery and exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->