### PR TITLE
Derive RSC client refs from the RSC graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/WebpackLoader.d.ts",
       "default": "./dist/WebpackLoader.js"
     },
+    "./RSCReferenceDiscoveryPlugin": {
+      "types": "./dist/RSCReferenceDiscoveryPlugin.d.ts",
+      "default": "./dist/RSCReferenceDiscoveryPlugin.js"
+    },
     "./RspackPlugin": {
       "types": "./dist/react-server-dom-rspack/plugin.d.ts",
       "default": "./dist/react-server-dom-rspack/plugin.js"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test:non-rsc": "jest tests --testPathIgnorePatterns=\".*\\.rsc\\.test\\..*\"",
     "build": "rm -rf dist tsconfig.tsbuildinfo && yarn run tsc",
     "prepublishOnly": "yarn run build",
-    "build-if-needed": "test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js || (yarn run build && test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js)",
+    "build-if-needed": "test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/RSCReferenceDiscoveryPlugin.js -a -f dist/RSCReferenceDiscoveryPlugin.d.ts -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js || (yarn run build && test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/RSCReferenceDiscoveryPlugin.js -a -f dist/RSCReferenceDiscoveryPlugin.d.ts -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js)",
     "prepack": "yarn run build-if-needed",
     "prepare": "yarn run build-if-needed"
   },

