### PR TITLE
Derive RSC client refs from the RSC graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/WebpackLoader.d.ts",
       "default": "./dist/WebpackLoader.js"
     },
+    "./RSCReferenceDiscoveryPlugin": {
+      "types": "./dist/RSCReferenceDiscoveryPlugin.d.ts",
+      "default": "./dist/RSCReferenceDiscoveryPlugin.js"
+    },
     "./RspackPlugin": {
       "types": "./dist/react-server-dom-rspack/plugin.d.ts",
       "default": "./dist/react-server-dom-rspack/plugin.js"

--- a/src/RSCReferenceDiscoveryPlugin.ts
+++ b/src/RSCReferenceDiscoveryPlugin.ts
@@ -1,0 +1,122 @@
+import * as path from 'path';
+import { hasUseClientDirective } from './clientReferences';
+
+type AnyCompilation = {
+  [key: symbol]: unknown;
+  hooks: {
+    processAssets: {
+      tap: (options: { name: string; stage: number }, callback: () => void) => void;
+    };
+  };
+  emitAsset: (filename: string, source: unknown) => void;
+};
+
+type AnyCompiler = {
+  context: string;
+  webpack?: {
+    Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+    sources: { RawSource: new (source: string) => unknown };
+  };
+  rspack?: {
+    Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+    sources: { RawSource: new (source: string) => unknown };
+  };
+  hooks: {
+    thisCompilation: {
+      tap: (name: string, callback: (compilation: AnyCompilation) => void) => void;
+    };
+  };
+};
+
+type LoaderContextWithCompilation = {
+  _compilation?: unknown;
+  resourcePath?: string;
+  cacheable?: (flag?: boolean) => void;
+};
+
+const RSC_CLIENT_REFERENCES_KEY: symbol = Symbol.for(
+  'react-on-rails-rsc.discoveredClientReferences',
+);
+
+function getClientReferenceSet(compilation: AnyCompilation): Set<string> {
+  const existing = compilation[RSC_CLIENT_REFERENCES_KEY];
+  if (existing instanceof Set) return existing as Set<string>;
+
+  const refs = new Set<string>();
+  compilation[RSC_CLIENT_REFERENCES_KEY] = refs;
+  return refs;
+}
+
+function existingClientReferenceSet(compilation: AnyCompilation): Set<string> | undefined {
+  const existing = compilation[RSC_CLIENT_REFERENCES_KEY];
+  return existing instanceof Set ? (existing as Set<string>) : undefined;
+}
+
+function resolveBundler(compiler: AnyCompiler) {
+  if (compiler.webpack) return compiler.webpack;
+  if (compiler.rspack) return compiler.rspack;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+  return require('webpack');
+}
+
+export function recordDiscoveredClientReferenceIfNeeded(
+  loaderContext: LoaderContextWithCompilation,
+  source: string | Buffer,
+): boolean {
+  const compilation = loaderContext._compilation as AnyCompilation | undefined;
+  if (!compilation) return false;
+
+  const refs = existingClientReferenceSet(compilation);
+  if (!refs) return false;
+
+  // Recording is a loader side effect. If this loader output is reused from a
+  // cache in a later watch rebuild, the side effect can be skipped and the
+  // emitted references can become stale.
+  loaderContext.cacheable?.(false);
+
+  const resourcePath = loaderContext.resourcePath;
+  if (!resourcePath || !hasUseClientDirective(source)) return false;
+
+  refs.add(resourcePath);
+  return true;
+}
+
+export class RSCReferenceDiscoveryPlugin {
+  private readonly filename: string;
+
+  constructor(options: { filename?: string } = {}) {
+    this.filename = options.filename || 'rsc-client-references.json';
+  }
+
+  apply(compiler: AnyCompiler): void {
+    const pluginName = 'RSCReferenceDiscoveryPlugin';
+    const bundler = resolveBundler(compiler);
+
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      getClientReferenceSet(compilation);
+
+      compilation.hooks.processAssets.tap(
+        { name: pluginName, stage: bundler.Compilation.PROCESS_ASSETS_STAGE_REPORT },
+        () => {
+          const refs = Array.from(getClientReferenceSet(compilation)).sort();
+          const payload = {
+            version: 1,
+            compilerContext: compiler.context,
+            count: refs.length,
+            refs,
+            relativeRefs: refs.map((file) =>
+              path.relative(compiler.context, file).replace(/\\/g, '/'),
+            ),
+          };
+
+          compilation.emitAsset(
+            this.filename,
+            new bundler.sources.RawSource(`${JSON.stringify(payload, null, 2)}\n`),
+          );
+        },
+      );
+    });
+  }
+}
+
+export default RSCReferenceDiscoveryPlugin;

