### PR TITLE
Add CSS-first chunk manifest regression

### DIFF
--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -1,0 +1,147 @@
+import { pathToFileURL } from 'url';
+
+const ReactFlightWebpackPlugin = require('../src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js');
+
+type AsyncHookCallback = (params: unknown, callback: (error?: Error | null) => void) => void;
+type SyncHookCallback = (...args: unknown[]) => void;
+
+describe('ReactFlightWebpackPlugin manifest chunk files', () => {
+  it('records the JavaScript chunk when CSS appears first in chunk.files', () => {
+    const clientFile = '/app/components/ClientComponent.js';
+    const runtimeFile = require.resolve('../src/react-server-dom-webpack/client.browser.js');
+    const plugin = new ReactFlightWebpackPlugin({
+      isServer: false,
+      clientReferences: [clientFile],
+    });
+
+    plugin.resolveAllClientFiles = jest.fn(
+      (
+        _context: string,
+        _contextResolver: unknown,
+        _normalResolver: unknown,
+        _fs: unknown,
+        _contextModuleFactory: unknown,
+        callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
+      ) => {
+        callback(null, [{ request: clientFile, userRequest: './ClientComponent.js' }]);
+      },
+    );
+
+    const beforeCompileCallbacks: AsyncHookCallback[] = [];
+    const thisCompilationCallbacks: SyncHookCallback[] = [];
+    const makeCallbacks: SyncHookCallback[] = [];
+    const compiler = {
+      context: '/app',
+      resolverFactory: {
+        get: jest.fn(() => ({})),
+      },
+      inputFileSystem: {},
+      hooks: {
+        beforeCompile: {
+          tapAsync: (_name: string, callback: AsyncHookCallback) => {
+            beforeCompileCallbacks.push(callback);
+          },
+        },
+        thisCompilation: {
+          tap: (_name: string, callback: SyncHookCallback) => {
+            thisCompilationCallbacks.push(callback);
+          },
+        },
+        make: {
+          tap: (_name: string, callback: SyncHookCallback) => {
+            makeCallbacks.push(callback);
+          },
+        },
+      },
+    };
+
+    plugin.apply(compiler);
+
+    beforeCompileCallbacks[0]!(
+      { contextModuleFactory: {} },
+      (error?: Error | null) => {
+        if (error) throw error;
+      },
+    );
+
+    const programCallbacks: Array<() => void> = [];
+    const parser = {
+      state: {
+        module: {
+          resource: runtimeFile,
+          addBlock: jest.fn(),
+        },
+      },
+      hooks: {
+        program: {
+          tap: (_name: string, callback: () => void) => {
+            programCallbacks.push(callback);
+          },
+        },
+      },
+    };
+    const normalModuleFactory = {
+      hooks: {
+        parser: {
+          for: jest.fn(() => ({
+            tap: (_name: string, callback: (parserArg: typeof parser) => void) => {
+              callback(parser);
+            },
+          })),
+        },
+      },
+    };
+    const emittedAssets = new Map<string, { source(): string | Buffer }>();
+    const processAssetCallbacks: Array<() => void> = [];
+    const chunk = {
+      id: 'client-chunk',
+      files: new Set(['client.css', 'client.js']),
+    };
+    const module = {
+      resource: clientFile,
+    };
+    const compilation = {
+      dependencyFactories: new Map(),
+      dependencyTemplates: new Map(),
+      warnings: [],
+      outputOptions: {
+        publicPath: '/assets/',
+      },
+      entrypoints: new Map(),
+      chunkGroups: [
+        {
+          chunks: [chunk],
+        },
+      ],
+      chunkGraph: {
+        getChunkModulesIterable: jest.fn(() => [module]),
+        getModuleId: jest.fn(() => './ClientComponent.js'),
+      },
+      hooks: {
+        processAssets: {
+          tap: (_options: unknown, callback: () => void) => {
+            processAssetCallbacks.push(callback);
+          },
+        },
+      },
+      emitAsset: (filename: string, source: { source(): string | Buffer }) => {
+        emittedAssets.set(filename, source);
+      },
+    };
+
+    thisCompilationCallbacks[0]!(compilation, { normalModuleFactory });
+    programCallbacks[0]!();
+    makeCallbacks[0]!(compilation);
+    processAssetCallbacks[0]!();
+
+    const manifestSource = emittedAssets.get('react-client-manifest.json')!.source().toString();
+    const manifest = JSON.parse(manifestSource);
+    const metadata = manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href];
+
+    expect(metadata).toEqual({
+      id: './ClientComponent.js',
+      chunks: ['client-chunk', 'client.js'],
+      name: '*',
+    });
+  });
+});