--- a/src/RSCReferenceDiscoveryPlugin.ts
+++ b/src/RSCReferenceDiscoveryPlugin.ts
@@ -62,15 +62,18 @@ export function recordDiscoveredClientReferenceIfNeeded(
   loaderContext: LoaderContextWithCompilation,
   source: string | Buffer,
 ): boolean {
+  // Webpack/Rspack do not expose a public loader API for the active compilation.
+  // `_compilation` is the only available bridge for recording loader side effects.
   const compilation = loaderContext._compilation as AnyCompilation | undefined;
   if (!compilation) return false;
 
   const refs = existingClientReferenceSet(compilation);
   if (!refs) return false;
 
-  // Recording is a loader side effect. If this loader output is reused from a
-  // cache in a later watch rebuild, the side effect can be skipped and the
-  // emitted references can become stale.
+  // Recording is a loader side effect. If cached loader output is reused in a
+  // watch rebuild, discovery can miss files that gained a `"use client"`
+  // directive. This intentionally disables caching for every RSC loader input
+  // while the plugin is active.
   loaderContext.cacheable?.(false);
 
   const resourcePath = loaderContext.resourcePath;

--- a/src/RSCReferenceDiscoveryPlugin.ts
+++ b/src/RSCReferenceDiscoveryPlugin.ts
@@ -55,8 +55,7 @@ function existingClientReferenceSet(compilation: AnyCompilation): Set<string> | 
 function resolveBundler(compiler: AnyCompiler) {
   if (compiler.webpack) return compiler.webpack;
   if (compiler.rspack) return compiler.rspack;
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-  return require('webpack');
+  throw new Error('RSCReferenceDiscoveryPlugin requires a compiler with webpack or rspack APIs');
 }
 
 export function recordDiscoveredClientReferenceIfNeeded(

--- a/src/RSCReferenceDiscoveryPlugin.ts
+++ b/src/RSCReferenceDiscoveryPlugin.ts
@@ -63,7 +63,8 @@ export function recordDiscoveredClientReferenceIfNeeded(
   source: string | Buffer,
 ): boolean {
   // Webpack/Rspack do not expose a public loader API for the active compilation.
-  // `_compilation` is the only available bridge for recording loader side effects.
+  // `_compilation` is the only available bridge for recording loader side effects;
+  // re-check this private API when upgrading webpack or rspack major versions.
   const compilation = loaderContext._compilation as AnyCompilation | undefined;
   if (!compilation) return false;
 
@@ -83,6 +84,12 @@ export function recordDiscoveredClientReferenceIfNeeded(
   return true;
 }
 
+/**
+ * Emits the client-reference list discovered during the RSC loader pass.
+ *
+ * While active, RSC loader output is marked non-cacheable so watch rebuilds
+ * cannot reuse cached modules and silently miss files that gained `"use client"`.
+ */
 export class RSCReferenceDiscoveryPlugin {
   private readonly filename: string;
 

--- a/src/RSCReferenceDiscoveryPlugin.ts
+++ b/src/RSCReferenceDiscoveryPlugin.ts
@@ -89,6 +89,10 @@ export function recordDiscoveredClientReferenceIfNeeded(
  *
  * While active, RSC loader output is marked non-cacheable so watch rebuilds
  * cannot reuse cached modules and silently miss files that gained `"use client"`.
+ * This trades incremental-build cache reuse for discovery correctness.
+ *
+ * The compilation state uses `Symbol.for` so duplicate package copies that run
+ * against the same compilation share one discovered-reference set.
  */
 export class RSCReferenceDiscoveryPlugin {
   private readonly filename: string;

--- a/src/RSCReferenceDiscoveryPlugin.ts
+++ b/src/RSCReferenceDiscoveryPlugin.ts
@@ -1,0 +1,122 @@
+import * as path from 'path';
+import { hasUseClientDirective } from './clientReferences';
+
+type AnyCompilation = {
+  [key: symbol]: unknown;
+  hooks: {
+    processAssets: {
+      tap: (options: { name: string; stage: number }, callback: () => void) => void;
+    };
+  };
+  emitAsset: (filename: string, source: unknown) => void;
+};
+
+type AnyCompiler = {
+  context: string;
+  webpack?: {
+    Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+    sources: { RawSource: new (source: string) => unknown };
+  };
+  rspack?: {
+    Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+    sources: { RawSource: new (source: string) => unknown };
+  };
+  hooks: {
+    thisCompilation: {
+      tap: (name: string, callback: (compilation: AnyCompilation) => void) => void;
+    };
+  };
+};
+
+type LoaderContextWithCompilation = {
+  _compilation?: unknown;
+  resourcePath?: string;
+  cacheable?: (flag?: boolean) => void;
+};
+
+const RSC_CLIENT_REFERENCES_KEY: symbol = Symbol.for(
+  'react-on-rails-rsc.discoveredClientReferences',
+);
+
+function getClientReferenceSet(compilation: AnyCompilation): Set<string> {
+  const existing = compilation[RSC_CLIENT_REFERENCES_KEY];
+  if (existing instanceof Set) return existing as Set<string>;
+
+  const refs = new Set<string>();
+  compilation[RSC_CLIENT_REFERENCES_KEY] = refs;
+  return refs;
+}
+
+function existingClientReferenceSet(compilation: AnyCompilation): Set<string> | undefined {
+  const existing = compilation[RSC_CLIENT_REFERENCES_KEY];
+  return existing instanceof Set ? (existing as Set<string>) : undefined;
+}
+
+function resolveBundler(compiler: AnyCompiler) {
+  if (compiler.webpack) return compiler.webpack;
+  if (compiler.rspack) return compiler.rspack;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+  return require('webpack');
+}
+
+export function recordDiscoveredClientReferenceIfNeeded(
+  loaderContext: LoaderContextWithCompilation,
+  source: string | Buffer,
+): boolean {
+  const compilation = loaderContext._compilation as AnyCompilation | undefined;
+  if (!compilation) return false;
+
+  const refs = existingClientReferenceSet(compilation);
+  if (!refs) return false;
+
+  // Recording is a loader side effect. If this loader output is reused from a
+  // cache in a later watch rebuild, the side effect can be skipped and the
+  // emitted references can become stale.
+  loaderContext.cacheable?.(false);
+
+  const resourcePath = loaderContext.resourcePath;
+  if (!resourcePath || !hasUseClientDirective(source)) return false;
+
+  refs.add(resourcePath);
+  return true;
+}
+
+export class RSCReferenceDiscoveryPlugin {
+  private readonly filename: string;
+
+  constructor(options: { filename?: string } = {}) {
+    this.filename = options.filename || 'rsc-client-references.json';
+  }
+
+  apply(compiler: AnyCompiler): void {
+    const pluginName = 'RSCReferenceDiscoveryPlugin';
+    const bundler = resolveBundler(compiler);
+
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      getClientReferenceSet(compilation);
+
+      compilation.hooks.processAssets.tap(
+        { name: pluginName, stage: bundler.Compilation.PROCESS_ASSETS_STAGE_REPORT },
+        () => {
+          const refs = Array.from(getClientReferenceSet(compilation)).sort();
+          const payload = {
+            version: 1,
+            compilerContext: compiler.context,
+            count: refs.length,
+            refs,
+            relativeRefs: refs.map((file) =>
+              path.relative(compiler.context, file).replace(/\\/g, '/'),
+            ),
+          };
+
+          compilation.emitAsset(
+            this.filename,
+            new bundler.sources.RawSource(`${JSON.stringify(payload, null, 2)}\n`),
+          );
+        },
+      );
+    });
+  }
+}
+
+export default RSCReferenceDiscoveryPlugin;

--- a/src/WebpackLoader.ts
+++ b/src/WebpackLoader.ts
@@ -1,7 +1,10 @@
 import { pathToFileURL } from 'url';
 import { LoaderDefinition } from 'webpack';
+import { recordDiscoveredClientReferenceIfNeeded } from './RSCReferenceDiscoveryPlugin';
 
 const RSCWebpackLoader: LoaderDefinition = async function RSCWebpackLoader(source) {
+  recordDiscoveredClientReferenceIfNeeded(this, source);
+
   // Convert file path to URL format
   const fileUrl = pathToFileURL(this.resourcePath).href;
 

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -61,11 +61,16 @@ export function hasUseClientDirective(source: string | Buffer): boolean {
   const text = Buffer.isBuffer(source) ? source.toString('utf8') : source;
   if (!text.includes('use client')) return false;
 
-  const program = acorn.parse(text, {
-    allowHashBang: true,
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-  }) as ParsedProgram;
+  let program: ParsedProgram;
+  try {
+    program = acorn.parse(text, {
+      allowHashBang: true,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    }) as ParsedProgram;
+  } catch {
+    return false;
+  }
 
   for (const statement of program.body || []) {
     if (

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -15,7 +15,7 @@ export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
  */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;
 
-const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*(?:;|\n|$)/;
+const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*(?:;|\r?\n|$)/;
 const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
 
 function stripProlog(source: string): string {

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -15,7 +15,7 @@ export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
  */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;
 
-const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*;?\s*(?:\n|$)/;
+const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*(?:;|\n|$)/;
 const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
 
 function stripProlog(source: string): string {

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -14,3 +14,24 @@ export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
  * Matches JavaScript, TypeScript, JSX, TSX, and their CommonJS/ESM variants.
  */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;
+
+const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*;?\s*(?:\n|$)/;
+const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
+
+function stripProlog(source: string): string {
+  let s = source;
+  if (s.charCodeAt(0) === 0xfeff) s = s.slice(1);
+  if (s.startsWith('#!')) {
+    const nl = s.indexOf('\n');
+    s = nl === -1 ? '' : s.slice(nl + 1);
+  }
+  const stripped = s.replace(LEADING_COMMENTS, '');
+  if (stripped !== s) s = stripped;
+  return s;
+}
+
+/** Check whether `source` starts with a `"use client"` directive. */
+export function hasUseClientDirective(source: string | Buffer): boolean {
+  const text = Buffer.isBuffer(source) ? source.toString('utf8') : source;
+  return USE_CLIENT_REGEX.test(stripProlog(text));
+}

--- a/src/clientReferences.ts
+++ b/src/clientReferences.ts
@@ -1,3 +1,5 @@
+import * as acorn from 'acorn-loose';
+
 /**
  * Default directories skipped by client reference discovery.
  * These are dependencies or generated asset outputs that can contain
@@ -15,23 +17,69 @@ export const DEFAULT_CLIENT_REFERENCES_EXCLUDE =
  */
 export const DEFAULT_CLIENT_REFERENCES_INCLUDE = /\.[cm]?[jt]sx?$/;
 
-const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*(?:;|\r?\n|$)/;
-const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
+type DirectiveStatement = {
+  directive?: string;
+  end: number;
+  expression?: {
+    type?: string;
+    value?: unknown;
+  };
+  type?: string;
+};
 
-function stripProlog(source: string): string {
-  let s = source;
-  if (s.charCodeAt(0) === 0xfeff) s = s.slice(1);
-  if (s.startsWith('#!')) {
-    const nl = s.indexOf('\n');
-    s = nl === -1 ? '' : s.slice(nl + 1);
+type ParsedProgram = {
+  body?: DirectiveStatement[];
+};
+
+function hasDirectiveTerminator(source: string, end: number): boolean {
+  if (source[end - 1] === ';') return true;
+
+  let i = end;
+  while (i < source.length) {
+    const charCode = source.charCodeAt(i);
+    if (charCode === 9 || charCode === 11 || charCode === 12 || charCode === 32) {
+      i += 1;
+      continue;
+    }
+    if (charCode === 10 || charCode === 13) return true;
+    if (source.startsWith('//', i)) return true;
+    if (source.startsWith('/*', i)) {
+      const commentEnd = source.indexOf('*/', i + 2);
+      if (commentEnd === -1) return false;
+      if (/[\r\n]/.test(source.slice(i + 2, commentEnd))) return true;
+      i = commentEnd + 2;
+      continue;
+    }
+    return false;
   }
-  const stripped = s.replace(LEADING_COMMENTS, '');
-  if (stripped !== s) s = stripped;
-  return s;
+
+  return true;
 }
 
 /** Check whether `source` starts with a `"use client"` directive. */
 export function hasUseClientDirective(source: string | Buffer): boolean {
   const text = Buffer.isBuffer(source) ? source.toString('utf8') : source;
-  return USE_CLIENT_REGEX.test(stripProlog(text));
+  if (!text.includes('use client')) return false;
+
+  const program = acorn.parse(text, {
+    allowHashBang: true,
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  }) as ParsedProgram;
+
+  for (const statement of program.body || []) {
+    if (
+      statement.type !== 'ExpressionStatement' ||
+      statement.expression?.type !== 'Literal' ||
+      typeof statement.expression.value !== 'string'
+    ) {
+      return false;
+    }
+
+    if (!statement.directive) return false;
+    if (!hasDirectiveTerminator(text, statement.end)) return false;
+    if (statement.directive === 'use client') return true;
+  }
+
+  return false;
 }

--- a/src/react-server-dom-rspack/shared.ts
+++ b/src/react-server-dom-rspack/shared.ts
@@ -13,23 +13,4 @@
 export const CLIENT_MODULES_KEY: symbol = Symbol.for('react-on-rails-rsc.clientModules');
 
 // ── directive detection (shared between loader + plugin FS walk) ──
-
-const USE_CLIENT_REGEX = /^\s*['"]use client['"]\s*;?\s*(?:\n|$)/;
-const LEADING_COMMENTS = /^(?:\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/))+/;
-
-function stripProlog(source: string): string {
-  let s = source;
-  if (s.charCodeAt(0) === 0xfeff) s = s.slice(1);
-  if (s.startsWith('#!')) {
-    const nl = s.indexOf('\n');
-    s = nl === -1 ? '' : s.slice(nl + 1);
-  }
-  const stripped = s.replace(LEADING_COMMENTS, '');
-  if (stripped !== s) s = stripped;
-  return s;
-}
-
-/** Check whether `source` starts with a `"use client"` directive. */
-export function hasUseClientDirective(source: string): boolean {
-  return USE_CLIENT_REGEX.test(stripProlog(source));
-}
+export { hasUseClientDirective } from '../clientReferences';

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -287,7 +287,18 @@ class ReactFlightWebpackPlugin {
                   "function" === typeof chunkGroup.getBlocks
                     ? chunkGroup.getBlocks()
                     : chunkGroup.blocksIterable;
-                if (!blocks) return;
+                if (!blocks) {
+                  const chunkGroupName =
+                    chunkGroup.name || chunkGroup.id || "(unnamed)";
+                  compilation.warnings.push(
+                    new webpack.WebpackError(
+                      "Client reference blocks were unavailable for chunk group " +
+                        chunkGroupName +
+                        ". React Server Components client manifest entries for this chunk group were skipped."
+                    )
+                  );
+                  return;
+                }
                 chunkResolvedClientFiles = new Set();
                 var _iterator = _createForOfIteratorHelper(blocks),
                   _step;

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -281,9 +281,41 @@ class ReactFlightWebpackPlugin {
                 });
             });
             compilation.chunkGroups.forEach(function (chunkGroup) {
+              let chunkResolvedClientFiles = resolvedClientFiles;
+              if (!_this.isServer) {
+                const blocks =
+                  "function" === typeof chunkGroup.getBlocks
+                    ? chunkGroup.getBlocks()
+                    : chunkGroup.blocksIterable;
+                if (!blocks) return;
+                chunkResolvedClientFiles = new Set();
+                var _iterator = _createForOfIteratorHelper(blocks),
+                  _step;
+                try {
+                  for (_iterator.s(); !(_step = _iterator.n()).done; ) {
+                    const block = _step.value,
+                      dependencies = block && block.dependencies;
+                    if (!dependencies) continue;
+                    for (let i = 0; i < dependencies.length; i++) {
+                      const dep = dependencies[i];
+                      if (
+                        (dep instanceof ClientReferenceDependency ||
+                          "client-reference" === dep.type) &&
+                        resolvedClientFiles.has(dep.request)
+                      )
+                        chunkResolvedClientFiles.add(dep.request);
+                    }
+                  }
+                } catch (err) {
+                  _iterator.e(err);
+                } finally {
+                  _iterator.f();
+                }
+                if (0 === chunkResolvedClientFiles.size) return;
+              }
               function recordModule(id, module) {
                 if (
-                  resolvedClientFiles.has(module.resource) &&
+                  chunkResolvedClientFiles.has(module.resource) &&
                   ((module = url.pathToFileURL(module.resource).href),
                   void 0 !== module)
                 )

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -280,6 +280,7 @@ class ReactFlightWebpackPlugin {
                   runtimeChunkFiles.add(runtimeFile);
                 });
             });
+            var missingClientReferenceBlocksWarningEmitted = false;
             compilation.chunkGroups.forEach(function (chunkGroup) {
               let chunkResolvedClientFiles = resolvedClientFiles;
               if (!_this.isServer) {
@@ -290,15 +291,18 @@ class ReactFlightWebpackPlugin {
                     ? chunkGroup.getBlocks()
                     : chunkGroup.blocksIterable;
                 if (!blocks) {
-                  const chunkGroupName =
-                    chunkGroup.name || chunkGroup.id || "(unnamed)";
-                  compilation.warnings.push(
-                    new webpack.WebpackError(
-                      "Client reference blocks were unavailable for chunk group " +
-                        chunkGroupName +
-                        ". React Server Components client manifest entries for this chunk group were skipped."
-                    )
-                  );
+                  if (!missingClientReferenceBlocksWarningEmitted) {
+                    missingClientReferenceBlocksWarningEmitted = true;
+                    const chunkGroupName =
+                      chunkGroup.name || chunkGroup.id || "(unnamed)";
+                    compilation.warnings.push(
+                      new webpack.WebpackError(
+                        "Client reference blocks were unavailable for chunk group " +
+                          chunkGroupName +
+                          ". React Server Components client manifest entries for this chunk group were skipped."
+                      )
+                    );
+                  }
                   return;
                 }
                 chunkResolvedClientFiles = new Set();

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -293,13 +293,10 @@ class ReactFlightWebpackPlugin {
                 if (!blocks) {
                   if (!missingClientReferenceBlocksWarningEmitted) {
                     missingClientReferenceBlocksWarningEmitted = true;
-                    const chunkGroupName =
-                      chunkGroup.name || chunkGroup.id || "(unnamed)";
                     compilation.warnings.push(
                       new webpack.WebpackError(
-                        "Client reference blocks were unavailable for chunk group " +
-                          chunkGroupName +
-                          ". React Server Components client manifest entries for this chunk group were skipped."
+                        "Client reference blocks were unavailable for one or more chunk groups. " +
+                          "React Server Components client manifest entries for affected chunk groups were skipped."
                       )
                     );
                   }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -284,6 +284,8 @@ class ReactFlightWebpackPlugin {
               let chunkResolvedClientFiles = resolvedClientFiles;
               if (!_this.isServer) {
                 const blocks =
+                  // `getBlocks()` exists in newer webpack 5 builds; older
+                  // webpack 5 builds expose the same data via `blocksIterable`.
                   "function" === typeof chunkGroup.getBlocks
                     ? chunkGroup.getBlocks()
                     : chunkGroup.blocksIterable;

--- a/tests/client-references.test.ts
+++ b/tests/client-references.test.ts
@@ -4,4 +4,26 @@ describe('hasUseClientDirective', () => {
   it('recognizes a directive followed by code on the same line', () => {
     expect(hasUseClientDirective("'use client'; export const answer = 42;\n")).toBe(true);
   });
+
+  it('recognizes double-quoted directives', () => {
+    expect(hasUseClientDirective('"use client";\nexport default function Client() {}\n')).toBe(
+      true,
+    );
+  });
+
+  it('recognizes Buffer input', () => {
+    expect(hasUseClientDirective(Buffer.from("'use client';\n"))).toBe(true);
+  });
+
+  it('recognizes directives after leading block comments', () => {
+    expect(hasUseClientDirective("/* @generated */\n'use client';\n")).toBe(true);
+  });
+
+  it('recognizes directives at EOF without trailing newline', () => {
+    expect(hasUseClientDirective("'use client'")).toBe(true);
+  });
+
+  it('ignores server modules without directives', () => {
+    expect(hasUseClientDirective('export default function Server() {}\n')).toBe(false);
+  });
 });

--- a/tests/client-references.test.ts
+++ b/tests/client-references.test.ts
@@ -23,6 +23,16 @@ describe('hasUseClientDirective', () => {
     expect(hasUseClientDirective("'use client'")).toBe(true);
   });
 
+  it('recognizes directives with Windows line endings', () => {
+    expect(hasUseClientDirective("'use client'\r\nexport default function Client() {}\r\n")).toBe(
+      true,
+    );
+  });
+
+  it('rejects same-line code without a directive semicolon', () => {
+    expect(hasUseClientDirective("'use client' export const answer = 42;\n")).toBe(false);
+  });
+
   it('ignores server modules without directives', () => {
     expect(hasUseClientDirective('export default function Server() {}\n')).toBe(false);
   });

--- a/tests/client-references.test.ts
+++ b/tests/client-references.test.ts
@@ -1,0 +1,7 @@
+import { hasUseClientDirective } from '../src/clientReferences';
+
+describe('hasUseClientDirective', () => {
+  it('recognizes a directive followed by code on the same line', () => {
+    expect(hasUseClientDirective("'use client'; export const answer = 42;\n")).toBe(true);
+  });
+});

--- a/tests/client-references.test.ts
+++ b/tests/client-references.test.ts
@@ -1,3 +1,4 @@
+import * as acorn from 'acorn-loose';
 import { hasUseClientDirective } from '../src/clientReferences';
 
 describe('hasUseClientDirective', () => {
@@ -67,6 +68,14 @@ describe('hasUseClientDirective', () => {
     expect(
       hasUseClientDirective('"use\\u0020client";\nexport default function Server() {}\n'),
     ).toBe(false);
+  });
+
+  it('returns false when directive parsing fails', () => {
+    jest.spyOn(acorn, 'parse').mockImplementationOnce(() => {
+      throw new Error('parse failed');
+    });
+
+    expect(hasUseClientDirective("'use client';\n")).toBe(false);
   });
 
   it('ignores server modules without directives', () => {

--- a/tests/client-references.test.ts
+++ b/tests/client-references.test.ts
@@ -29,8 +29,44 @@ describe('hasUseClientDirective', () => {
     );
   });
 
+  it('recognizes directives with carriage-return line endings', () => {
+    expect(hasUseClientDirective("'use client'\rexport default function Client() {}\r")).toBe(
+      true,
+    );
+  });
+
+  it('recognizes use client after earlier directive prologue entries', () => {
+    expect(hasUseClientDirective("'use strict';\n'use client';\nexport default function Client() {}\n")).toBe(
+      true,
+    );
+  });
+
+  it('recognizes directives followed by trailing line comments', () => {
+    expect(hasUseClientDirective("'use client' // generated\nexport default function Client() {}\n")).toBe(
+      true,
+    );
+  });
+
   it('rejects same-line code without a directive semicolon', () => {
     expect(hasUseClientDirective("'use client' export const answer = 42;\n")).toBe(false);
+  });
+
+  it('rejects line-comment cases where the next token continues the expression', () => {
+    expect(hasUseClientDirective("'use client' // generated\n[foo].forEach(() => {});\n")).toBe(
+      false,
+    );
+  });
+
+  it('rejects parenthesized string expressions', () => {
+    expect(hasUseClientDirective('("use client");\nexport default function Server() {}\n')).toBe(
+      false,
+    );
+  });
+
+  it('rejects escaped directive-like string values', () => {
+    expect(
+      hasUseClientDirective('"use\\u0020client";\nexport default function Server() {}\n'),
+    ).toBe(false);
   });
 
   it('ignores server modules without directives', () => {

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -1,0 +1,205 @@
+import { pathToFileURL } from 'url';
+
+const ReactFlightWebpackPlugin = require('../src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js');
+
+type AsyncHookCallback = (params: unknown, callback: (error?: Error | null) => void) => void;
+type SyncHookCallback = (...args: unknown[]) => void;
+
+type Chunk = {
+  id: string;
+  files: Set<string>;
+};
+
+const clientFile = '/app/components/ErrorBoundary.tsx';
+
+const buildManifest = ({
+  isServer,
+  chunkGroups,
+  getChunkModulesIterable,
+}: {
+  isServer: boolean;
+  chunkGroups: (clientReferenceBlocks: unknown[]) => unknown[];
+  getChunkModulesIterable: (chunk: Chunk) => unknown[];
+}) => {
+  const runtimeFile = require.resolve(
+    isServer ? '../src/react-server-dom-webpack/client.node.js' : '../src/react-server-dom-webpack/client.browser.js',
+  );
+  const plugin = new ReactFlightWebpackPlugin({
+    isServer,
+    clientReferences: [clientFile],
+  });
+
+  plugin.resolveAllClientFiles = jest.fn(
+    (
+      _context: string,
+      _contextResolver: unknown,
+      _normalResolver: unknown,
+      _fs: unknown,
+      _contextModuleFactory: unknown,
+      callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
+    ) => {
+      callback(null, [
+        { request: clientFile, type: 'client-reference', userRequest: './ErrorBoundary.tsx' } as never,
+      ]);
+    },
+  );
+
+  const beforeCompileCallbacks: AsyncHookCallback[] = [];
+  const thisCompilationCallbacks: SyncHookCallback[] = [];
+  const makeCallbacks: SyncHookCallback[] = [];
+  const compiler = {
+    context: '/app',
+    resolverFactory: {
+      get: jest.fn(() => ({})),
+    },
+    inputFileSystem: {},
+    hooks: {
+      beforeCompile: {
+        tapAsync: (_name: string, callback: AsyncHookCallback) => {
+          beforeCompileCallbacks.push(callback);
+        },
+      },
+      thisCompilation: {
+        tap: (_name: string, callback: SyncHookCallback) => {
+          thisCompilationCallbacks.push(callback);
+        },
+      },
+      make: {
+        tap: (_name: string, callback: SyncHookCallback) => {
+          makeCallbacks.push(callback);
+        },
+      },
+    },
+  };
+
+  plugin.apply(compiler);
+  beforeCompileCallbacks[0]!(
+    { contextModuleFactory: {} },
+    (error?: Error | null) => {
+      if (error) throw error;
+    },
+  );
+
+  const programCallbacks: Array<() => void> = [];
+  const clientReferenceBlocks: unknown[] = [];
+  const parser = {
+    state: {
+      module: {
+        resource: runtimeFile,
+        addBlock: jest.fn((block: unknown) => {
+          clientReferenceBlocks.push(block);
+        }),
+      },
+    },
+    hooks: {
+      program: {
+        tap: (_name: string, callback: () => void) => {
+          programCallbacks.push(callback);
+        },
+      },
+    },
+  };
+  const normalModuleFactory = {
+    hooks: {
+      parser: {
+        for: jest.fn(() => ({
+          tap: (_name: string, callback: (parserArg: typeof parser) => void) => {
+            callback(parser);
+          },
+        })),
+      },
+    },
+  };
+  const emittedAssets = new Map<string, { source(): string | Buffer }>();
+  const processAssetCallbacks: Array<() => void> = [];
+  const compilation = {
+    dependencyFactories: new Map(),
+    dependencyTemplates: new Map(),
+    warnings: [],
+    outputOptions: {
+      publicPath: '/assets/',
+    },
+    entrypoints: new Map(),
+    chunkGroups: chunkGroups(clientReferenceBlocks),
+    chunkGraph: {
+      getChunkModulesIterable: jest.fn(getChunkModulesIterable),
+      getModuleId: jest.fn(() => './client/app/components/ErrorBoundary.tsx'),
+    },
+    hooks: {
+      processAssets: {
+        tap: (_options: unknown, callback: () => void) => {
+          processAssetCallbacks.push(callback);
+        },
+      },
+    },
+    emitAsset: (filename: string, source: { source(): string | Buffer }) => {
+      emittedAssets.set(filename, source);
+    },
+  };
+
+  thisCompilationCallbacks[0]!(compilation, { normalModuleFactory });
+  programCallbacks[0]!();
+  expect(clientReferenceBlocks).not.toHaveLength(0);
+  makeCallbacks[0]!(compilation);
+  processAssetCallbacks[0]!();
+
+  const manifestAsset = emittedAssets.get(
+    isServer ? 'react-server-client-manifest.json' : 'react-client-manifest.json',
+  );
+  expect(manifestAsset).toBeDefined();
+
+  return JSON.parse(manifestAsset!.source().toString());
+};
+
+describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
+  it('does not merge unrelated entry chunks into the client manifest entry', () => {
+    const clientModule = { resource: clientFile };
+    const clientChunk = { id: 'client0', files: new Set(['js/client0.chunk.js']) };
+    const unrelatedEntryChunk = {
+      id: 'generated/ServerComponentRouter',
+      files: new Set(['js/generated/ServerComponentRouter.js']),
+    };
+
+    const manifest = buildManifest({
+      isServer: false,
+      chunkGroups: (clientReferenceBlocks) => [
+        {
+          getBlocks: () => [],
+          chunks: [unrelatedEntryChunk],
+        },
+        {
+          getBlocks: () => clientReferenceBlocks,
+          chunks: [clientChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [clientModule],
+    });
+
+    expect(manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href]).toEqual({
+      id: './client/app/components/ErrorBoundary.tsx',
+      chunks: ['client0', 'js/client0.chunk.js'],
+      name: '*',
+    });
+  });
+
+  it('keeps generating server manifest metadata from server chunk groups without client-reference blocks', () => {
+    const serverModule = { resource: clientFile };
+    const serverChunk = { id: 'server-bundle', files: new Set(['server-bundle.js']) };
+
+    const manifest = buildManifest({
+      isServer: true,
+      chunkGroups: () => [
+        {
+          chunks: [serverChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [serverModule],
+    });
+
+    expect(manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href]).toEqual({
+      id: './client/app/components/ErrorBoundary.tsx',
+      chunks: ['server-bundle', 'server-bundle.js'],
+      name: '*',
+    });
+  });
+});

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -4,6 +4,11 @@ const ReactFlightWebpackPlugin = require('../src/react-server-dom-webpack/cjs/re
 
 type AsyncHookCallback = (params: unknown, callback: (error?: Error | null) => void) => void;
 type SyncHookCallback = (...args: unknown[]) => void;
+type ClientReference = {
+  request: string;
+  userRequest: string;
+  type?: string;
+};
 
 type Chunk = {
   id: string;
@@ -36,10 +41,10 @@ const buildManifest = ({
       _normalResolver: unknown,
       _fs: unknown,
       _contextModuleFactory: unknown,
-      callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
+      callback: (error: Error | null, refs?: ClientReference[]) => void,
     ) => {
       callback(null, [
-        { request: clientFile, type: 'client-reference', userRequest: './ErrorBoundary.tsx' } as never,
+        { request: clientFile, type: 'client-reference', userRequest: './ErrorBoundary.tsx' },
       ]);
     },
   );
@@ -148,7 +153,10 @@ const buildManifest = ({
   );
   expect(manifestAsset).toBeDefined();
 
-  return JSON.parse(manifestAsset!.source().toString());
+  return {
+    manifest: JSON.parse(manifestAsset!.source().toString()),
+    warnings: compilation.warnings,
+  };
 };
 
 describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
@@ -160,7 +168,7 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
       files: new Set(['js/generated/ServerComponentRouter.js']),
     };
 
-    const manifest = buildManifest({
+    const { manifest } = buildManifest({
       isServer: false,
       chunkGroups: (clientReferenceBlocks) => [
         {
@@ -186,7 +194,7 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     const serverModule = { resource: clientFile };
     const serverChunk = { id: 'server-bundle', files: new Set(['server-bundle.js']) };
 
-    const manifest = buildManifest({
+    const { manifest } = buildManifest({
       isServer: true,
       chunkGroups: () => [
         {
@@ -201,5 +209,27 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
       chunks: ['server-bundle', 'server-bundle.js'],
       name: '*',
     });
+  });
+
+  it('warns when a client chunk group cannot expose client-reference blocks', () => {
+    const clientModule = { resource: clientFile };
+    const clientChunk = { id: 'client0', files: new Set(['js/client0.chunk.js']) };
+
+    const { manifest, warnings } = buildManifest({
+      isServer: false,
+      chunkGroups: () => [
+        {
+          name: 'client-entry',
+          chunks: [clientChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [clientModule],
+    });
+
+    expect(manifest.filePathToModuleMetadata).toEqual({});
+    expect(warnings).toHaveLength(1);
+    expect(String(warnings[0])).toContain(
+      'Client reference blocks were unavailable for chunk group client-entry',
+    );
   });
 });

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -116,11 +116,12 @@ const buildManifest = ({
     },
   };
   const emittedAssets = new Map<string, { source(): string | Buffer }>();
+  const warnings: unknown[] = [];
   const processAssetCallbacks: Array<() => void> = [];
   const compilation = {
     dependencyFactories: new Map(),
     dependencyTemplates: new Map(),
-    warnings: [],
+    warnings,
     outputOptions: {
       publicPath: '/assets/',
     },
@@ -155,7 +156,7 @@ const buildManifest = ({
 
   return {
     manifest: JSON.parse(manifestAsset!.source().toString()),
-    warnings: compilation.warnings,
+    warnings,
   };
 };
 

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -233,4 +233,30 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
       'Client reference blocks were unavailable for chunk group client-entry',
     );
   });
+
+  it('warns only once when several client chunk groups cannot expose client-reference blocks', () => {
+    const clientModule = { resource: clientFile };
+    const firstChunk = { id: 'client0', files: new Set(['js/client0.chunk.js']) };
+    const secondChunk = { id: 'client1', files: new Set(['js/client1.chunk.js']) };
+
+    const { warnings } = buildManifest({
+      isServer: false,
+      chunkGroups: () => [
+        {
+          name: 'client-entry',
+          chunks: [firstChunk],
+        },
+        {
+          name: 'admin-entry',
+          chunks: [secondChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [clientModule],
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(String(warnings[0])).toContain(
+      'Client reference blocks were unavailable for chunk group client-entry',
+    );
+  });
 });

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -230,7 +230,7 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     expect(manifest.filePathToModuleMetadata).toEqual({});
     expect(warnings).toHaveLength(1);
     expect(String(warnings[0])).toContain(
-      'Client reference blocks were unavailable for chunk group client-entry',
+      'Client reference blocks were unavailable for one or more chunk groups',
     );
   });
 
@@ -256,7 +256,7 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
 
     expect(warnings).toHaveLength(1);
     expect(String(warnings[0])).toContain(
-      'Client reference blocks were unavailable for chunk group client-entry',
+      'Client reference blocks were unavailable for one or more chunk groups',
     );
   });
 });

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -191,6 +191,28 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     });
   });
 
+  it('uses blocksIterable when getBlocks is unavailable', () => {
+    const clientModule = { resource: clientFile };
+    const clientChunk = { id: 'client0', files: new Set(['js/client0.chunk.js']) };
+
+    const { manifest } = buildManifest({
+      isServer: false,
+      chunkGroups: (clientReferenceBlocks) => [
+        {
+          blocksIterable: clientReferenceBlocks,
+          chunks: [clientChunk],
+        },
+      ],
+      getChunkModulesIterable: () => [clientModule],
+    });
+
+    expect(manifest.filePathToModuleMetadata[pathToFileURL(clientFile).href]).toEqual({
+      id: './client/app/components/ErrorBoundary.tsx',
+      chunks: ['client0', 'js/client0.chunk.js'],
+      name: '*',
+    });
+  });
+
   it('keeps generating server manifest metadata from server chunk groups without client-reference blocks', () => {
     const serverModule = { resource: clientFile };
     const serverChunk = { id: 'server-bundle', files: new Set(['server-bundle.js']) };

--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -4,6 +4,11 @@ const ReactFlightWebpackPlugin = require('../src/react-server-dom-webpack/cjs/re
 
 type AsyncHookCallback = (params: unknown, callback: (error?: Error | null) => void) => void;
 type SyncHookCallback = (...args: unknown[]) => void;
+type ClientReference = {
+  request: string;
+  userRequest: string;
+  type?: string;
+};
 
 describe('ReactFlightWebpackPlugin manifest chunk files', () => {
   it('records the JavaScript chunk when CSS appears first in chunk.files', () => {
@@ -23,10 +28,10 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
         _normalResolver: unknown,
         _fs: unknown,
         _contextModuleFactory: unknown,
-        callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
+        callback: (error: Error | null, refs?: ClientReference[]) => void,
       ) => {
         callback(null, [
-          { request: clientFile, type: 'client-reference', userRequest: './ClientComponent.js' } as never,
+          { request: clientFile, type: 'client-reference', userRequest: './ClientComponent.js' },
         ]);
       },
     );

--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -25,7 +25,9 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
         _contextModuleFactory: unknown,
         callback: (error: Error | null, refs?: Array<{ request: string; userRequest: string }>) => void,
       ) => {
-        callback(null, [{ request: clientFile, userRequest: './ClientComponent.js' }]);
+        callback(null, [
+          { request: clientFile, type: 'client-reference', userRequest: './ClientComponent.js' } as never,
+        ]);
       },
     );
 
@@ -68,11 +70,14 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
     );
 
     const programCallbacks: Array<() => void> = [];
+    const clientReferenceBlocks: unknown[] = [];
     const parser = {
       state: {
         module: {
           resource: runtimeFile,
-          addBlock: jest.fn(),
+          addBlock: jest.fn((block: unknown) => {
+            clientReferenceBlocks.push(block);
+          }),
         },
       },
       hooks: {
@@ -113,6 +118,7 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
       entrypoints: new Map(),
       chunkGroups: [
         {
+          getBlocks: () => clientReferenceBlocks,
           chunks: [chunk],
         },
       ],
@@ -136,6 +142,7 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
     thisCompilationCallbacks[0]!(compilation, { normalModuleFactory });
     expect(programCallbacks).toHaveLength(3);
     programCallbacks.forEach((callback) => callback());
+    expect(clientReferenceBlocks).not.toHaveLength(0);
     expect(makeCallbacks).toHaveLength(1);
     makeCallbacks[0]!(compilation);
     expect(processAssetCallbacks).toHaveLength(1);

--- a/tests/rsc-reference-discovery-plugin.test.ts
+++ b/tests/rsc-reference-discovery-plugin.test.ts
@@ -1,0 +1,163 @@
+import * as path from 'path';
+import {
+  recordDiscoveredClientReferenceIfNeeded,
+  RSCReferenceDiscoveryPlugin,
+} from '../src/RSCReferenceDiscoveryPlugin';
+
+class FakeRawSource {
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  source(): string {
+    return this.value;
+  }
+}
+
+type FakeCompilation = {
+  [key: symbol]: unknown;
+  hooks: {
+    processAssets: {
+      tap: jest.Mock;
+    };
+  };
+  emitAsset: jest.Mock;
+};
+
+const createCompilation = (): {
+  compilation: FakeCompilation;
+  getProcessAssetsCallback: () => () => void;
+} => {
+  let processAssetsCallback: (() => void) | undefined;
+  const compilation = {
+    hooks: {
+      processAssets: {
+        tap: jest.fn((_options, callback) => {
+          processAssetsCallback = callback;
+        }),
+      },
+    },
+    emitAsset: jest.fn(),
+  } as FakeCompilation;
+
+  return {
+    compilation,
+    getProcessAssetsCallback: () => {
+      if (!processAssetsCallback) throw new Error('processAssets callback was not registered');
+      return processAssetsCallback;
+    },
+  };
+};
+
+const createCompiler = (context: string): {
+  compiler: {
+    context: string;
+    webpack: {
+      Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+      sources: { RawSource: typeof FakeRawSource };
+    };
+    hooks: { thisCompilation: { tap: jest.Mock } };
+  };
+  getThisCompilationCallback: () => (compilation: FakeCompilation) => void;
+} => {
+  let thisCompilationCallback: ((compilation: FakeCompilation) => void) | undefined;
+  const compiler = {
+    context,
+    webpack: {
+      Compilation: { PROCESS_ASSETS_STAGE_REPORT: 5000 },
+      sources: { RawSource: FakeRawSource },
+    },
+    hooks: {
+      thisCompilation: {
+        tap: jest.fn((_name, callback) => {
+          thisCompilationCallback = callback;
+        }),
+      },
+    },
+  };
+
+  return {
+    compiler,
+    getThisCompilationCallback: () => {
+      if (!thisCompilationCallback) throw new Error('thisCompilation callback was not registered');
+      return thisCompilationCallback;
+    },
+  };
+};
+
+describe('RSCReferenceDiscoveryPlugin', () => {
+  it('emits references recorded by RSCWebpackLoader', () => {
+    const context = path.join(__dirname, 'fixtures');
+    const component = path.join(context, 'components', 'ClientComponent.jsx');
+    const { compiler, getThisCompilationCallback } = createCompiler(context);
+    const { compilation, getProcessAssetsCallback } = createCompilation();
+
+    new RSCReferenceDiscoveryPlugin({ filename: 'custom-rsc-client-references.json' }).apply(
+      compiler,
+    );
+    getThisCompilationCallback()(compilation);
+
+    const cacheable = jest.fn();
+    const recorded = recordDiscoveredClientReferenceIfNeeded(
+      { _compilation: compilation, resourcePath: component, cacheable },
+      "'use client';\nexport default function ClientComponent() { return null; }\n",
+    );
+
+    expect(recorded).toBe(true);
+    expect(cacheable).toHaveBeenCalledWith(false);
+
+    getProcessAssetsCallback()();
+
+    expect(compilation.emitAsset).toHaveBeenCalledTimes(1);
+    const [filename, source] = compilation.emitAsset.mock.calls[0]!;
+    expect(filename).toBe('custom-rsc-client-references.json');
+
+    const payload = JSON.parse((source as FakeRawSource).source()) as {
+      version: number;
+      compilerContext: string;
+      count: number;
+      refs: string[];
+      relativeRefs: string[];
+    };
+    expect(payload).toEqual({
+      version: 1,
+      compilerContext: context,
+      count: 1,
+      refs: [component],
+      relativeRefs: ['components/ClientComponent.jsx'],
+    });
+  });
+
+  it('does not record when the emitter plugin is not active for the compilation', () => {
+    const cacheable = jest.fn();
+    const recorded = recordDiscoveredClientReferenceIfNeeded(
+      {
+        _compilation: { hooks: { processAssets: { tap: jest.fn() } }, emitAsset: jest.fn() },
+        resourcePath: '/app/Client.jsx',
+        cacheable,
+      },
+      "'use client';\nexport default function Client() { return null; }\n",
+    );
+
+    expect(recorded).toBe(false);
+    expect(cacheable).not.toHaveBeenCalled();
+  });
+
+  it('marks loader output non-cacheable when active even for non-client modules', () => {
+    const { compiler, getThisCompilationCallback } = createCompiler('/app');
+    const { compilation } = createCompilation();
+    new RSCReferenceDiscoveryPlugin().apply(compiler);
+    getThisCompilationCallback()(compilation);
+
+    const cacheable = jest.fn();
+    const recorded = recordDiscoveredClientReferenceIfNeeded(
+      { _compilation: compilation, resourcePath: '/app/Server.jsx', cacheable },
+      'export default function Server() { return null; }\n',
+    );
+
+    expect(recorded).toBe(false);
+    expect(cacheable).toHaveBeenCalledWith(false);
+  });
+});

--- a/tests/rsc-reference-discovery-plugin.test.ts
+++ b/tests/rsc-reference-discovery-plugin.test.ts
@@ -51,10 +51,17 @@ const createCompilation = (): {
   };
 };
 
-const createCompiler = (context: string): {
+const createCompiler = (
+  context: string,
+  bundler: 'webpack' | 'rspack' = 'webpack',
+): {
   compiler: {
     context: string;
-    webpack: {
+    webpack?: {
+      Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
+      sources: { RawSource: typeof FakeRawSource };
+    };
+    rspack?: {
       Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
       sources: { RawSource: typeof FakeRawSource };
     };
@@ -63,12 +70,12 @@ const createCompiler = (context: string): {
   getThisCompilationCallback: () => (compilation: FakeCompilation) => void;
 } => {
   let thisCompilationCallback: ((compilation: FakeCompilation) => void) | undefined;
+  const bundlerApi = {
+    Compilation: { PROCESS_ASSETS_STAGE_REPORT: 5000 },
+    sources: { RawSource: FakeRawSource },
+  };
   const compiler = {
     context,
-    webpack: {
-      Compilation: { PROCESS_ASSETS_STAGE_REPORT: 5000 },
-      sources: { RawSource: FakeRawSource },
-    },
     hooks: {
       thisCompilation: {
         tap: jest.fn((_name, callback) => {
@@ -76,6 +83,7 @@ const createCompiler = (context: string): {
         }),
       },
     },
+    [bundler]: bundlerApi,
   };
 
   return {
@@ -97,6 +105,18 @@ describe('RSCReferenceDiscoveryPlugin', () => {
     expect(() => new RSCReferenceDiscoveryPlugin().apply(compiler)).toThrow(
       'RSCReferenceDiscoveryPlugin requires a compiler with webpack or rspack APIs',
     );
+  });
+
+  it('accepts Rspack compiler APIs', () => {
+    const context = path.join(__dirname, 'fixtures');
+    const { compiler, getThisCompilationCallback } = createCompiler(context, 'rspack');
+    const { compilation, getProcessAssetsCallback } = createCompilation();
+
+    new RSCReferenceDiscoveryPlugin().apply(compiler);
+    getThisCompilationCallback()(compilation);
+    getProcessAssetsCallback()();
+
+    expect(compilation.emitAsset).toHaveBeenCalledTimes(1);
   });
 
   it('emits references recorded by RSCWebpackLoader', () => {

--- a/tests/rsc-reference-discovery-plugin.test.ts
+++ b/tests/rsc-reference-discovery-plugin.test.ts
@@ -88,6 +88,17 @@ const createCompiler = (context: string): {
 };
 
 describe('RSCReferenceDiscoveryPlugin', () => {
+  it('throws a descriptive error when no bundler API is available', () => {
+    const compiler = {
+      context: '/app',
+      hooks: { thisCompilation: { tap: jest.fn() } },
+    };
+
+    expect(() => new RSCReferenceDiscoveryPlugin().apply(compiler)).toThrow(
+      'RSCReferenceDiscoveryPlugin requires a compiler with webpack or rspack APIs',
+    );
+  });
+
   it('emits references recorded by RSCWebpackLoader', () => {
     const context = path.join(__dirname, 'fixtures');
     const component = path.join(context, 'components', 'ClientComponent.jsx');


### PR DESCRIPTION
> [!IMPORTANT]
> Replacement / maintainer-owned follow-up for #46. This is paired with shakacode/react_on_rails#3556 and should be reviewed together with that PR.

## Summary

- Carries forward #46's RSC graph-derived client-reference discovery support.
- Adds the public `RSCReferenceDiscoveryPlugin` package export and loader recording path from #46.
- Adds review fixes on top of #46:
  - Detects same-line directives such as `'use client'; export const x = 1`.
  - Throws a descriptive error when neither `compiler.webpack` nor `compiler.rspack` is available instead of falling through to a bare `require('webpack')`.
  - Emits a Webpack warning when a client chunk group cannot expose client-reference blocks, rather than silently skipping it.
  - Removes `as never` casts in manifest tests by typing the mock client-reference shape explicitly.

## Verification

- Red first:
  - `tests/client-references.test.ts` failed for same-line `'use client'` detection.
  - `tests/rsc-reference-discovery-plugin.test.ts` failed for the missing bundler API diagnostic.
  - `tests/react-flight-webpack-plugin-client-reference-chunks.test.ts` failed for the missing warning on chunk groups without block metadata.
- Green after fix:
  - `yarn jest tests/client-references.test.ts tests/rsc-reference-discovery-plugin.test.ts tests/react-flight-webpack-plugin-client-reference-chunks.test.ts tests/react-flight-webpack-plugin-css-order.test.ts --runInBand`
  - `yarn test`
  - `yarn build`
  - `git diff --check`
  - `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

The existing `cacheable(false)` behavior is intentionally preserved. #46's tests already assert that loader output is non-cacheable even for currently non-client modules, because otherwise a watch rebuild can miss a file that gains a `'use client'` directive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build-time RSC client manifest chunk mapping and directive discovery; incorrect behavior could mis-wire client components at runtime, though behavior is heavily tested.
> 
> **Overview**
> Adds **graph-derived RSC client-reference discovery**: a public **`RSCReferenceDiscoveryPlugin`** records `"use client"` modules during the RSC **Webpack loader** pass and emits **`rsc-client-references.json`**, with loader output marked **non-cacheable** while the plugin is active so watch rebuilds do not miss newly added directives.
> 
> **`hasUseClientDirective`** is centralized in **`clientReferences`** (Acorn-based parsing) and shared with Rspack; it now handles edge cases such as **same-line** directives and stricter prologue rules.
> 
> **`ReactFlightWebpackPlugin`** client manifests tie modules to chunks using **client-reference async blocks** per chunk group (with **`getBlocks` / `blocksIterable`** fallbacks), reducing unrelated entry chunks in the client manifest and emitting a **Webpack warning** when block metadata is missing instead of silently skipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5695cf91caad7323197576bf110fba5b0124b3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->