### PR TITLE
Fix RSC runtime detection for duplicate package installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [19.0.5-rc.3] - 2026-05-30
 
 ### Fixed
+- Fixed Webpack plugin runtime detection when package managers install multiple `react-on-rails-rsc` package instances for different peer dependency sets.
 - Fixed `RSCRspackPlugin` so an unset `optimization.splitChunks.chunks` preserves the Rspack/Webpack default `async` behavior while still excluding generated RSC client-reference chunks from splitChunks extraction.
 
 ## [19.0.5-rc.2] - 2026-05-30

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -9,7 +9,8 @@
  */
 
 "use strict";
-var path = require("path"),
+var fs = require("fs"),
+  path = require("path"),
   url = require("url"),
   asyncLib = require("neo-async"),
   acorn = require("acorn-loose"),
@@ -94,6 +95,33 @@ class ClientReferenceDependency extends ModuleDependency {
 }
 const clientFileNameOnClient = require.resolve("../client.browser.js"),
   clientFileNameOnServer = require.resolve("../client.node.js");
+function isReactOnRailsRSCRuntimeResource(resource, isServer) {
+  if (
+    resource === (isServer ? clientFileNameOnServer : clientFileNameOnClient)
+  )
+    return !0;
+  if ("string" !== typeof resource) return !1;
+  const normalizedResource = path.normalize(resource),
+    expectedSuffix = path.join(
+      "react-server-dom-webpack",
+      isServer ? "client.node.js" : "client.browser.js"
+    );
+  if (!normalizedResource.endsWith(expectedSuffix)) return !1;
+  let dir = path.dirname(normalizedResource);
+  for (let i = 0; 20 > i; i++) {
+    const packageJsonPath = path.join(dir, "package.json");
+    try {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      if ("react-on-rails-rsc" === packageJson.name) return !0;
+    } catch (x) {
+      if ("ENOENT" !== x.code && "ENOTDIR" !== x.code) return !1;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return !1;
+    dir = parent;
+  }
+  return !1;
+}
 class ReactFlightWebpackPlugin {
   constructor(options) {
     this.isServer =
@@ -164,10 +192,10 @@ class ReactFlightWebpackPlugin {
           parser.hooks.program.tap("React Server Plugin", () => {
             const module = parser.state.module;
             if (
-              module.resource ===
-                (_this.isServer
-                  ? clientFileNameOnServer
-                  : clientFileNameOnClient) &&
+              isReactOnRailsRSCRuntimeResource(
+                module.resource,
+                _this.isServer
+              ) &&
               ((clientFileNameFound = !0), resolvedClientReferences)
             )
               for (let i = 0; i < resolvedClientReferences.length; i++) {
@@ -409,4 +437,6 @@ class ReactFlightWebpackPlugin {
     );
   }
 }
+ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource =
+  isReactOnRailsRSCRuntimeResource;
 module.exports = ReactFlightWebpackPlugin;

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -95,7 +95,16 @@ class ClientReferenceDependency extends ModuleDependency {
 }
 const clientFileNameOnClient = require.resolve("../client.browser.js"),
   clientFileNameOnServer = require.resolve("../client.node.js");
+const runtimeResourceDetectionCache = new Map();
 function isReactOnRailsRSCRuntimeResource(resource, isServer) {
+  const cacheKey = isServer + "\0" + resource;
+  if (runtimeResourceDetectionCache.has(cacheKey))
+    return runtimeResourceDetectionCache.get(cacheKey);
+  const result = detectReactOnRailsRSCRuntimeResource(resource, isServer);
+  runtimeResourceDetectionCache.set(cacheKey, result);
+  return result;
+}
+function detectReactOnRailsRSCRuntimeResource(resource, isServer) {
   if (
     resource === (isServer ? clientFileNameOnServer : clientFileNameOnClient)
   )
@@ -106,7 +115,7 @@ function isReactOnRailsRSCRuntimeResource(resource, isServer) {
       "react-server-dom-webpack",
       isServer ? "client.node.js" : "client.browser.js"
     );
-  if (!normalizedResource.endsWith(expectedSuffix)) return !1;
+  if (!normalizedResource.endsWith(path.sep + expectedSuffix)) return !1;
   let dir = path.dirname(normalizedResource);
   for (let i = 0; 20 > i; i++) {
     const packageJsonPath = path.join(dir, "package.json");
@@ -114,7 +123,12 @@ function isReactOnRailsRSCRuntimeResource(resource, isServer) {
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
       if ("react-on-rails-rsc" === packageJson.name) return !0;
     } catch (x) {
-      if ("ENOENT" !== x.code && "ENOTDIR" !== x.code) return !1;
+      if (
+        !(x instanceof SyntaxError) &&
+        "ENOENT" !== x.code &&
+        "ENOTDIR" !== x.code
+      )
+        return !1;
     }
     const parent = path.dirname(dir);
     if (parent === dir) return !1;

--- a/tests/webpack-plugin-runtime-detection.test.ts
+++ b/tests/webpack-plugin-runtime-detection.test.ts
@@ -11,9 +11,11 @@ const tempRoots: string[] = [];
 const createDoppelgangerRuntime = ({
   packageName = 'react-on-rails-rsc',
   runtimeFile = 'client.browser.js',
+  runtimeDirectory = 'react-server-dom-webpack',
 }: {
   packageName?: string;
   runtimeFile?: string;
+  runtimeDirectory?: string;
 }) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ror-rsc-doppelganger-'));
   tempRoots.push(root);
@@ -22,7 +24,7 @@ const createDoppelgangerRuntime = ({
     root,
     'node_modules/.pnpm/react-on-rails-rsc@19.0.4_webpack@5.103.0/node_modules/react-on-rails-rsc',
   );
-  const runtimeDir = path.join(packageRoot, 'dist/react-server-dom-webpack');
+  const runtimeDir = path.join(packageRoot, 'dist', runtimeDirectory);
   fs.mkdirSync(runtimeDir, { recursive: true });
   fs.writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: packageName }));
 
@@ -77,5 +79,24 @@ describe('ReactFlightWebpackPlugin runtime detection', () => {
     expect(
       ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
     ).toBe(false);
+  });
+
+  it('rejects runtime-like directory names that only end with the expected runtime directory', () => {
+    const runtimePath = createDoppelgangerRuntime({
+      runtimeDirectory: 'evil-react-server-dom-webpack',
+    });
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
+    ).toBe(false);
+  });
+
+  it('continues walking when an intermediate package.json is malformed', () => {
+    const runtimePath = createDoppelgangerRuntime({});
+    fs.writeFileSync(path.join(path.dirname(runtimePath), 'package.json'), '{');
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
+    ).toBe(true);
   });
 });

--- a/tests/webpack-plugin-runtime-detection.test.ts
+++ b/tests/webpack-plugin-runtime-detection.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ReactFlightWebpackPlugin = require('../src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js') as {
+  __internal_isReactOnRailsRSCRuntimeResource(resource: string | undefined, isServer: boolean): boolean;
+};
+
+const tempRoots: string[] = [];
+
+const createDoppelgangerRuntime = ({
+  packageName = 'react-on-rails-rsc',
+  runtimeFile = 'client.browser.js',
+}: {
+  packageName?: string;
+  runtimeFile?: string;
+}) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ror-rsc-doppelganger-'));
+  tempRoots.push(root);
+
+  const packageRoot = path.join(
+    root,
+    'node_modules/.pnpm/react-on-rails-rsc@19.0.4_webpack@5.103.0/node_modules/react-on-rails-rsc',
+  );
+  const runtimeDir = path.join(packageRoot, 'dist/react-server-dom-webpack');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: packageName }));
+
+  const runtimePath = path.join(runtimeDir, runtimeFile);
+  fs.writeFileSync(runtimePath, '');
+
+  return runtimePath;
+};
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    fs.rmSync(tempRoots.pop()!, { force: true, recursive: true });
+  }
+});
+
+describe('ReactFlightWebpackPlugin runtime detection', () => {
+  it('keeps recognizing the plugin package runtime by exact path', () => {
+    const runtimePath = path.resolve(__dirname, '../src/react-server-dom-webpack/client.browser.js');
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
+    ).toBe(true);
+  });
+
+  it('recognizes a client runtime from a separate react-on-rails-rsc package instance', () => {
+    const runtimePath = createDoppelgangerRuntime({});
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
+    ).toBe(true);
+  });
+
+  it('recognizes a server runtime from a separate react-on-rails-rsc package instance', () => {
+    const runtimePath = createDoppelgangerRuntime({ runtimeFile: 'client.node.js' });
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, true),
+    ).toBe(true);
+  });
+
+  it('rejects runtime-shaped paths from other packages', () => {
+    const runtimePath = createDoppelgangerRuntime({ packageName: 'not-react-on-rails-rsc' });
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
+    ).toBe(false);
+  });
+
+  it('rejects the opposite runtime target', () => {
+    const runtimePath = createDoppelgangerRuntime({ runtimeFile: 'client.node.js' });
+
+    expect(
+      ReactFlightWebpackPlugin.__internal_isReactOnRailsRSCRuntimeResource(runtimePath, false),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Hardens the Webpack plugin's client runtime detection so it no longer depends only on strict path equality with the plugin package's own runtime file.
- Keeps the exact-path fast path, then accepts runtime-shaped files from another installed `react-on-rails-rsc` package instance by walking ancestor `package.json` files and verifying `name === "react-on-rails-rsc"`.
- Adds a regression for pnpm-style duplicate package installs where webpack resolves the runtime from a different physical package instance than the plugin.

Closes shakacode/react_on_rails#3212.

## Verification

- `yarn install --frozen-lockfile`
- `yarn build`
- `yarn jest tests/webpack-plugin-runtime-detection.test.ts --runInBand` — 1 suite, 5 tests passed.
- `git diff --check`
- `yarn test` — RSC suite: 2 suites, 6 tests passed; non-RSC suite: 10 suites, 88 tests passed.

Notes: Yarn emitted cache/global-folder warnings in the sandbox. Jest emitted the existing `ts-jest` TS151002 warnings, the existing haste-map package-name collision warning after build, and existing console output from RSC streaming tests. All commands exited 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build-time plugin behavior that gates RSC client manifest generation; logic is scoped and regression-tested but mis-detection could still skip or mis-wire client references.
> 
> **Overview**
> Fixes **ReactFlightWebpackPlugin** failing to wire client references when Webpack resolves the RSC runtime from a **different physical copy** of `react-on-rails-rsc` (e.g. pnpm peer-specific installs), which previously broke manifest generation because detection used only strict equality with `require.resolve` paths.
> 
> Runtime matching now keeps the exact-path fast path, then treats paths ending in `react-server-dom-webpack/client.browser.js` or `client.node.js` as valid when an ancestor `package.json` has `name: "react-on-rails-rsc"`, with a small cache and safe handling of missing or invalid `package.json` files. The parser hook uses this helper instead of comparing `module.resource` directly.
> 
> Adds **`webpack-plugin-runtime-detection.test.ts`** (pnpm-style temp layouts) via an exported **`__internal_isReactOnRailsRSCRuntimeResource`** hook, and documents the fix in **CHANGELOG** for 19.0.5-rc.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee7d3a5257a2da8c73c6b3e1cc81ee32be59f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->