--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -8,12 +8,14 @@ type SyncHookCallback = (...args: unknown[]) => void;
 describe('ReactFlightWebpackPlugin manifest chunk files', () => {
   it('records the JavaScript chunk when CSS appears first in chunk.files', () => {
     const clientFile = '/app/components/ClientComponent.js';
+    // The plugin matches this specific runtime resource to inject client-reference dependency blocks.
     const runtimeFile = require.resolve('../src/react-server-dom-webpack/client.browser.js');
     const plugin = new ReactFlightWebpackPlugin({
       isServer: false,
       clientReferences: [clientFile],
     });
 
+    // Keep this focused on manifest generation once the plugin has discovered the client reference.
     plugin.resolveAllClientFiles = jest.fn(
       (
         _context: string,
@@ -57,6 +59,7 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
 
     plugin.apply(compiler);
 
+    expect(beforeCompileCallbacks).toHaveLength(1);
     beforeCompileCallbacks[0]!(
       { contextModuleFactory: {} },
       (error?: Error | null) => {
@@ -129,12 +132,18 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
       },
     };
 
+    expect(thisCompilationCallbacks).toHaveLength(1);
     thisCompilationCallbacks[0]!(compilation, { normalModuleFactory });
-    programCallbacks[0]!();
+    expect(programCallbacks).toHaveLength(3);
+    programCallbacks.forEach((callback) => callback());
+    expect(makeCallbacks).toHaveLength(1);
     makeCallbacks[0]!(compilation);
+    expect(processAssetCallbacks).toHaveLength(1);
     processAssetCallbacks[0]!();
 
-    const manifestSource = emittedAssets.get('react-client-manifest.json')!.source().toString();
+    const manifestAsset = emittedAssets.get('react-client-manifest.json');
+    expect(manifestAsset).toBeDefined();
+    const manifestSource = manifestAsset!.source().toString();
     const manifest = JSON.parse(manifestSource);
     const metadata = manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href];
 


### PR DESCRIPTION
Refs #27

## Summary
- Adds a focused ReactFlightWebpackPlugin regression for CSS-first chunk file ordering.
- Verifies the generated client manifest records the JavaScript file when chunk.files contains CSS before JS.
- Keeps this as a tests-only lock on behavior currently passing on main.

## Test plan
- yarn install --frozen-lockfile
- yarn jest tests/react-flight-webpack-plugin-css-order.test.ts --runInBand
- git diff --check
- yarn build
- yarn test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or plugin logic modifications.
> 
> **Overview**
> Adds a **tests-only** regression in `tests/react-flight-webpack-plugin-css-order.test.ts` for `ReactFlightWebpackPlugin` client manifest generation.
> 
> The test drives the plugin with mocked webpack compiler/compilation hooks and a chunk whose `files` set lists **CSS before JS** (`client.css`, then `client.js`). It asserts `react-client-manifest.json` still includes the **JavaScript asset** in module metadata (`chunks: ['client-chunk', 'client.js']`), guarding behavior where manifest chunk selection must not depend on CSS being listed first.
> 
> No production/plugin source changes in this diff—only coverage to prevent regressions related to issue #27.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2902f1ddc15c47c0d96f84a9b35118d5371d6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for CSS and JavaScript chunk ordering in the React Flight Webpack Plugin manifest generation and chunk metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->