--- a/src/WebpackLoader.ts
+++ b/src/WebpackLoader.ts
@@ -1,7 +1,10 @@
 import { pathToFileURL } from 'url';
 import { LoaderDefinition } from 'webpack';
+import { recordDiscoveredClientReferenceIfNeeded } from './RSCReferenceDiscoveryPlugin';
 
 const RSCWebpackLoader: LoaderDefinition = async function RSCWebpackLoader(source) {
+  recordDiscoveredClientReferenceIfNeeded(this, source);
+
   // Convert file path to URL format
   const fileUrl = pathToFileURL(this.resourcePath).href;
 

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -14,3 +14,24 @@ export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
  * Matches JavaScript, TypeScript, JSX, TSX, and their CommonJS/ESM variants.
  */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;
+
+const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*;?\s*(?:\n|$)/;
+const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
+
+function stripProlog(source: string): string {
+  let s = source;
+  if (s.charCodeAt(0) === 0xfeff) s = s.slice(1);
+  if (s.startsWith('#!')) {
+    const nl = s.indexOf('\n');
+    s = nl === -1 ? '' : s.slice(nl + 1);
+  }
+  const stripped = s.replace(LEADING_COMMENTS, '');
+  if (stripped !== s) s = stripped;
+  return s;
+}
+
+/** Check whether `source` starts with a `"use client"` directive. */
+export function hasUseClientDirective(source: string | Buffer): boolean {
+  const text = Buffer.isBuffer(source) ? source.toString('utf8') : source;
+  return USE_CLIENT_REGEX.test(stripProlog(text));
+}

--- a/src/react-server-dom-rspack/shared.ts
+++ b/src/react-server-dom-rspack/shared.ts
@@ -13,23 +13,4 @@
 export const CLIENT_MODULES_KEY: symbol = Symbol.for('react-on-rails-rsc.clientModules');
 
 // ── directive detection (shared between loader + plugin FS walk) ──
-
-const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*;?\s*(?:\n|$)/;
-const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
-
-function stripProlog(source: string): string {
-  let s = source;
-  if (s.charCodeAt(0) === 0xfeff) s = s.slice(1);
-  if (s.startsWith('#!')) {
-    const nl = s.indexOf('\n');
-    s = nl === -1 ? '' : s.slice(nl + 1);
-  }
-  const stripped = s.replace(LEADING_COMMENTS, '');
-  if (stripped !== s) s = stripped;
-  return s;
-}
-
-/** Check whether `source` starts with a `"use client"` directive. */
-export function hasUseClientDirective(source: string): boolean {
-  return USE_CLIENT_REGEX.test(stripProlog(source));
-}
+export { hasUseClientDirective } from '../clientReferences';

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -281,9 +281,41 @@ class ReactFlightWebpackPlugin {
                 });
             });
             compilation.chunkGroups.forEach(function (chunkGroup) {
+              let chunkResolvedClientFiles = resolvedClientFiles;
+              if (!_this.isServer) {
+                const blocks =
+                  "function" === typeof chunkGroup.getBlocks
+                    ? chunkGroup.getBlocks()
+                    : chunkGroup.blocksIterable;
+                if (!blocks) return;
+                chunkResolvedClientFiles = new Set();
+                var _iterator = _createForOfIteratorHelper(blocks),
+                  _step;
+                try {
+                  for (_iterator.s(); !(_step = _iterator.n()).done; ) {
+                    const block = _step.value,
+                      dependencies = block && block.dependencies;
+                    if (!dependencies) continue;
+                    for (let i = 0; i < dependencies.length; i++) {
+                      const dep = dependencies[i];
+                      if (
+                        (dep instanceof ClientReferenceDependency ||
+                          "client-reference" === dep.type) &&
+                        resolvedClientFiles.has(dep.request)
+                      )
+                        chunkResolvedClientFiles.add(dep.request);
+                    }
+                  }
+                } catch (err) {
+                  _iterator.e(err);
+                } finally {
+                  _iterator.f();
+                }
+                if (0 === chunkResolvedClientFiles.size) return;
+              }
               function recordModule(id, module) {
                 if (
-                  resolvedClientFiles.has(module.resource) &&
+                  chunkResolvedClientFiles.has(module.resource) &&
                   ((module = url.pathToFileURL(module.resource).href),
                   void 0 !== module)
                 )

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -1,0 +1,205 @@
+import { pathToFileURL } from 'url';
+
+const ReactFlightWebpackPlugin = require('../src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js');
+
+type AsyncHookCallback = (params: unknown, callback: (error?: Error | null) => void) => void;
+type SyncHookCallback = (...args: unknown[]) => void;
+
+type Chunk = {
+  id: string;
+  files: Set<string>;
+};
+
+const clientFile = '/app/components/ErrorBoundary.tsx';
+
+const buildManifest = ({
+  isServer,
+  chunkGroups,
+  getChunkModulesIterable,
+}: {
+  isServer: boolean;
+  chunkGroups: (clientReferenceBlocks: unknown[]) => unknown[];
+  getChunkModulesIterable: (chunk: Chunk) => unknown[];
+}) => {
+  const runtimeFile = require.resolve(
+    isServer ? '../src/react-server-dom-webpack/client.node.js' : '../src/react-server-dom-webpack/client.browser.js',
+  );
+  const plugin = new ReactFlightWebpackPlugin({
+    isServer,
+    clientReferences: [clientFile],
+  });
+
+  plugin.resolveAllClientFiles = jest.fn(
+    (
+      _context: string,
+      _contextResolver: unknown,
+      _normalResolver: unknown,
+      _fs: unknown,
+      _contextModuleFactory: unknown,
+      callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
+    ) => {
+      callback(null, [
+        { request: clientFile, type: 'client-reference', userRequest: './ErrorBoundary.tsx' } as never,
+      ]);
+    },
+  );
+
+  const beforeCompileCallbacks: AsyncHookCallback[] = [];
+  const thisCompilationCallbacks: SyncHookCallback[] = [];
+  const makeCallbacks: SyncHookCallback[] = [];
+  const compiler = {
+    context: '/app',
+    resolverFactory: {
+      get: jest.fn(() => ({})),
+    },
+    inputFileSystem: {},
+    hooks: {
+      beforeCompile: {
+        tapAsync: (_name: string, callback: AsyncHookCallback) => {
+          beforeCompileCallbacks.push(callback);
+        },
+      },
+      thisCompilation: {
+        tap: (_name: string, callback: SyncHookCallback) => {
+          thisCompilationCallbacks.push(callback);
+        },
+      },
+      make: {
+        tap: (_name: string, callback: SyncHookCallback) => {
+          makeCallbacks.push(callback);
+        },
+      },
+    },
+  };
+
+  plugin.apply(compiler);
+  beforeCompileCallbacks[0]!(
+    { contextModuleFactory: {} },
+    (error?: Error | null) => {
+      if (error) throw error;
+    },
+  );
+
+  const programCallbacks: Array<() => void> = [];
+  const clientReferenceBlocks: unknown[] = [];
+  const parser = {
+    state: {
+      module: {
+        resource: runtimeFile,
+        addBlock: jest.fn((block: unknown) => {
+          clientReferenceBlocks.push(block);
+        }),
+      },
+    },
+    hooks: {
+      program: {
+        tap: (_name: string, callback: () => void) => {
+          programCallbacks.push(callback);
+        },
+      },
+    },
+  };
+  const normalModuleFactory = {
+    hooks: {
+      parser: {
+        for: jest.fn(() => ({
+          tap: (_name: string, callback: (parserArg: typeof parser) => void) => {
+            callback(parser);
+          },
+        })),
+      },
+    },
+  };
+  const emittedAssets = new Map<string, { source(): string | Buffer }>();
+  const processAssetCallbacks: Array<() => void> = [];
+  const compilation = {
+    dependencyFactories: new Map(),
+    dependencyTemplates: new Map(),
+    warnings: [],
+    outputOptions: {
+      publicPath: '/assets/',
+    },
+    entrypoints: new Map(),
+    chunkGroups: chunkGroups(clientReferenceBlocks),
+    chunkGraph: {
+      getChunkModulesIterable: jest.fn(getChunkModulesIterable),
+      getModuleId: jest.fn(() => './client/app/components/ErrorBoundary.tsx'),
+    },
+    hooks: {
+      processAssets: {
+        tap: (_options: unknown, callback: () => void) => {
+          processAssetCallbacks.push(callback);
+        },
+      },
+    },
+    emitAsset: (filename: string, source: { source(): string | Buffer }) => {
+      emittedAssets.set(filename, source);
+    },
+  };
+
+  thisCompilationCallbacks[0]!(compilation, { normalModuleFactory });
+  programCallbacks[0]!();
+  expect(clientReferenceBlocks).not.toHaveLength(0);
+  makeCallbacks[0]!(compilation);
+  processAssetCallbacks[0]!();
+
+  const manifestAsset = emittedAssets.get(
+    isServer ? 'react-server-client-manifest.json' : 'react-client-manifest.json',
+  );
+  expect(manifestAsset).toBeDefined();
+
+  return JSON.parse(manifestAsset!.source().toString());
+};
+
+describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
+  it('does not merge unrelated entry chunks into the client manifest entry', () => {
+    const clientModule = { resource: clientFile };
+    const clientChunk = { id: 'client0', files: new Set(['js/client0.chunk.js']) };
+    const unrelatedEntryChunk = {
+      id: 'generated/ServerComponentRouter',
+      files: new Set(['js/generated/ServerComponentRouter.js']),
+    };
+
+    const manifest = buildManifest({
+      isServer: false,
+      chunkGroups: (clientReferenceBlocks) => [
+        {
+          getBlocks: () => [],
+          chunks: [unrelatedEntryChunk],
+        },
+        {
+          getBlocks: () => clientReferenceBlocks,
+          chunks: [clientChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [clientModule],
+    });
+
+    expect(manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href]).toEqual({
+      id: './client/app/components/ErrorBoundary.tsx',
+      chunks: ['client0', 'js/client0.chunk.js'],
+      name: '*',
+    });
+  });
+
+  it('keeps generating server manifest metadata from server chunk groups without client-reference blocks', () => {
+    const serverModule = { resource: clientFile };
+    const serverChunk = { id: 'server-bundle', files: new Set(['server-bundle.js']) };
+
+    const manifest = buildManifest({
+      isServer: true,
+      chunkGroups: () => [
+        {
+          chunks: [serverChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [serverModule],
+    });
+
+    expect(manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href]).toEqual({
+      id: './client/app/components/ErrorBoundary.tsx',
+      chunks: ['server-bundle', 'server-bundle.js'],
+      name: '*',
+    });
+  });
+});

--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -25,7 +25,9 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
         _contextModuleFactory: unknown,
         callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
       ) => {
-        callback(null, [{ request: clientFile, userRequest: './ClientComponent.js' }]);
+        callback(null, [
+          { request: clientFile, type: 'client-reference', userRequest: './ClientComponent.js' } as never,
+        ]);
       },
     );
 
@@ -68,11 +70,14 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
     );
 
     const programCallbacks: Array<() => void> = [];
+    const clientReferenceBlocks: unknown[] = [];
     const parser = {
       state: {
         module: {
           resource: runtimeFile,
-          addBlock: jest.fn(),
+          addBlock: jest.fn((block: unknown) => {
+            clientReferenceBlocks.push(block);
+          }),
         },
       },
       hooks: {
@@ -113,6 +118,7 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
       entrypoints: new Map(),
       chunkGroups: [
         {
+          getBlocks: () => clientReferenceBlocks,
           chunks: [chunk],
         },
       ],
@@ -136,6 +142,7 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
     thisCompilationCallbacks[0]!(compilation, { normalModuleFactory });
     expect(programCallbacks).toHaveLength(3);
     programCallbacks.forEach((callback) => callback());
+    expect(clientReferenceBlocks).not.toHaveLength(0);
     expect(makeCallbacks).toHaveLength(1);
     makeCallbacks[0]!(compilation);
     expect(processAssetCallbacks).toHaveLength(1);

--- a/tests/rsc-reference-discovery-plugin.test.ts
+++ b/tests/rsc-reference-discovery-plugin.test.ts
@@ -1,0 +1,163 @@
+import * as path from 'path';
+import {
+  recordDiscoveredClientReferenceIfNeeded,
+  RSCReferenceDiscoveryPlugin,
+} from '../src/RSCReferenceDiscoveryPlugin';
+
+class FakeRawSource {
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  source(): string {
+    return this.value;
+  }
+}
+
+type FakeCompilation = {
+  [key: symbol]: unknown;
+  hooks: {
+    processAssets: {
+      tap: jest.Mock;
+    };
+  };
+  emitAsset: jest.Mock;
+};
+
+const createCompilation = (): {
+  compilation: FakeCompilation;
+  getProcessAssetsCallback: () => () => void;
+} => {
+  let processAssetsCallback: (() => void) | undefined;
+  const compilation = {
+    hooks: {
+      processAssets: {
+        tap: jest.fn((_options, callback) => {
+          processAssetsCallback = callback;
+        }),
+      },
+    },
+    emitAsset: jest.fn(),
+  } as FakeCompilation;
+
+  return {
+    compilation,
+    getProcessAssetsCallback: () => {
+      if (!processAssetsCallback) throw new Error('processAssets callback was not registered');
+      return processAssetsCallback;
+    },
+  };
+};
+
+const createCompiler = (context: string): {
+  compiler: {
+    context: string;
+    webpack: {
+      Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+      sources: { RawSource: typeof FakeRawSource };
+    };
+    hooks: { thisCompilation: { tap: jest.Mock } };
+  };
+  getThisCompilationCallback: () => (compilation: FakeCompilation) => void;
+} => {
+  let thisCompilationCallback: ((compilation: FakeCompilation) => void) | undefined;
+  const compiler = {
+    context,
+    webpack: {
+      Compilation: { PROCESS_ASSETS_STAGE_REPORT: 5000 },
+      sources: { RawSource: FakeRawSource },
+    },
+    hooks: {
+      thisCompilation: {
+        tap: jest.fn((_name, callback) => {
+          thisCompilationCallback = callback;
+        }),
+      },
+    },
+  };
+
+  return {
+    compiler,
+    getThisCompilationCallback: () => {
+      if (!thisCompilationCallback) throw new Error('thisCompilation callback was not registered');
+      return thisCompilationCallback;
+    },
+  };
+};
+
+describe('RSCReferenceDiscoveryPlugin', () => {
+  it('emits references recorded by RSCWebpackLoader', () => {
+    const context = path.join(__dirname, 'fixtures');
+    const component = path.join(context, 'components', 'ClientComponent.jsx');
+    const { compiler, getThisCompilationCallback } = createCompiler(context);
+    const { compilation, getProcessAssetsCallback } = createCompilation();
+
+    new RSCReferenceDiscoveryPlugin({ filename: 'custom-rsc-client-references.json' }).apply(
+      compiler,
+    );
+    getThisCompilationCallback()(compilation);
+
+    const cacheable = jest.fn();
+    const recorded = recordDiscoveredClientReferenceIfNeeded(
+      { _compilation: compilation, resourcePath: component, cacheable },
+      "'use client';\nexport default function ClientComponent() { return null; }\n",
+    );
+
+    expect(recorded).toBe(true);
+    expect(cacheable).toHaveBeenCalledWith(false);
+
+    getProcessAssetsCallback()();
+
+    expect(compilation.emitAsset).toHaveBeenCalledTimes(1);
+    const [filename, source] = compilation.emitAsset.mock.calls[0]!;
+    expect(filename).toBe('custom-rsc-client-references.json');
+
+    const payload = JSON.parse((source as FakeRawSource).source()) as {
+      version: number;
+      compilerContext: string;
+      count: number;
+      refs: string[];
+      relativeRefs: string[];
+    };
+    expect(payload).toEqual({
+      version: 1,
+      compilerContext: context,
+      count: 1,
+      refs: [component],
+      relativeRefs: ['components/ClientComponent.jsx'],
+    });
+  });
+
+  it('does not record when the emitter plugin is not active for the compilation', () => {
+    const cacheable = jest.fn();
+    const recorded = recordDiscoveredClientReferenceIfNeeded(
+      {
+        _compilation: { hooks: { processAssets: { tap: jest.fn() } }, emitAsset: jest.fn() },
+        resourcePath: '/app/Client.jsx',
+        cacheable,
+      },
+      "'use client';\nexport default function Client() { return null; }\n",
+    );
+
+    expect(recorded).toBe(false);
+    expect(cacheable).not.toHaveBeenCalled();
+  });
+
+  it('marks loader output non-cacheable when active even for non-client modules', () => {
+    const { compiler, getThisCompilationCallback } = createCompiler('/app');
+    const { compilation } = createCompilation();
+    new RSCReferenceDiscoveryPlugin().apply(compiler);
+    getThisCompilationCallback()(compilation);
+
+    const cacheable = jest.fn();
+    const recorded = recordDiscoveredClientReferenceIfNeeded(
+      { _compilation: compilation, resourcePath: '/app/Server.jsx', cacheable },
+      'export default function Server() { return null; }\n',
+    );
+
+    expect(recorded).toBe(false);
+    expect(cacheable).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is paired with shakacode/react_on_rails#3556 and should be reviewed together with that PR. It should not be merged on its own.

## Summary

- emit RSC-discovered client references through the existing RSC loader path
- add `RSCReferenceDiscoveryPlugin` so downstream builds can consume exact refs from the RSC graph
- limit Webpack client manifest chunks to chunk groups created by client-reference dependencies
- keep the server manifest metadata path unchanged

This supports the graph-derived client reference proposal in shakacode/react_on_rails#3553.

## Why

Broad `clientReferences` scanning can treat unrelated `'use client'` files as RSC client references. For Rspack, those false positives become injected dynamic imports. For Webpack manifests, unrelated chunk groups can make normal browser entries eligible for RSC client-reference loading.

This PR adds package-level support for using the RSC graph as the source of truth and includes a targeted Webpack client-manifest chunk filtering fix for the over-inclusion case found while validating that path.
## Verification

- `yarn build`
- `yarn test`

Result: 15 suites passed, 99 tests passed.
