### PR TITLE
Release react-on-rails-rsc 19.0.5-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [19.0.5-rc.5] - 2026-06-03
+
+### Changed
+- Updated the vendored `react-server-dom-webpack` runtime to React 19.0.4 and aligned package peer dependencies with React 19.0.4.
+
+### Fixed
+- Replaced the `19.0.5-rc.4` runtime bundle that still reported React 19.0.3, so release candidates no longer include React Server Components runtime versions affected by CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779.
+
 ## [19.0.5-rc.4] - 2026-06-02
 
 ### Added
@@ -44,6 +52,7 @@ All notable changes to this package will be documented in this file.
 ### Changed
 - Released the first `19.0.5` release candidate.
 
+[19.0.5-rc.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.4...19.0.5-rc.5
 [19.0.5-rc.4]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.3...19.0.5-rc.4
 [19.0.5-rc.3]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.2...19.0.5-rc.3
 [19.0.5-rc.2]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.1...19.0.5-rc.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-rsc",
-  "version": "19.0.5-rc.4",
+  "version": "19.0.5-rc.5",
   "description": "React Server Components support for react_on_rails Ruby gem",
   "exports": {
     "./client": {
@@ -97,8 +97,8 @@
     "webpack": "^5.98.0"
   },
   "peerDependencies": {
-    "react": "^19.0.3",
-    "react-dom": "^19.0.3",
+    "react": "^19.0.4",
+    "react-dom": "^19.0.4",
     "webpack": "^5.59.0"
   },
   "dependencies": {

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
@@ -438,6 +438,11 @@
         return "$" + (iterable ? "x" : "X") + streamId.toString(16);
       }
       function resolveToJSON(key, value) {
+        "__proto__" === key &&
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(this, key)
+          );
         var originalValue = this[key];
         "object" !== typeof originalValue ||
           originalValue === value ||
@@ -682,14 +687,17 @@
         if ("undefined" === typeof value) return "$undefined";
         if ("function" === typeof value) {
           parentReference = knownServerReferences.get(value);
-          if (void 0 !== parentReference)
-            return (
-              (key = JSON.stringify(parentReference, resolveToJSON)),
-              null === formData && (formData = new FormData()),
-              (parentReference = nextPartId++),
-              formData.set(formFieldPrefix + parentReference, key),
-              "$h" + parentReference.toString(16)
-            );
+          if (void 0 !== parentReference) {
+            key = writtenObjects.get(value);
+            if (void 0 !== key) return key;
+            key = JSON.stringify(parentReference, resolveToJSON);
+            null === formData && (formData = new FormData());
+            parentReference = nextPartId++;
+            formData.set(formFieldPrefix + parentReference, key);
+            key = "$h" + parentReference.toString(16);
+            writtenObjects.set(value, key);
+            return key;
+          }
           if (
             void 0 !== temporaryReferences &&
             -1 === key.indexOf(":") &&
@@ -1112,10 +1120,17 @@
               value.then(fulfill, reject);
               return;
             }
-          value = value[path[i]];
+          var name = path[i];
+          if (
+            "object" === typeof value &&
+            null !== value &&
+            hasOwnProperty.call(value, name)
+          )
+            value = value[name];
+          else throw Error("Invalid reference.");
         }
         i = map(response, value, parentObject, key);
-        parentObject[key] = i;
+        "__proto__" !== key && (parentObject[key] = i);
         "" === key && null === handler.value && (handler.value = i);
         if (
           parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1208,7 +1223,7 @@
             boundArgs.unshift(null);
             resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
           }
-          parentObject[key] = resolvedValue;
+          "__proto__" !== key && (parentObject[key] = resolvedValue);
           "" === key &&
             null === handler.value &&
             (handler.value = resolvedValue);
@@ -1466,14 +1481,15 @@
             }
           case "Y":
             return (
-              Object.defineProperty(parentObject, key, {
-                get: function () {
-                  return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
-                },
-                set: function () {},
-                enumerable: !0,
-                configurable: !1
-              }),
+              "__proto__" !== key &&
+                Object.defineProperty(parentObject, key, {
+                  get: function () {
+                    return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
+                  },
+                  set: function () {},
+                  enumerable: !0,
+                  configurable: !1
+                }),
               null
             );
           default:
@@ -2495,10 +2511,10 @@
       return hook.checkDCE ? !0 : !1;
     })({
       bundleType: 1,
-      version: "19.0.3",
-      rendererPackageName: "react-server-dom-webpack",
+      version: "19.0.4",
+      rendererPackageName: "react-on-rails-rsc",
       currentDispatcherRef: ReactSharedInternals,
-      reconcilerVersion: "19.0.3",
+      reconcilerVersion: "19.0.4",
       getCurrentComponentInfo: function () {
         return currentOwnerInDEV;
       }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js
@@ -444,14 +444,17 @@ function processReply(
     if ("undefined" === typeof value) return "$undefined";
     if ("function" === typeof value) {
       parentReference = knownServerReferences.get(value);
-      if (void 0 !== parentReference)
-        return (
-          (key = JSON.stringify(parentReference, resolveToJSON)),
-          null === formData && (formData = new FormData()),
-          (parentReference = nextPartId++),
-          formData.set(formFieldPrefix + parentReference, key),
-          "$h" + parentReference.toString(16)
-        );
+      if (void 0 !== parentReference) {
+        key = writtenObjects.get(value);
+        if (void 0 !== key) return key;
+        key = JSON.stringify(parentReference, resolveToJSON);
+        null === formData && (formData = new FormData());
+        parentReference = nextPartId++;
+        formData.set(formFieldPrefix + parentReference, key);
+        key = "$h" + parentReference.toString(16);
+        writtenObjects.set(value, key);
+        return key;
+      }
       if (
         void 0 !== temporaryReferences &&
         -1 === key.indexOf(":") &&
@@ -729,10 +732,17 @@ function waitForReference(
           value.then(fulfill, reject);
           return;
         }
-      value = value[path[i]];
+      var name = path[i];
+      if (
+        "object" === typeof value &&
+        null !== value &&
+        hasOwnProperty.call(value, name)
+      )
+        value = value[name];
+      else throw Error("Invalid reference.");
     }
     i = map(response, value, parentObject, key);
-    parentObject[key] = i;
+    "__proto__" !== key && (parentObject[key] = i);
     "" === key && null === handler.value && (handler.value = i);
     if (
       parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -808,7 +818,7 @@ function loadServerReference(response, metaData, parentObject, key) {
         boundArgs.unshift(null);
         resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
       }
-      parentObject[key] = resolvedValue;
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
       "" === key && null === handler.value && (handler.value = resolvedValue);
       if (
         parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1121,8 +1131,8 @@ function startReadableStream(response, id, type) {
             (previousBlockedChunk = chunk));
       } else {
         chunk = previousBlockedChunk;
-        var chunk$52 = createPendingChunk(response);
-        chunk$52.then(
+        var chunk$53 = createPendingChunk(response);
+        chunk$53.then(
           function (v) {
             return controller.enqueue(v);
           },
@@ -1130,10 +1140,10 @@ function startReadableStream(response, id, type) {
             return controller.error(e);
           }
         );
-        previousBlockedChunk = chunk$52;
+        previousBlockedChunk = chunk$53;
         chunk.then(function () {
-          previousBlockedChunk === chunk$52 && (previousBlockedChunk = null);
-          resolveModelChunk(chunk$52, json);
+          previousBlockedChunk === chunk$53 && (previousBlockedChunk = null);
+          resolveModelChunk(chunk$53, json);
         });
       }
     },
@@ -1268,8 +1278,8 @@ function mergeBuffer(buffer, lastChunk) {
   for (var l = buffer.length, byteLength = lastChunk.length, i = 0; i < l; i++)
     byteLength += buffer[i].byteLength;
   byteLength = new Uint8Array(byteLength);
-  for (var i$53 = (i = 0); i$53 < l; i$53++) {
-    var chunk = buffer[i$53];
+  for (var i$54 = (i = 0); i$54 < l; i$54++) {
+    var chunk = buffer[i$54];
     byteLength.set(chunk, i);
     i += chunk.byteLength;
   }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
@@ -459,6 +459,11 @@
         return "$" + (iterable ? "x" : "X") + streamId.toString(16);
       }
       function resolveToJSON(key, value) {
+        "__proto__" === key &&
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(this, key)
+          );
         var originalValue = this[key];
         "object" !== typeof originalValue ||
           originalValue === value ||
@@ -703,14 +708,17 @@
         if ("undefined" === typeof value) return "$undefined";
         if ("function" === typeof value) {
           parentReference = knownServerReferences.get(value);
-          if (void 0 !== parentReference)
-            return (
-              (key = JSON.stringify(parentReference, resolveToJSON)),
-              null === formData && (formData = new FormData()),
-              (parentReference = nextPartId++),
-              formData.set(formFieldPrefix + parentReference, key),
-              "$h" + parentReference.toString(16)
-            );
+          if (void 0 !== parentReference) {
+            key = writtenObjects.get(value);
+            if (void 0 !== key) return key;
+            key = JSON.stringify(parentReference, resolveToJSON);
+            null === formData && (formData = new FormData());
+            parentReference = nextPartId++;
+            formData.set(formFieldPrefix + parentReference, key);
+            key = "$h" + parentReference.toString(16);
+            writtenObjects.set(value, key);
+            return key;
+          }
           if (
             void 0 !== temporaryReferences &&
             -1 === key.indexOf(":") &&
@@ -1316,10 +1324,17 @@
               value.then(fulfill, reject);
               return;
             }
-          value = value[path[i]];
+          var name = path[i];
+          if (
+            "object" === typeof value &&
+            null !== value &&
+            hasOwnProperty.call(value, name)
+          )
+            value = value[name];
+          else throw Error("Invalid reference.");
         }
         i = map(response, value, parentObject, key);
-        parentObject[key] = i;
+        "__proto__" !== key && (parentObject[key] = i);
         "" === key && null === handler.value && (handler.value = i);
         if (
           parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1412,7 +1427,7 @@
             boundArgs.unshift(null);
             resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
           }
-          parentObject[key] = resolvedValue;
+          "__proto__" !== key && (parentObject[key] = resolvedValue);
           "" === key &&
             null === handler.value &&
             (handler.value = resolvedValue);
@@ -1670,14 +1685,15 @@
             }
           case "Y":
             return (
-              Object.defineProperty(parentObject, key, {
-                get: function () {
-                  return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
-                },
-                set: function () {},
-                enumerable: !0,
-                configurable: !1
-              }),
+              "__proto__" !== key &&
+                Object.defineProperty(parentObject, key, {
+                  get: function () {
+                    return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
+                  },
+                  set: function () {},
+                  enumerable: !0,
+                  configurable: !1
+                }),
               null
             );
           default:

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
@@ -456,14 +456,17 @@ function processReply(
     if ("undefined" === typeof value) return "$undefined";
     if ("function" === typeof value) {
       parentReference = knownServerReferences.get(value);
-      if (void 0 !== parentReference)
-        return (
-          (key = JSON.stringify(parentReference, resolveToJSON)),
-          null === formData && (formData = new FormData()),
-          (parentReference = nextPartId++),
-          formData.set(formFieldPrefix + parentReference, key),
-          "$h" + parentReference.toString(16)
-        );
+      if (void 0 !== parentReference) {
+        key = writtenObjects.get(value);
+        if (void 0 !== key) return key;
+        key = JSON.stringify(parentReference, resolveToJSON);
+        null === formData && (formData = new FormData());
+        parentReference = nextPartId++;
+        formData.set(formFieldPrefix + parentReference, key);
+        key = "$h" + parentReference.toString(16);
+        writtenObjects.set(value, key);
+        return key;
+      }
       if (
         void 0 !== temporaryReferences &&
         -1 === key.indexOf(":") &&
@@ -883,10 +886,17 @@ function waitForReference(
           value.then(fulfill, reject);
           return;
         }
-      value = value[path[i]];
+      var name = path[i];
+      if (
+        "object" === typeof value &&
+        null !== value &&
+        hasOwnProperty.call(value, name)
+      )
+        value = value[name];
+      else throw Error("Invalid reference.");
     }
     i = map(response, value, parentObject, key);
-    parentObject[key] = i;
+    "__proto__" !== key && (parentObject[key] = i);
     "" === key && null === handler.value && (handler.value = i);
     if (
       parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -966,7 +976,7 @@ function loadServerReference(response, metaData, parentObject, key) {
         boundArgs.unshift(null);
         resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
       }
-      parentObject[key] = resolvedValue;
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
       "" === key && null === handler.value && (handler.value = resolvedValue);
       if (
         parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1284,8 +1294,8 @@ function startReadableStream(response, id, type) {
             (previousBlockedChunk = chunk));
       } else {
         chunk = previousBlockedChunk;
-        var chunk$52 = createPendingChunk(response);
-        chunk$52.then(
+        var chunk$53 = createPendingChunk(response);
+        chunk$53.then(
           function (v) {
             return controller.enqueue(v);
           },
@@ -1293,10 +1303,10 @@ function startReadableStream(response, id, type) {
             return controller.error(e);
           }
         );
-        previousBlockedChunk = chunk$52;
+        previousBlockedChunk = chunk$53;
         chunk.then(function () {
-          previousBlockedChunk === chunk$52 && (previousBlockedChunk = null);
-          resolveModelChunk(chunk$52, json);
+          previousBlockedChunk === chunk$53 && (previousBlockedChunk = null);
+          resolveModelChunk(chunk$53, json);
         });
       }
     },
@@ -1431,8 +1441,8 @@ function mergeBuffer(buffer, lastChunk) {
   for (var l = buffer.length, byteLength = lastChunk.length, i = 0; i < l; i++)
     byteLength += buffer[i].byteLength;
   byteLength = new Uint8Array(byteLength);
-  for (var i$53 = (i = 0); i$53 < l; i$53++) {
-    var chunk = buffer[i$53];
+  for (var i$54 = (i = 0); i$54 < l; i$54++) {
+    var chunk = buffer[i$54];
     byteLength.set(chunk, i);
     i += chunk.byteLength;
   }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
@@ -459,6 +459,11 @@
         return "$" + (iterable ? "x" : "X") + streamId.toString(16);
       }
       function resolveToJSON(key, value) {
+        "__proto__" === key &&
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(this, key)
+          );
         var originalValue = this[key];
         "object" !== typeof originalValue ||
           originalValue === value ||
@@ -703,14 +708,17 @@
         if ("undefined" === typeof value) return "$undefined";
         if ("function" === typeof value) {
           parentReference = knownServerReferences.get(value);
-          if (void 0 !== parentReference)
-            return (
-              (key = JSON.stringify(parentReference, resolveToJSON)),
-              null === formData && (formData = new FormData()),
-              (parentReference = nextPartId++),
-              formData.set(formFieldPrefix + parentReference, key),
-              "$h" + parentReference.toString(16)
-            );
+          if (void 0 !== parentReference) {
+            key = writtenObjects.get(value);
+            if (void 0 !== key) return key;
+            key = JSON.stringify(parentReference, resolveToJSON);
+            null === formData && (formData = new FormData());
+            parentReference = nextPartId++;
+            formData.set(formFieldPrefix + parentReference, key);
+            key = "$h" + parentReference.toString(16);
+            writtenObjects.set(value, key);
+            return key;
+          }
           if (
             void 0 !== temporaryReferences &&
             -1 === key.indexOf(":") &&
@@ -1316,10 +1324,17 @@
               value.then(fulfill, reject);
               return;
             }
-          value = value[path[i]];
+          var name = path[i];
+          if (
+            "object" === typeof value &&
+            null !== value &&
+            hasOwnProperty.call(value, name)
+          )
+            value = value[name];
+          else throw Error("Invalid reference.");
         }
         i = map(response, value, parentObject, key);
-        parentObject[key] = i;
+        "__proto__" !== key && (parentObject[key] = i);
         "" === key && null === handler.value && (handler.value = i);
         if (
           parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1412,7 +1427,7 @@
             boundArgs.unshift(null);
             resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
           }
-          parentObject[key] = resolvedValue;
+          "__proto__" !== key && (parentObject[key] = resolvedValue);
           "" === key &&
             null === handler.value &&
             (handler.value = resolvedValue);
@@ -1670,14 +1685,15 @@
             }
           case "Y":
             return (
-              Object.defineProperty(parentObject, key, {
-                get: function () {
-                  return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
-                },
-                set: function () {},
-                enumerable: !0,
-                configurable: !1
-              }),
+              "__proto__" !== key &&
+                Object.defineProperty(parentObject, key, {
+                  get: function () {
+                    return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
+                  },
+                  set: function () {},
+                  enumerable: !0,
+                  configurable: !1
+                }),
               null
             );
           default:

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
@@ -457,14 +457,17 @@ function processReply(
     if ("undefined" === typeof value) return "$undefined";
     if ("function" === typeof value) {
       parentReference = knownServerReferences.get(value);
-      if (void 0 !== parentReference)
-        return (
-          (key = JSON.stringify(parentReference, resolveToJSON)),
-          null === formData && (formData = new FormData()),
-          (parentReference = nextPartId++),
-          formData.set(formFieldPrefix + parentReference, key),
-          "$h" + parentReference.toString(16)
-        );
+      if (void 0 !== parentReference) {
+        key = writtenObjects.get(value);
+        if (void 0 !== key) return key;
+        key = JSON.stringify(parentReference, resolveToJSON);
+        null === formData && (formData = new FormData());
+        parentReference = nextPartId++;
+        formData.set(formFieldPrefix + parentReference, key);
+        key = "$h" + parentReference.toString(16);
+        writtenObjects.set(value, key);
+        return key;
+      }
       if (
         void 0 !== temporaryReferences &&
         -1 === key.indexOf(":") &&
@@ -884,10 +887,17 @@ function waitForReference(
           value.then(fulfill, reject);
           return;
         }
-      value = value[path[i]];
+      var name = path[i];
+      if (
+        "object" === typeof value &&
+        null !== value &&
+        hasOwnProperty.call(value, name)
+      )
+        value = value[name];
+      else throw Error("Invalid reference.");
     }
     i = map(response, value, parentObject, key);
-    parentObject[key] = i;
+    "__proto__" !== key && (parentObject[key] = i);
     "" === key && null === handler.value && (handler.value = i);
     if (
       parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -967,7 +977,7 @@ function loadServerReference(response, metaData, parentObject, key) {
         boundArgs.unshift(null);
         resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
       }
-      parentObject[key] = resolvedValue;
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
       "" === key && null === handler.value && (handler.value = resolvedValue);
       if (
         parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1285,8 +1295,8 @@ function startReadableStream(response, id, type) {
             (previousBlockedChunk = chunk));
       } else {
         chunk = previousBlockedChunk;
-        var chunk$52 = createPendingChunk(response);
-        chunk$52.then(
+        var chunk$53 = createPendingChunk(response);
+        chunk$53.then(
           function (v) {
             return controller.enqueue(v);
           },
@@ -1294,10 +1304,10 @@ function startReadableStream(response, id, type) {
             return controller.error(e);
           }
         );
-        previousBlockedChunk = chunk$52;
+        previousBlockedChunk = chunk$53;
         chunk.then(function () {
-          previousBlockedChunk === chunk$52 && (previousBlockedChunk = null);
-          resolveModelChunk(chunk$52, json);
+          previousBlockedChunk === chunk$53 && (previousBlockedChunk = null);
+          resolveModelChunk(chunk$53, json);
         });
       }
     },
@@ -1432,8 +1442,8 @@ function mergeBuffer(buffer, lastChunk) {
   for (var l = buffer.length, byteLength = lastChunk.length, i = 0; i < l; i++)
     byteLength += buffer[i].byteLength;
   byteLength = new Uint8Array(byteLength);
-  for (var i$53 = (i = 0); i$53 < l; i$53++) {
-    var chunk = buffer[i$53];
+  for (var i$54 = (i = 0); i$54 < l; i$54++) {
+    var chunk = buffer[i$54];
     byteLength.set(chunk, i);
     i += chunk.byteLength;
   }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
@@ -422,6 +422,11 @@
         return "$" + (iterable ? "x" : "X") + streamId.toString(16);
       }
       function resolveToJSON(key, value) {
+        "__proto__" === key &&
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(this, key)
+          );
         var originalValue = this[key];
         "object" !== typeof originalValue ||
           originalValue === value ||
@@ -666,14 +671,17 @@
         if ("undefined" === typeof value) return "$undefined";
         if ("function" === typeof value) {
           parentReference = knownServerReferences.get(value);
-          if (void 0 !== parentReference)
-            return (
-              (key = JSON.stringify(parentReference, resolveToJSON)),
-              null === formData && (formData = new FormData()),
-              (parentReference = nextPartId++),
-              formData.set(formFieldPrefix + parentReference, key),
-              "$h" + parentReference.toString(16)
-            );
+          if (void 0 !== parentReference) {
+            key = writtenObjects.get(value);
+            if (void 0 !== key) return key;
+            key = JSON.stringify(parentReference, resolveToJSON);
+            null === formData && (formData = new FormData());
+            parentReference = nextPartId++;
+            formData.set(formFieldPrefix + parentReference, key);
+            key = "$h" + parentReference.toString(16);
+            writtenObjects.set(value, key);
+            return key;
+          }
           if (
             void 0 !== temporaryReferences &&
             -1 === key.indexOf(":") &&
@@ -1279,10 +1287,17 @@
               value.then(fulfill, reject);
               return;
             }
-          value = value[path[i]];
+          var name = path[i];
+          if (
+            "object" === typeof value &&
+            null !== value &&
+            hasOwnProperty.call(value, name)
+          )
+            value = value[name];
+          else throw Error("Invalid reference.");
         }
         i = map(response, value, parentObject, key);
-        parentObject[key] = i;
+        "__proto__" !== key && (parentObject[key] = i);
         "" === key && null === handler.value && (handler.value = i);
         if (
           parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1375,7 +1390,7 @@
             boundArgs.unshift(null);
             resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
           }
-          parentObject[key] = resolvedValue;
+          "__proto__" !== key && (parentObject[key] = resolvedValue);
           "" === key &&
             null === handler.value &&
             (handler.value = resolvedValue);
@@ -1633,14 +1648,15 @@
             }
           case "Y":
             return (
-              Object.defineProperty(parentObject, key, {
-                get: function () {
-                  return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
-                },
-                set: function () {},
-                enumerable: !0,
-                configurable: !1
-              }),
+              "__proto__" !== key &&
+                Object.defineProperty(parentObject, key, {
+                  get: function () {
+                    return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
+                  },
+                  set: function () {},
+                  enumerable: !0,
+                  configurable: !1
+                }),
               null
             );
           default:

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
@@ -423,14 +423,17 @@ function processReply(
     if ("undefined" === typeof value) return "$undefined";
     if ("function" === typeof value) {
       parentReference = knownServerReferences.get(value);
-      if (void 0 !== parentReference)
-        return (
-          (key = JSON.stringify(parentReference, resolveToJSON)),
-          null === formData && (formData = new FormData()),
-          (parentReference = nextPartId++),
-          formData.set(formFieldPrefix + parentReference, key),
-          "$h" + parentReference.toString(16)
-        );
+      if (void 0 !== parentReference) {
+        key = writtenObjects.get(value);
+        if (void 0 !== key) return key;
+        key = JSON.stringify(parentReference, resolveToJSON);
+        null === formData && (formData = new FormData());
+        parentReference = nextPartId++;
+        formData.set(formFieldPrefix + parentReference, key);
+        key = "$h" + parentReference.toString(16);
+        writtenObjects.set(value, key);
+        return key;
+      }
       if (
         void 0 !== temporaryReferences &&
         -1 === key.indexOf(":") &&
@@ -850,10 +853,17 @@ function waitForReference(
           value.then(fulfill, reject);
           return;
         }
-      value = value[path[i]];
+      var name = path[i];
+      if (
+        "object" === typeof value &&
+        null !== value &&
+        hasOwnProperty.call(value, name)
+      )
+        value = value[name];
+      else throw Error("Invalid reference.");
     }
     i = map(response, value, parentObject, key);
-    parentObject[key] = i;
+    "__proto__" !== key && (parentObject[key] = i);
     "" === key && null === handler.value && (handler.value = i);
     if (
       parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -933,7 +943,7 @@ function loadServerReference(response, metaData, parentObject, key) {
         boundArgs.unshift(null);
         resolvedValue = resolvedValue.bind.apply(resolvedValue, boundArgs);
       }
-      parentObject[key] = resolvedValue;
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
       "" === key && null === handler.value && (handler.value = resolvedValue);
       if (
         parentObject[0] === REACT_ELEMENT_TYPE &&
@@ -1251,8 +1261,8 @@ function startReadableStream(response, id, type) {
             (previousBlockedChunk = chunk));
       } else {
         chunk = previousBlockedChunk;
-        var chunk$52 = createPendingChunk(response);
-        chunk$52.then(
+        var chunk$53 = createPendingChunk(response);
+        chunk$53.then(
           function (v) {
             return controller.enqueue(v);
           },
@@ -1260,10 +1270,10 @@ function startReadableStream(response, id, type) {
             return controller.error(e);
           }
         );
-        previousBlockedChunk = chunk$52;
+        previousBlockedChunk = chunk$53;
         chunk.then(function () {
-          previousBlockedChunk === chunk$52 && (previousBlockedChunk = null);
-          resolveModelChunk(chunk$52, json);
+          previousBlockedChunk === chunk$53 && (previousBlockedChunk = null);
+          resolveModelChunk(chunk$53, json);
         });
       }
     },
@@ -1398,8 +1408,8 @@ function mergeBuffer(buffer, lastChunk) {
   for (var l = buffer.length, byteLength = lastChunk.length, i = 0; i < l; i++)
     byteLength += buffer[i].byteLength;
   byteLength = new Uint8Array(byteLength);
-  for (var i$53 = (i = 0); i$53 < l; i$53++) {
-    var chunk = buffer[i$53];
+  for (var i$54 = (i = 0); i$54 < l; i$54++) {
+    var chunk = buffer[i$54];
     byteLength.set(chunk, i);
     i += chunk.byteLength;
   }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -357,7 +357,8 @@ class ReactFlightWebpackPlugin {
                     const file = _step.value;
                     if (
                       file.endsWith(".js") &&
-                      !file.endsWith(".hot-update.js")
+                      !file.endsWith(".hot-update.js") &&
+                      (_this.isServer || !runtimeChunkFiles.has(file))
                     ) {
                       chunks.push(c.id, file);
                       break;

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
@@ -1458,6 +1458,13 @@
       value
     ) {
       task.model = value;
+      parentPropertyName === __PROTO__$1 &&
+        callWithDebugContextInDEV(request, task, function () {
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(parent, parentPropertyName)
+          );
+        });
       if (value === REACT_ELEMENT_TYPE) return "$";
       if (null === value) return null;
       if ("object" === typeof value) {
@@ -1628,7 +1635,7 @@
         if (value instanceof Date) return "$D" + value.toJSON();
         elementReference = getPrototypeOf(value);
         if (
-          elementReference !== ObjectPrototype &&
+          elementReference !== ObjectPrototype$1 &&
           (null === elementReference ||
             null !== getPrototypeOf(elementReference))
         )
@@ -2515,12 +2522,12 @@
       this.value = value;
       this.reason = reason;
     }
-    function wakeChunk(response, listeners, value) {
+    function wakeChunk(response, listeners, value, chunk) {
       for (var i = 0; i < listeners.length; i++) {
         var listener = listeners[i];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, chunk.reason);
       }
     }
     function rejectChunk(response, listeners, error) {
@@ -2530,27 +2537,6 @@
           ? listener(error)
           : rejectReference(response, listener.handler, error);
       }
-    }
-    function resolveBlockedCycle(resolvedChunk, reference) {
-      var referencedChunk = reference.handler.chunk;
-      if (null === referencedChunk) return null;
-      if (referencedChunk === resolvedChunk) return reference.handler;
-      reference = referencedChunk.value;
-      if (null !== reference)
-        for (
-          referencedChunk = 0;
-          referencedChunk < reference.length;
-          referencedChunk++
-        ) {
-          var listener = reference[referencedChunk];
-          if (
-            "function" !== typeof listener &&
-            ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-            null !== listener)
-          )
-            return listener;
-        }
-      return null;
     }
     function triggerErrorOnChunk(response, chunk, error) {
       if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2575,57 +2561,25 @@
         chunk.value = value;
         chunk.reason = _defineProperty({ id: id }, RESPONSE_SYMBOL, response);
         if (null !== resolveListeners)
-          a: switch ((initializeModelChunk(chunk), chunk.status)) {
+          switch ((initializeModelChunk(chunk), chunk.status)) {
             case "fulfilled":
-              wakeChunk(response, resolveListeners, chunk.value);
+              wakeChunk(response, resolveListeners, chunk.value, chunk);
               break;
             case "blocked":
-              for (value = 0; value < resolveListeners.length; value++)
-                if (
-                  ((id = resolveListeners[value]), "function" !== typeof id)
-                ) {
-                  var cyclicHandler = resolveBlockedCycle(chunk, id);
-                  if (null !== cyclicHandler)
-                    switch (
-                      (fulfillReference(response, id, cyclicHandler.value),
-                      resolveListeners.splice(value, 1),
-                      value--,
-                      null !== rejectListeners &&
-                        ((id = rejectListeners.indexOf(id)),
-                        -1 !== id && rejectListeners.splice(id, 1)),
-                      chunk.status)
-                    ) {
-                      case "fulfilled":
-                        wakeChunk(response, resolveListeners, chunk.value);
-                        break a;
-                      case "rejected":
-                        null !== rejectListeners &&
-                          rejectChunk(response, rejectListeners, chunk.reason);
-                        break a;
-                    }
-                }
             case "pending":
               if (chunk.value)
-                for (
-                  response = 0;
-                  response < resolveListeners.length;
-                  response++
-                )
-                  chunk.value.push(resolveListeners[response]);
+                for (value = 0; value < resolveListeners.length; value++)
+                  chunk.value.push(resolveListeners[value]);
               else chunk.value = resolveListeners;
               if (chunk.reason) {
                 if (rejectListeners)
-                  for (
-                    resolveListeners = 0;
-                    resolveListeners < rejectListeners.length;
-                    resolveListeners++
-                  )
-                    chunk.reason.push(rejectListeners[resolveListeners]);
+                  for (value = 0; value < rejectListeners.length; value++)
+                    chunk.reason.push(rejectListeners[value]);
               } else chunk.reason = rejectListeners;
               break;
             case "rejected":
               rejectListeners &&
-                wakeChunk(response, rejectListeners, chunk.reason);
+                rejectChunk(response, rejectListeners, chunk.reason);
           }
       }
     }
@@ -2649,15 +2603,51 @@
       );
     }
     function loadServerReference$1(response, metaData, parentObject, key) {
+      function reject(error) {
+        var rejectListeners = blockedPromise.reason,
+          erroredPromise = blockedPromise;
+        erroredPromise.status = "rejected";
+        erroredPromise.value = null;
+        erroredPromise.reason = error;
+        null !== rejectListeners &&
+          rejectChunk(response, rejectListeners, error);
+        rejectReference(response, handler, error);
+      }
       var id = metaData.id;
       if ("string" !== typeof id || "then" === key) return null;
+      var cachedPromise = metaData.$$promise;
+      if (void 0 !== cachedPromise) {
+        if ("fulfilled" === cachedPromise.status)
+          return (
+            (cachedPromise = cachedPromise.value),
+            "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+          );
+        initializingHandler
+          ? ((id = initializingHandler), id.deps++)
+          : (id = initializingHandler =
+              { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+        cachedPromise.then(
+          resolveReference.bind(null, response, id, parentObject, key),
+          rejectReference.bind(null, response, id)
+        );
+        return null;
+      }
+      var blockedPromise = new ReactPromise("blocked", null, null);
+      metaData.$$promise = blockedPromise;
       var serverReference = resolveServerReference(response._bundlerConfig, id);
-      id = metaData.bound;
-      var promise = preloadModule(serverReference);
-      if (promise)
-        id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-      else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-      else return requireModule(serverReference);
+      cachedPromise = metaData.bound;
+      if ((id = preloadModule(serverReference)))
+        cachedPromise instanceof ReactPromise &&
+          (id = Promise.all([id, cachedPromise]));
+      else if (cachedPromise instanceof ReactPromise)
+        id = Promise.resolve(cachedPromise);
+      else
+        return (
+          (cachedPromise = requireModule(serverReference)),
+          (id = blockedPromise),
+          (id.status = "fulfilled"),
+          (id.value = cachedPromise)
+        );
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -2669,92 +2659,106 @@
           deps: 1,
           errored: !1
         };
-      promise.then(
-        function () {
-          var resolvedValue = requireModule(serverReference);
-          if (metaData.bound) {
-            var promiseValue = metaData.bound.value;
-            promiseValue = Array.isArray(promiseValue)
-              ? promiseValue.slice(0)
-              : [];
-            promiseValue.unshift(null);
-            resolvedValue = resolvedValue.bind.apply(
-              resolvedValue,
-              promiseValue
+      id.then(function () {
+        var resolvedValue = requireModule(serverReference);
+        if (metaData.bound) {
+          var promiseValue = metaData.bound.value;
+          promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+          if (promiseValue.length > MAX_BOUND_ARGS) {
+            reject(
+              Error(
+                "Server Function has too many bound arguments. Received " +
+                  promiseValue.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              )
             );
+            return;
           }
-          parentObject[key] = resolvedValue;
-          "" === key &&
-            null === handler.value &&
-            (handler.value = resolvedValue);
-          handler.deps--;
-          0 === handler.deps &&
-            ((resolvedValue = handler.chunk),
-            null !== resolvedValue &&
-              "blocked" === resolvedValue.status &&
-              ((promiseValue = resolvedValue.value),
-              (resolvedValue.status = "fulfilled"),
-              (resolvedValue.value = handler.value),
-              (resolvedValue.reason = null),
-              null !== promiseValue &&
-                wakeChunk(response, promiseValue, handler.value)));
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+          promiseValue.unshift(null);
+          resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
         }
-      );
+        promiseValue = blockedPromise.value;
+        var initializedPromise = blockedPromise;
+        initializedPromise.status = "fulfilled";
+        initializedPromise.value = resolvedValue;
+        initializedPromise.reason = null;
+        null !== promiseValue &&
+          wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+        resolveReference(response, handler, parentObject, key, resolvedValue);
+      }, reject);
       return null;
     }
-    function reviveModel(response, parentObj, parentKey, value, reference) {
+    function reviveModel(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    ) {
       if ("string" === typeof value)
         return parseModelString(
           response,
           parentObj,
           parentKey,
           value,
-          reference
+          reference,
+          arrayRoot
         );
       if ("object" === typeof value && null !== value)
         if (
           (void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
             response._temporaryReferences.set(value, reference),
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
+          isArrayImpl(value))
+        ) {
+          if (null === arrayRoot) {
+            var childContext = { count: 0, fork: !1 };
+            response._rootArrayContexts.set(value, childContext);
+          } else childContext = arrayRoot;
+          1 < value.length && (childContext.fork = !0);
+          bumpArrayCount(childContext, value.length + 1, response);
+          for (parentObj = 0; parentObj < value.length; parentObj++)
+            value[parentObj] = reviveModel(
               response,
               value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
+              "" + parentObj,
+              value[parentObj],
+              void 0 !== reference ? reference + ":" + parentObj : void 0,
+              childContext
             );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj || "__proto__" === i
-                ? (value[i] = parentObj)
-                : delete value[i]);
+        } else
+          for (childContext in value)
+            hasOwnProperty.call(value, childContext) &&
+              ("__proto__" === childContext
+                ? delete value[childContext]
+                : ((parentObj =
+                    void 0 !== reference && -1 === childContext.indexOf(":")
+                      ? reference + ":" + childContext
+                      : void 0),
+                  (parentObj = reviveModel(
+                    response,
+                    value,
+                    childContext,
+                    value[childContext],
+                    parentObj,
+                    null
+                  )),
+                  void 0 !== parentObj
+                    ? (value[childContext] = parentObj)
+                    : delete value[childContext]));
       return value;
+    }
+    function bumpArrayCount(arrayContext, slots, response) {
+      if (
+        (arrayContext.count += slots) > response._arraySizeLimit &&
+        arrayContext.fork
+      )
+        throw Error(
+          "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+        );
     }
     function initializeModelChunk(chunk) {
       var prevHandler = initializingHandler;
@@ -2769,13 +2773,15 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var rawModel = JSON.parse(resolvedModel),
-          value = reviveModel(
+        var rawModel = JSON.parse(resolvedModel);
+        resolvedModel = { count: 0, fork: !1 };
+        var value = reviveModel(
             response,
             { "": rawModel },
             "",
             rawModel,
-            _chunk$reason
+            _chunk$reason,
+            resolvedModel
           ),
           resolveListeners = chunk.value;
         if (null !== resolveListeners)
@@ -2787,19 +2793,20 @@
             var listener = resolveListeners[rawModel];
             "function" === typeof listener
               ? listener(value)
-              : fulfillReference(response, listener, value);
+              : fulfillReference(response, listener, value, resolvedModel);
           }
         if (null !== initializingHandler) {
           if (initializingHandler.errored) throw initializingHandler.reason;
           if (0 < initializingHandler.deps) {
             initializingHandler.value = value;
+            initializingHandler.reason = resolvedModel;
             initializingHandler.chunk = chunk;
             return;
           }
         }
         chunk.status = "fulfilled";
         chunk.value = value;
-        chunk.reason = null;
+        chunk.reason = resolvedModel;
       } catch (error) {
         (chunk.status = "rejected"), (chunk.reason = error);
       } finally {
@@ -2812,7 +2819,8 @@
           ? triggerErrorOnChunk(response, chunk, error)
           : "fulfilled" === chunk.status &&
             null !== chunk.reason &&
-            chunk.reason.error(error);
+            ((chunk = chunk.reason),
+            "function" === typeof chunk.error && chunk.error(error));
       });
     }
     function getChunk(response, id) {
@@ -2831,40 +2839,74 @@
         chunks.set(id, chunk));
       return chunk;
     }
-    function fulfillReference(response, reference, value) {
+    function fulfillReference(response, reference, value, arrayRoot) {
       var handler = reference.handler,
         parentObject = reference.parentObject,
         key = reference.key,
         map = reference.map,
         path = reference.path;
       try {
-        for (var i = 1; i < path.length; i++) {
+        for (
+          var localLength = 0,
+            rootArrayContexts = response._rootArrayContexts,
+            i = 1;
+          i < path.length;
+          i++
+        ) {
           var name = path[i];
           if (
             "object" !== typeof value ||
-            !hasOwnProperty.call(value, name) ||
-            value instanceof Promise
+            null === value ||
+            (getPrototypeOf(value) !== ObjectPrototype &&
+              getPrototypeOf(value) !== ArrayPrototype) ||
+            !hasOwnProperty.call(value, name)
           )
             throw Error("Invalid reference.");
           value = value[name];
+          if (isArrayImpl(value))
+            (localLength = 0),
+              (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+          else if (((arrayRoot = null), "string" === typeof value))
+            localLength = value.length;
+          else if ("bigint" === typeof value) {
+            var n = Math.abs(Number(value));
+            localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+          } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
         }
-        var mappedValue = map(response, value, parentObject, key);
-        parentObject[key] = mappedValue;
-        "" === key && null === handler.value && (handler.value = mappedValue);
+        var resolvedValue = map(response, value, parentObject, key);
+        var referenceArrayRoot = reference.arrayRoot;
+        null !== referenceArrayRoot &&
+          (null !== arrayRoot
+            ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+              bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+            : 0 < localLength &&
+              bumpArrayCount(referenceArrayRoot, localLength, response));
       } catch (error) {
-        rejectReference(response, reference.handler, error);
+        rejectReference(response, handler, error);
         return;
       }
+      resolveReference(response, handler, parentObject, key, resolvedValue);
+    }
+    function resolveReference(
+      response,
+      handler,
+      parentObject,
+      key,
+      resolvedValue
+    ) {
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
+      "" === key && null === handler.value && (handler.value = resolvedValue);
       handler.deps--;
       0 === handler.deps &&
-        ((reference = handler.chunk),
-        null !== reference &&
-          "blocked" === reference.status &&
-          ((value = reference.value),
-          (reference.status = "fulfilled"),
-          (reference.value = handler.value),
-          (reference.reason = handler.reason),
-          null !== value && wakeChunk(response, value, handler.value)));
+        ((parentObject = handler.chunk),
+        null !== parentObject &&
+          "blocked" === parentObject.status &&
+          ((key = parentObject.value),
+          (parentObject.status = "fulfilled"),
+          (parentObject.value = handler.value),
+          (parentObject.reason = handler.reason),
+          null !== key &&
+            wakeChunk(response, key, handler.value, parentObject)));
     }
     function rejectReference(response, handler, error) {
       handler.errored ||
@@ -2876,29 +2918,66 @@
           "blocked" === handler.status &&
           triggerErrorOnChunk(response, handler, error));
     }
-    function getOutlinedModel(response, reference, parentObject, key, map) {
+    function getOutlinedModel(
+      response,
+      reference,
+      parentObject,
+      key,
+      referenceArrayRoot,
+      map
+    ) {
       reference = reference.split(":");
-      var id = parseInt(reference[0], 16);
-      id = getChunk(response, id);
-      switch (id.status) {
+      var id = parseInt(reference[0], 16),
+        chunk = getChunk(response, id);
+      switch (chunk.status) {
         case "resolved_model":
-          initializeModelChunk(id);
+          initializeModelChunk(chunk);
       }
-      switch (id.status) {
+      switch (chunk.status) {
         case "fulfilled":
-          id = id.value;
-          for (var i = 1; i < reference.length; i++) {
-            var name = reference[i];
+          id = chunk.value;
+          chunk = chunk.reason;
+          for (
+            var localLength = 0,
+              rootArrayContexts = response._rootArrayContexts,
+              i = 1;
+            i < reference.length;
+            i++
+          ) {
+            localLength = reference[i];
             if (
               "object" !== typeof id ||
-              !hasOwnProperty.call(id, name) ||
-              id instanceof Promise
+              null === id ||
+              (getPrototypeOf(id) !== ObjectPrototype &&
+                getPrototypeOf(id) !== ArrayPrototype) ||
+              !hasOwnProperty.call(id, localLength)
             )
               throw Error("Invalid reference.");
-            id = id[name];
+            id = id[localLength];
+            isArrayImpl(id)
+              ? ((localLength = 0),
+                (chunk = rootArrayContexts.get(id) || chunk))
+              : ((chunk = null),
+                "string" === typeof id
+                  ? (localLength = id.length)
+                  : "bigint" === typeof id
+                    ? ((localLength = Math.abs(Number(id))),
+                      (localLength =
+                        0 === localLength
+                          ? 1
+                          : Math.floor(Math.log10(localLength)) + 1))
+                    : (localLength = ArrayBuffer.isView(id)
+                        ? id.byteLength
+                        : 0));
           }
-          return map(response, id, parentObject, key);
-        case "pending":
+          parentObject = map(response, id, parentObject, key);
+          null !== referenceArrayRoot &&
+            (null !== chunk
+              ? (chunk.fork && (referenceArrayRoot.fork = !0),
+                bumpArrayCount(referenceArrayRoot, chunk.count, response))
+              : 0 < localLength &&
+                bumpArrayCount(referenceArrayRoot, localLength, response));
+          return parentObject;
         case "blocked":
           return (
             initializingHandler
@@ -2911,31 +2990,34 @@
                     deps: 1,
                     errored: !1
                   }),
-            (parentObject = {
+            (referenceArrayRoot = {
               handler: response,
               parentObject: parentObject,
               key: key,
               map: map,
-              path: reference
+              path: reference,
+              arrayRoot: referenceArrayRoot
             }),
-            null === id.value
-              ? (id.value = [parentObject])
-              : id.value.push(parentObject),
-            null === id.reason
-              ? (id.reason = [parentObject])
-              : id.reason.push(parentObject),
+            null === chunk.value
+              ? (chunk.value = [referenceArrayRoot])
+              : chunk.value.push(referenceArrayRoot),
+            null === chunk.reason
+              ? (chunk.reason = [referenceArrayRoot])
+              : chunk.reason.push(referenceArrayRoot),
             null
           );
+        case "pending":
+          throw Error("Invalid forward reference.");
         default:
           return (
             initializingHandler
               ? ((initializingHandler.errored = !0),
                 (initializingHandler.value = null),
-                (initializingHandler.reason = id.reason))
+                (initializingHandler.reason = chunk.reason))
               : (initializingHandler = {
                   chunk: null,
                   value: null,
-                  reason: id.reason,
+                  reason: chunk.reason,
                   deps: 0,
                   errored: !0
                 }),
@@ -2944,13 +3026,25 @@
       }
     }
     function createMap(response, model) {
-      return new Map(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+      response = new Map(model);
+      model.$$consumed = !0;
+      return response;
     }
     function createSet(response, model) {
-      return new Set(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+      response = new Set(model);
+      model.$$consumed = !0;
+      return response;
     }
     function extractIterator(response, model) {
-      return model[Symbol.iterator]();
+      if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+      response = model[Symbol.iterator]();
+      model.$$consumed = !0;
+      return response;
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -2961,13 +3055,34 @@
       constructor,
       bytesPerElement,
       parentObject,
-      parentKey
+      parentKey,
+      referenceArrayRoot
     ) {
+      function reject(error) {
+        if (!handler.errored) {
+          handler.errored = !0;
+          handler.value = null;
+          handler.reason = error;
+          var chunk = handler.chunk;
+          null !== chunk &&
+            "blocked" === chunk.status &&
+            triggerErrorOnChunk(response, chunk, error);
+        }
+      }
       reference = parseInt(reference.slice(2), 16);
-      bytesPerElement = response._prefix + reference;
-      if (response._chunks.has(reference))
+      var key = response._prefix + reference;
+      bytesPerElement = response._chunks;
+      if (bytesPerElement.has(reference))
         throw Error("Already initialized typed array.");
-      reference = response._formData.get(bytesPerElement).arrayBuffer();
+      bytesPerElement.set(
+        reference,
+        new ReactPromise(
+          "rejected",
+          null,
+          Error("Already initialized typed array.")
+        )
+      );
+      reference = response._formData.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -2979,40 +3094,32 @@
           deps: 1,
           errored: !1
         };
-      reference.then(
-        function (buffer) {
-          buffer =
+      reference.then(function (buffer) {
+        try {
+          null !== referenceArrayRoot &&
+            bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+          var resolvedValue =
             constructor === ArrayBuffer ? buffer : new constructor(buffer);
-          parentObject[parentKey] = buffer;
+          "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
           "" === parentKey &&
             null === handler.value &&
-            (handler.value = buffer);
-          handler.deps--;
-          if (
-            0 === handler.deps &&
-            ((buffer = handler.chunk),
-            null !== buffer && "blocked" === buffer.status)
-          ) {
-            var resolveListeners = buffer.value;
-            buffer.status = "fulfilled";
-            buffer.value = handler.value;
-            buffer.reason = null;
-            null !== resolveListeners &&
-              wakeChunk(response, resolveListeners, handler.value);
-          }
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+            (handler.value = resolvedValue);
+        } catch (x) {
+          reject(x);
+          return;
         }
-      );
+        handler.deps--;
+        0 === handler.deps &&
+          ((buffer = handler.chunk),
+          null !== buffer &&
+            "blocked" === buffer.status &&
+            ((resolvedValue = buffer.value),
+            (buffer.status = "fulfilled"),
+            (buffer.value = handler.value),
+            (buffer.reason = null),
+            null !== resolvedValue &&
+              wakeChunk(response, resolvedValue, handler.value, buffer)));
+      }, reject);
       return null;
     }
     function resolveStream(response, id, stream, controller) {
@@ -3030,90 +3137,78 @@
               : controller.enqueueModel(chunks));
     }
     function parseReadableStream(response, reference, type) {
+      function enqueue(value) {
+        "bytes" !== type || ArrayBuffer.isView(value)
+          ? controller.enqueue(value)
+          : flightController.error(Error("Invalid data for bytes stream."));
+      }
       reference = parseInt(reference.slice(2), 16);
       if (response._chunks.has(reference))
         throw Error("Already initialized stream.");
       var controller = null,
-        closed = !1;
-      type = new ReadableStream({
-        type: type,
-        start: function (c) {
-          controller = c;
-        }
-      });
-      var previousBlockedChunk = null;
-      resolveStream(response, reference, type, {
-        enqueueModel: function (json) {
-          if (null === previousBlockedChunk) {
-            var chunk = new ReactPromise(
-              "resolved_model",
-              json,
-              _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
-            );
-            initializeModelChunk(chunk);
-            "fulfilled" === chunk.status
-              ? controller.enqueue(chunk.value)
-              : (chunk.then(
-                  function (v) {
-                    return controller.enqueue(v);
-                  },
-                  function (e) {
-                    return controller.error(e);
-                  }
-                ),
-                (previousBlockedChunk = chunk));
-          } else {
-            chunk = previousBlockedChunk;
-            var _chunk = new ReactPromise("pending", null, null);
-            _chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            );
-            previousBlockedChunk = _chunk;
-            chunk.then(function () {
-              previousBlockedChunk === _chunk && (previousBlockedChunk = null);
-              resolveModelChunk(response, _chunk, json, -1);
-            });
+        closed = !1,
+        stream = new ReadableStream({
+          type: type,
+          start: function (c) {
+            controller = c;
           }
-        },
-        close: function () {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.close();
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.close();
+        }),
+        previousBlockedChunk = null,
+        flightController = {
+          enqueueModel: function (json) {
+            if (null === previousBlockedChunk) {
+              var chunk = new ReactPromise(
+                "resolved_model",
+                json,
+                _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
+              );
+              initializeModelChunk(chunk);
+              "fulfilled" === chunk.status
+                ? enqueue(chunk.value)
+                : (chunk.then(enqueue, flightController.error),
+                  (previousBlockedChunk = chunk));
+            } else {
+              chunk = previousBlockedChunk;
+              var _chunk = new ReactPromise("pending", null, null);
+              _chunk.then(enqueue, flightController.error);
+              previousBlockedChunk = _chunk;
+              chunk.then(function () {
+                previousBlockedChunk === _chunk &&
+                  (previousBlockedChunk = null);
+                resolveModelChunk(response, _chunk, json, -1);
               });
             }
-        },
-        error: function (error) {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.error(error);
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.error(error);
-              });
-            }
-        }
-      });
-      return type;
+          },
+          close: function () {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.close();
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.close();
+                });
+              }
+          },
+          error: function (error) {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.error(error);
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.error(error);
+                });
+              }
+          }
+        };
+      resolveStream(response, reference, stream, flightController);
+      return stream;
     }
-    function asyncIterator() {
-      return this;
-    }
-    function createIterator(next) {
-      next = { next: next };
-      next[ASYNC_ITERATOR] = asyncIterator;
-      return next;
+    function FlightIterator(next) {
+      this.next = next;
     }
     function parseAsyncIterable(response, reference, iterator) {
       reference = parseInt(reference.slice(2), 16);
@@ -3124,7 +3219,7 @@
         nextWriteIndex = 0,
         iterable = _defineProperty({}, ASYNC_ITERATOR, function () {
           var nextReadIndex = 0;
-          return createIterator(function (arg) {
+          return new FlightIterator(function (arg) {
             if (void 0 !== arg)
               throw Error(
                 "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -3203,19 +3298,30 @@
       });
       return iterator;
     }
-    function parseModelString(response, obj, key, value, reference) {
+    function parseModelString(response, obj, key, value, reference, arrayRoot) {
       if ("$" === value[0]) {
         switch (value[1]) {
           case "$":
-            return value.slice(1);
+            return (
+              null !== arrayRoot &&
+                bumpArrayCount(arrayRoot, value.length - 1, response),
+              value.slice(1)
+            );
           case "@":
             return (
               (obj = parseInt(value.slice(2), 16)), getChunk(response, obj)
             );
           case "h":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, loadServerReference$1)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                loadServerReference$1
+              )
             );
           case "T":
             if (
@@ -3231,27 +3337,44 @@
             );
           case "Q":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createMap)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
             );
           case "W":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createSet)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
             obj = value.slice(2);
-            var formPrefix = response._prefix + obj + "_",
-              data = new FormData();
-            response._formData.forEach(function (entry, entryKey) {
-              entryKey.startsWith(formPrefix) &&
-                data.append(entryKey.slice(formPrefix.length), entry);
-            });
-            return data;
+            obj = response._prefix + obj + "_";
+            key = new FormData();
+            response = response._formData;
+            arrayRoot = Array.from(response.keys());
+            for (value = 0; value < arrayRoot.length; value++)
+              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+                for (
+                  var entries = response.getAll(reference),
+                    newKey = reference.slice(obj.length),
+                    j = 0;
+                  j < entries.length;
+                  j++
+                )
+                  key.append(newKey, entries[j]);
+                response.delete(reference);
+              }
+            return key;
           case "i":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, extractIterator)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                extractIterator
+              )
             );
           case "I":
             return Infinity;
@@ -3264,15 +3387,50 @@
           case "D":
             return new Date(Date.parse(value.slice(2)));
           case "n":
-            return BigInt(value.slice(2));
+            obj = value.slice(2);
+            if (obj.length > MAX_BIGINT_DIGITS)
+              throw Error(
+                "BigInt is too large. Received " +
+                  obj.length +
+                  " digits but the limit is " +
+                  MAX_BIGINT_DIGITS +
+                  "."
+              );
+            null !== arrayRoot &&
+              bumpArrayCount(arrayRoot, obj.length, response);
+            return BigInt(obj);
         }
         switch (value[1]) {
           case "A":
-            return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              ArrayBuffer,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "O":
-            return parseTypedArray(response, value, Int8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "o":
-            return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "U":
             return parseTypedArray(
               response,
@@ -3280,22 +3438,79 @@
               Uint8ClampedArray,
               1,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "S":
-            return parseTypedArray(response, value, Int16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "s":
-            return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "L":
-            return parseTypedArray(response, value, Int32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "l":
-            return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "G":
-            return parseTypedArray(response, value, Float32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "g":
-            return parseTypedArray(response, value, Float64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "M":
-            return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              BigInt64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "m":
             return parseTypedArray(
               response,
@@ -3303,10 +3518,19 @@
               BigUint64Array,
               8,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "V":
-            return parseTypedArray(response, value, DataView, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              DataView,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
@@ -3324,8 +3548,16 @@
             return parseAsyncIterable(response, value, !0);
         }
         value = value.slice(1);
-        return getOutlinedModel(response, value, obj, key, createModel);
+        return getOutlinedModel(
+          response,
+          value,
+          obj,
+          key,
+          arrayRoot,
+          createModel
+        );
       }
+      null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
       return value;
     }
     function createResponse(
@@ -3337,25 +3569,40 @@
           3 < arguments.length && void 0 !== arguments[3]
             ? arguments[3]
             : new FormData(),
+        arraySizeLimit =
+          4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
         chunks = new Map();
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
         _formData: backingFormData,
         _chunks: chunks,
-        _temporaryReferences: temporaryReferences
+        _temporaryReferences: temporaryReferences,
+        _rootArrayContexts: new WeakMap(),
+        _arraySizeLimit: arraySizeLimit
       };
     }
     function close(response) {
       reportGlobalError(response, Error("Connection closed."));
     }
-    function loadServerReference(bundlerConfig, id, bound) {
+    function loadServerReference(bundlerConfig, metaData) {
+      var id = metaData.id;
+      if ("string" !== typeof id) return null;
       var serverReference = resolveServerReference(bundlerConfig, id);
       bundlerConfig = preloadModule(serverReference);
-      return bound
-        ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+      metaData = metaData.bound;
+      return null !== metaData
+        ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
             _ref = _ref[0];
             var fn = requireModule(serverReference);
+            if (_ref.length > MAX_BOUND_ARGS)
+              throw Error(
+                "Server Function has too many bound arguments. Received " +
+                  _ref.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              );
             return fn.bind.apply(fn, [null].concat(_ref));
           })
         : bundlerConfig
@@ -3364,8 +3611,19 @@
             })
           : Promise.resolve(requireModule(serverReference));
     }
-    function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-      body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+    function decodeBoundActionMetaData(
+      body,
+      serverManifest,
+      formFieldPrefix,
+      arraySizeLimit
+    ) {
+      body = createResponse(
+        serverManifest,
+        formFieldPrefix,
+        void 0,
+        body,
+        arraySizeLimit
+      );
       close(body);
       body = getChunk(body, 0);
       body.then(function () {});
@@ -3791,13 +4049,14 @@
       patchConsole(console, "table"),
       patchConsole(console, "trace"),
       patchConsole(console, "warn"));
-    var ObjectPrototype = Object.prototype,
+    var ObjectPrototype$1 = Object.prototype,
       stringify = JSON.stringify,
       PENDING$1 = 0,
       COMPLETED = 1,
       ABORTED = 3,
       ERRORED$1 = 4,
       RENDERING = 5,
+      __PROTO__$1 = "__proto__",
       OPENING = 10,
       ABORTING = 12,
       CLOSING = 13,
@@ -3828,16 +4087,23 @@
         case "fulfilled":
           if ("function" === typeof resolve) {
             for (
-              var inspectedValue = this.value, cycleProtection = 0;
+              var inspectedValue = this.value,
+                cycleProtection = 0,
+                visited = new Set();
               inspectedValue instanceof ReactPromise;
 
             ) {
               cycleProtection++;
-              if (inspectedValue === this || 1e3 < cycleProtection) {
+              if (
+                inspectedValue === this ||
+                visited.has(inspectedValue) ||
+                1e3 < cycleProtection
+              ) {
                 "function" === typeof reject &&
                   reject(Error("Cannot have cyclic thenables."));
                 return;
               }
+              visited.add(inspectedValue);
               if ("fulfilled" === inspectedValue.status)
                 inspectedValue = inspectedValue.value;
               else break;
@@ -3858,7 +4124,15 @@
           "function" === typeof reject && reject(this.reason);
       }
     };
-    var initializingHandler = null;
+    var ObjectPrototype = Object.prototype,
+      ArrayPrototype = Array.prototype,
+      initializingHandler = null;
+    FlightIterator.prototype = {};
+    FlightIterator.prototype[ASYNC_ITERATOR] = function () {
+      return this;
+    };
+    var MAX_BIGINT_DIGITS = 300,
+      MAX_BOUND_ARGS = 1e3;
     exports.createClientModuleProxy = function (moduleId) {
       moduleId = registerClientReferenceImpl({}, moduleId, !1);
       return new Proxy(moduleId, proxyHandlers$1);
@@ -3868,20 +4142,24 @@
     };
     exports.decodeAction = function (body, serverManifest) {
       var formData = new FormData(),
-        action = null;
+        action = null,
+        seenActions = new Set();
       body.forEach(function (value, key) {
         key.startsWith("$ACTION_")
           ? key.startsWith("$ACTION_REF_")
-            ? ((value = "$ACTION_" + key.slice(12) + ":"),
+            ? seenActions.has(key) ||
+              (seenActions.add(key),
+              (value = "$ACTION_" + key.slice(12) + ":"),
               (value = decodeBoundActionMetaData(body, serverManifest, value)),
-              (action = loadServerReference(
-                serverManifest,
-                value.id,
-                value.bound
-              )))
+              (action = loadServerReference(serverManifest, value)))
             : key.startsWith("$ACTION_ID_") &&
-              ((value = key.slice(11)),
-              (action = loadServerReference(serverManifest, value, null)))
+              !seenActions.has(key) &&
+              (seenActions.add(key),
+              (value = key.slice(11)),
+              (action = loadServerReference(serverManifest, {
+                id: value,
+                bound: null
+              })))
           : formData.append(key, value);
       });
       return null === action
@@ -3917,7 +4195,8 @@
         webpackMap,
         "",
         options ? options.temporaryReferences : void 0,
-        body
+        body,
+        options ? options.arraySizeLimit : void 0
       );
       webpackMap = getChunk(body, 0);
       close(body);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.production.js
@@ -710,7 +710,7 @@ function describeObjectForErrorMessage(objectOrArray, expandedName) {
         "\n  " + str + "\n  " + objectOrArray)
       : "\n  " + str;
 }
-var ObjectPrototype = Object.prototype,
+var ObjectPrototype$1 = Object.prototype,
   stringify = JSON.stringify;
 function defaultErrorHandler(error) {
   console.error(error);
@@ -1529,7 +1529,7 @@ function renderModelDestructive(
     if (value instanceof Date) return "$D" + value.toJSON();
     request = getPrototypeOf(value);
     if (
-      request !== ObjectPrototype &&
+      request !== ObjectPrototype$1 &&
       (null === request || null !== getPrototypeOf(request))
     )
       throw Error(
@@ -2026,16 +2026,23 @@ ReactPromise.prototype.then = function (resolve, reject) {
     case "fulfilled":
       if ("function" === typeof resolve) {
         for (
-          var inspectedValue = this.value, cycleProtection = 0;
+          var inspectedValue = this.value,
+            cycleProtection = 0,
+            visited = new Set();
           inspectedValue instanceof ReactPromise;
 
         ) {
           cycleProtection++;
-          if (inspectedValue === this || 1e3 < cycleProtection) {
+          if (
+            inspectedValue === this ||
+            visited.has(inspectedValue) ||
+            1e3 < cycleProtection
+          ) {
             "function" === typeof reject &&
               reject(Error("Cannot have cyclic thenables."));
             return;
           }
+          visited.add(inspectedValue);
           if ("fulfilled" === inspectedValue.status)
             inspectedValue = inspectedValue.value;
           else break;
@@ -2054,12 +2061,14 @@ ReactPromise.prototype.then = function (resolve, reject) {
       "function" === typeof reject && reject(this.reason);
   }
 };
-function wakeChunk(response, listeners, value) {
+var ObjectPrototype = Object.prototype,
+  ArrayPrototype = Array.prototype;
+function wakeChunk(response, listeners, value, chunk) {
   for (var i = 0; i < listeners.length; i++) {
     var listener = listeners[i];
     "function" === typeof listener
       ? listener(value)
-      : fulfillReference(response, listener, value);
+      : fulfillReference(response, listener, value, chunk.reason);
   }
 }
 function rejectChunk(response, listeners, error) {
@@ -2069,27 +2078,6 @@ function rejectChunk(response, listeners, error) {
       ? listener(error)
       : rejectReference(response, listener.handler, error);
   }
-}
-function resolveBlockedCycle(resolvedChunk, reference) {
-  var referencedChunk = reference.handler.chunk;
-  if (null === referencedChunk) return null;
-  if (referencedChunk === resolvedChunk) return reference.handler;
-  reference = referencedChunk.value;
-  if (null !== reference)
-    for (
-      referencedChunk = 0;
-      referencedChunk < reference.length;
-      referencedChunk++
-    ) {
-      var listener = reference[referencedChunk];
-      if (
-        "function" !== typeof listener &&
-        ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-        null !== listener)
-      )
-        return listener;
-    }
-  return null;
 }
 function triggerErrorOnChunk(response, chunk, error) {
   if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2126,33 +2114,11 @@ function resolveModelChunk(response, chunk, value, id) {
     chunk.reason =
       ((value.id = id), (value[RESPONSE_SYMBOL] = response), value);
     if (null !== resolveListeners)
-      a: switch ((initializeModelChunk(chunk), chunk.status)) {
+      switch ((initializeModelChunk(chunk), chunk.status)) {
         case "fulfilled":
-          wakeChunk(response, resolveListeners, chunk.value);
+          wakeChunk(response, resolveListeners, chunk.value, chunk);
           break;
         case "blocked":
-          for (value = 0; value < resolveListeners.length; value++)
-            if (((id = resolveListeners[value]), "function" !== typeof id)) {
-              var cyclicHandler = resolveBlockedCycle(chunk, id);
-              if (null !== cyclicHandler)
-                switch (
-                  (fulfillReference(response, id, cyclicHandler.value),
-                  resolveListeners.splice(value, 1),
-                  value--,
-                  null !== rejectListeners &&
-                    ((id = rejectListeners.indexOf(id)),
-                    -1 !== id && rejectListeners.splice(id, 1)),
-                  chunk.status)
-                ) {
-                  case "fulfilled":
-                    wakeChunk(response, resolveListeners, chunk.value);
-                    break a;
-                  case "rejected":
-                    null !== rejectListeners &&
-                      rejectChunk(response, rejectListeners, chunk.reason);
-                    break a;
-                }
-            }
         case "pending":
           if (chunk.value)
             for (response = 0; response < resolveListeners.length; response++)
@@ -2169,7 +2135,8 @@ function resolveModelChunk(response, chunk, value, id) {
           } else chunk.reason = rejectListeners;
           break;
         case "rejected":
-          rejectListeners && wakeChunk(response, rejectListeners, chunk.reason);
+          rejectListeners &&
+            rejectChunk(response, rejectListeners, chunk.reason);
       }
   }
 }
@@ -2192,15 +2159,50 @@ function resolveIteratorResultChunk(response, chunk, value, done) {
   );
 }
 function loadServerReference$1(response, metaData, parentObject, key) {
+  function reject(error) {
+    var rejectListeners = blockedPromise.reason,
+      erroredPromise = blockedPromise;
+    erroredPromise.status = "rejected";
+    erroredPromise.value = null;
+    erroredPromise.reason = error;
+    null !== rejectListeners && rejectChunk(response, rejectListeners, error);
+    rejectReference(response, handler, error);
+  }
   var id = metaData.id;
   if ("string" !== typeof id || "then" === key) return null;
+  var cachedPromise = metaData.$$promise;
+  if (void 0 !== cachedPromise) {
+    if ("fulfilled" === cachedPromise.status)
+      return (
+        (cachedPromise = cachedPromise.value),
+        "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+      );
+    initializingHandler
+      ? ((id = initializingHandler), id.deps++)
+      : (id = initializingHandler =
+          { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+    cachedPromise.then(
+      resolveReference.bind(null, response, id, parentObject, key),
+      rejectReference.bind(null, response, id)
+    );
+    return null;
+  }
+  var blockedPromise = new ReactPromise("blocked", null, null);
+  metaData.$$promise = blockedPromise;
   var serverReference = resolveServerReference(response._bundlerConfig, id);
-  id = metaData.bound;
-  var promise = preloadModule(serverReference);
-  if (promise)
-    id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-  else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-  else return requireModule(serverReference);
+  cachedPromise = metaData.bound;
+  if ((id = preloadModule(serverReference)))
+    cachedPromise instanceof ReactPromise &&
+      (id = Promise.all([id, cachedPromise]));
+  else if (cachedPromise instanceof ReactPromise)
+    id = Promise.resolve(cachedPromise);
+  else
+    return (
+      (cachedPromise = requireModule(serverReference)),
+      (id = blockedPromise),
+      (id.status = "fulfilled"),
+      (id.value = cachedPromise)
+    );
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2212,73 +2214,104 @@ function loadServerReference$1(response, metaData, parentObject, key) {
       deps: 1,
       errored: !1
     };
-  promise.then(
-    function () {
-      var resolvedValue = requireModule(serverReference);
-      if (metaData.bound) {
-        var promiseValue = metaData.bound.value;
-        promiseValue = Array.isArray(promiseValue) ? promiseValue.slice(0) : [];
-        promiseValue.unshift(null);
-        resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
+  id.then(function () {
+    var resolvedValue = requireModule(serverReference);
+    if (metaData.bound) {
+      var promiseValue = metaData.bound.value;
+      promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+      if (1e3 < promiseValue.length) {
+        reject(
+          Error(
+            "Server Function has too many bound arguments. Received " +
+              promiseValue.length +
+              " but the limit is 1000."
+          )
+        );
+        return;
       }
-      parentObject[key] = resolvedValue;
-      "" === key && null === handler.value && (handler.value = resolvedValue);
-      handler.deps--;
-      0 === handler.deps &&
-        ((resolvedValue = handler.chunk),
-        null !== resolvedValue &&
-          "blocked" === resolvedValue.status &&
-          ((promiseValue = resolvedValue.value),
-          (resolvedValue.status = "fulfilled"),
-          (resolvedValue.value = handler.value),
-          (resolvedValue.reason = null),
-          null !== promiseValue &&
-            wakeChunk(response, promiseValue, handler.value)));
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+      promiseValue.unshift(null);
+      resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
     }
-  );
+    promiseValue = blockedPromise.value;
+    var initializedPromise = blockedPromise;
+    initializedPromise.status = "fulfilled";
+    initializedPromise.value = resolvedValue;
+    initializedPromise.reason = null;
+    null !== promiseValue &&
+      wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+    resolveReference(response, handler, parentObject, key, resolvedValue);
+  }, reject);
   return null;
 }
-function reviveModel(response, parentObj, parentKey, value, reference) {
+function reviveModel(
+  response,
+  parentObj,
+  parentKey,
+  value,
+  reference,
+  arrayRoot
+) {
   if ("string" === typeof value)
-    return parseModelString(response, parentObj, parentKey, value, reference);
+    return parseModelString(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    );
   if ("object" === typeof value && null !== value)
     if (
       (void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
         response._temporaryReferences.set(value, reference),
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
+      isArrayImpl(value))
+    ) {
+      if (null === arrayRoot) {
+        var childContext = { count: 0, fork: !1 };
+        response._rootArrayContexts.set(value, childContext);
+      } else childContext = arrayRoot;
+      1 < value.length && (childContext.fork = !0);
+      bumpArrayCount(childContext, value.length + 1, response);
+      for (parentObj = 0; parentObj < value.length; parentObj++)
+        value[parentObj] = reviveModel(
           response,
           value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
+          "" + parentObj,
+          value[parentObj],
+          void 0 !== reference ? reference + ":" + parentObj : void 0,
+          childContext
         );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj || "__proto__" === i
-            ? (value[i] = parentObj)
-            : delete value[i]);
+    } else
+      for (childContext in value)
+        hasOwnProperty.call(value, childContext) &&
+          ("__proto__" === childContext
+            ? delete value[childContext]
+            : ((parentObj =
+                void 0 !== reference && -1 === childContext.indexOf(":")
+                  ? reference + ":" + childContext
+                  : void 0),
+              (parentObj = reviveModel(
+                response,
+                value,
+                childContext,
+                value[childContext],
+                parentObj,
+                null
+              )),
+              void 0 !== parentObj
+                ? (value[childContext] = parentObj)
+                : delete value[childContext]));
   return value;
+}
+function bumpArrayCount(arrayContext, slots, response) {
+  if (
+    (arrayContext.count += slots) > response._arraySizeLimit &&
+    arrayContext.fork
+  )
+    throw Error(
+      "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+    );
 }
 var initializingHandler = null;
 function initializeModelChunk(chunk) {
@@ -2293,13 +2326,15 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var rawModel = JSON.parse(resolvedModel),
-      value = reviveModel(
+    var rawModel = JSON.parse(resolvedModel);
+    resolvedModel = { count: 0, fork: !1 };
+    var value = reviveModel(
         response,
         { "": rawModel },
         "",
         rawModel,
-        _chunk$reason
+        _chunk$reason,
+        resolvedModel
       ),
       resolveListeners = chunk.value;
     if (null !== resolveListeners)
@@ -2311,19 +2346,20 @@ function initializeModelChunk(chunk) {
         var listener = resolveListeners[rawModel];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, resolvedModel);
       }
     if (null !== initializingHandler) {
       if (initializingHandler.errored) throw initializingHandler.reason;
       if (0 < initializingHandler.deps) {
         initializingHandler.value = value;
+        initializingHandler.reason = resolvedModel;
         initializingHandler.chunk = chunk;
         return;
       }
     }
     chunk.status = "fulfilled";
     chunk.value = value;
-    chunk.reason = null;
+    chunk.reason = resolvedModel;
   } catch (error) {
     (chunk.status = "rejected"), (chunk.reason = error);
   } finally {
@@ -2336,7 +2372,8 @@ function reportGlobalError(response, error) {
       ? triggerErrorOnChunk(response, chunk, error)
       : "fulfilled" === chunk.status &&
         null !== chunk.reason &&
-        chunk.reason.error(error);
+        ((chunk = chunk.reason),
+        "function" === typeof chunk.error && chunk.error(error));
   });
 }
 function getChunk(response, id) {
@@ -2351,40 +2388,67 @@ function getChunk(response, id) {
     chunks.set(id, chunk));
   return chunk;
 }
-function fulfillReference(response, reference, value) {
+function fulfillReference(response, reference, value, arrayRoot) {
   var handler = reference.handler,
     parentObject = reference.parentObject,
     key = reference.key,
     map = reference.map,
     path = reference.path;
   try {
-    for (var i = 1; i < path.length; i++) {
+    for (
+      var localLength = 0,
+        rootArrayContexts = response._rootArrayContexts,
+        i = 1;
+      i < path.length;
+      i++
+    ) {
       var name = path[i];
       if (
         "object" !== typeof value ||
-        !hasOwnProperty.call(value, name) ||
-        value instanceof Promise
+        null === value ||
+        (getPrototypeOf(value) !== ObjectPrototype &&
+          getPrototypeOf(value) !== ArrayPrototype) ||
+        !hasOwnProperty.call(value, name)
       )
         throw Error("Invalid reference.");
       value = value[name];
+      if (isArrayImpl(value))
+        (localLength = 0),
+          (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+      else if (((arrayRoot = null), "string" === typeof value))
+        localLength = value.length;
+      else if ("bigint" === typeof value) {
+        var n = Math.abs(Number(value));
+        localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+      } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
     }
-    var mappedValue = map(response, value, parentObject, key);
-    parentObject[key] = mappedValue;
-    "" === key && null === handler.value && (handler.value = mappedValue);
+    var resolvedValue = map(response, value, parentObject, key);
+    var referenceArrayRoot = reference.arrayRoot;
+    null !== referenceArrayRoot &&
+      (null !== arrayRoot
+        ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+          bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+        : 0 < localLength &&
+          bumpArrayCount(referenceArrayRoot, localLength, response));
   } catch (error) {
-    rejectReference(response, reference.handler, error);
+    rejectReference(response, handler, error);
     return;
   }
+  resolveReference(response, handler, parentObject, key, resolvedValue);
+}
+function resolveReference(response, handler, parentObject, key, resolvedValue) {
+  "__proto__" !== key && (parentObject[key] = resolvedValue);
+  "" === key && null === handler.value && (handler.value = resolvedValue);
   handler.deps--;
   0 === handler.deps &&
-    ((reference = handler.chunk),
-    null !== reference &&
-      "blocked" === reference.status &&
-      ((value = reference.value),
-      (reference.status = "fulfilled"),
-      (reference.value = handler.value),
-      (reference.reason = handler.reason),
-      null !== value && wakeChunk(response, value, handler.value)));
+    ((parentObject = handler.chunk),
+    null !== parentObject &&
+      "blocked" === parentObject.status &&
+      ((key = parentObject.value),
+      (parentObject.status = "fulfilled"),
+      (parentObject.value = handler.value),
+      (parentObject.reason = handler.reason),
+      null !== key && wakeChunk(response, key, handler.value, parentObject)));
 }
 function rejectReference(response, handler, error) {
   handler.errored ||
@@ -2396,60 +2460,97 @@ function rejectReference(response, handler, error) {
       "blocked" === handler.status &&
       triggerErrorOnChunk(response, handler, error));
 }
-function getOutlinedModel(response, reference, parentObject, key, map) {
+function getOutlinedModel(
+  response,
+  reference,
+  parentObject,
+  key,
+  referenceArrayRoot,
+  map
+) {
   reference = reference.split(":");
-  var id = parseInt(reference[0], 16);
-  id = getChunk(response, id);
-  switch (id.status) {
+  var id = parseInt(reference[0], 16),
+    chunk = getChunk(response, id);
+  switch (chunk.status) {
     case "resolved_model":
-      initializeModelChunk(id);
+      initializeModelChunk(chunk);
   }
-  switch (id.status) {
+  switch (chunk.status) {
     case "fulfilled":
-      id = id.value;
-      for (var i = 1; i < reference.length; i++) {
-        var name = reference[i];
+      id = chunk.value;
+      chunk = chunk.reason;
+      for (
+        var localLength = 0,
+          rootArrayContexts = response._rootArrayContexts,
+          i = 1;
+        i < reference.length;
+        i++
+      ) {
+        localLength = reference[i];
         if (
           "object" !== typeof id ||
-          !hasOwnProperty.call(id, name) ||
-          id instanceof Promise
+          null === id ||
+          (getPrototypeOf(id) !== ObjectPrototype &&
+            getPrototypeOf(id) !== ArrayPrototype) ||
+          !hasOwnProperty.call(id, localLength)
         )
           throw Error("Invalid reference.");
-        id = id[name];
+        id = id[localLength];
+        isArrayImpl(id)
+          ? ((localLength = 0), (chunk = rootArrayContexts.get(id) || chunk))
+          : ((chunk = null),
+            "string" === typeof id
+              ? (localLength = id.length)
+              : "bigint" === typeof id
+                ? ((localLength = Math.abs(Number(id))),
+                  (localLength =
+                    0 === localLength
+                      ? 1
+                      : Math.floor(Math.log10(localLength)) + 1))
+                : (localLength = ArrayBuffer.isView(id) ? id.byteLength : 0));
       }
-      return map(response, id, parentObject, key);
-    case "pending":
+      parentObject = map(response, id, parentObject, key);
+      null !== referenceArrayRoot &&
+        (null !== chunk
+          ? (chunk.fork && (referenceArrayRoot.fork = !0),
+            bumpArrayCount(referenceArrayRoot, chunk.count, response))
+          : 0 < localLength &&
+            bumpArrayCount(referenceArrayRoot, localLength, response));
+      return parentObject;
     case "blocked":
       return (
         initializingHandler
           ? ((response = initializingHandler), response.deps++)
           : (response = initializingHandler =
               { chunk: null, value: null, reason: null, deps: 1, errored: !1 }),
-        (parentObject = {
+        (referenceArrayRoot = {
           handler: response,
           parentObject: parentObject,
           key: key,
           map: map,
-          path: reference
+          path: reference,
+          arrayRoot: referenceArrayRoot
         }),
-        null === id.value
-          ? (id.value = [parentObject])
-          : id.value.push(parentObject),
-        null === id.reason
-          ? (id.reason = [parentObject])
-          : id.reason.push(parentObject),
+        null === chunk.value
+          ? (chunk.value = [referenceArrayRoot])
+          : chunk.value.push(referenceArrayRoot),
+        null === chunk.reason
+          ? (chunk.reason = [referenceArrayRoot])
+          : chunk.reason.push(referenceArrayRoot),
         null
       );
+    case "pending":
+      throw Error("Invalid forward reference.");
     default:
       return (
         initializingHandler
           ? ((initializingHandler.errored = !0),
             (initializingHandler.value = null),
-            (initializingHandler.reason = id.reason))
+            (initializingHandler.reason = chunk.reason))
           : (initializingHandler = {
               chunk: null,
               value: null,
-              reason: id.reason,
+              reason: chunk.reason,
               deps: 0,
               errored: !0
             }),
@@ -2458,13 +2559,25 @@ function getOutlinedModel(response, reference, parentObject, key, map) {
   }
 }
 function createMap(response, model) {
-  return new Map(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+  response = new Map(model);
+  model.$$consumed = !0;
+  return response;
 }
 function createSet(response, model) {
-  return new Set(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+  response = new Set(model);
+  model.$$consumed = !0;
+  return response;
 }
 function extractIterator(response, model) {
-  return model[Symbol.iterator]();
+  if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+  response = model[Symbol.iterator]();
+  model.$$consumed = !0;
+  return response;
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2475,13 +2588,34 @@ function parseTypedArray(
   constructor,
   bytesPerElement,
   parentObject,
-  parentKey
+  parentKey,
+  referenceArrayRoot
 ) {
+  function reject(error) {
+    if (!handler.errored) {
+      handler.errored = !0;
+      handler.value = null;
+      handler.reason = error;
+      var chunk = handler.chunk;
+      null !== chunk &&
+        "blocked" === chunk.status &&
+        triggerErrorOnChunk(response, chunk, error);
+    }
+  }
   reference = parseInt(reference.slice(2), 16);
-  bytesPerElement = response._prefix + reference;
-  if (response._chunks.has(reference))
+  var key = response._prefix + reference;
+  bytesPerElement = response._chunks;
+  if (bytesPerElement.has(reference))
     throw Error("Already initialized typed array.");
-  reference = response._formData.get(bytesPerElement).arrayBuffer();
+  bytesPerElement.set(
+    reference,
+    new ReactPromise(
+      "rejected",
+      null,
+      Error("Already initialized typed array.")
+    )
+  );
+  reference = response._formData.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2493,37 +2627,32 @@ function parseTypedArray(
       deps: 1,
       errored: !1
     };
-  reference.then(
-    function (buffer) {
-      buffer = constructor === ArrayBuffer ? buffer : new constructor(buffer);
-      parentObject[parentKey] = buffer;
-      "" === parentKey && null === handler.value && (handler.value = buffer);
-      handler.deps--;
-      if (
-        0 === handler.deps &&
-        ((buffer = handler.chunk),
-        null !== buffer && "blocked" === buffer.status)
-      ) {
-        var resolveListeners = buffer.value;
-        buffer.status = "fulfilled";
-        buffer.value = handler.value;
-        buffer.reason = null;
-        null !== resolveListeners &&
-          wakeChunk(response, resolveListeners, handler.value);
-      }
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+  reference.then(function (buffer) {
+    try {
+      null !== referenceArrayRoot &&
+        bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+      var resolvedValue =
+        constructor === ArrayBuffer ? buffer : new constructor(buffer);
+      "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
+      "" === parentKey &&
+        null === handler.value &&
+        (handler.value = resolvedValue);
+    } catch (x) {
+      reject(x);
+      return;
     }
-  );
+    handler.deps--;
+    0 === handler.deps &&
+      ((buffer = handler.chunk),
+      null !== buffer &&
+        "blocked" === buffer.status &&
+        ((resolvedValue = buffer.value),
+        (buffer.status = "fulfilled"),
+        (buffer.value = handler.value),
+        (buffer.reason = null),
+        null !== resolvedValue &&
+          wakeChunk(response, resolvedValue, handler.value, buffer)));
+  }, reject);
   return null;
 }
 function resolveStream(response, id, stream, controller) {
@@ -2539,86 +2668,78 @@ function resolveStream(response, id, stream, controller) {
           : controller.enqueueModel(chunks));
 }
 function parseReadableStream(response, reference, type) {
+  function enqueue(value) {
+    "bytes" !== type || ArrayBuffer.isView(value)
+      ? controller.enqueue(value)
+      : flightController.error(Error("Invalid data for bytes stream."));
+  }
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
     throw Error("Already initialized stream.");
   var controller = null,
-    closed = !1;
-  type = new ReadableStream({
-    type: type,
-    start: function (c) {
-      controller = c;
-    }
-  });
-  var previousBlockedChunk = null;
-  resolveStream(response, reference, type, {
-    enqueueModel: function (json) {
-      if (null === previousBlockedChunk) {
-        var chunk = createResolvedModelChunk(response, json, -1);
-        initializeModelChunk(chunk);
-        "fulfilled" === chunk.status
-          ? controller.enqueue(chunk.value)
-          : (chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            ),
-            (previousBlockedChunk = chunk));
-      } else {
-        chunk = previousBlockedChunk;
-        var chunk$31 = new ReactPromise("pending", null, null);
-        chunk$31.then(
-          function (v) {
-            return controller.enqueue(v);
-          },
-          function (e) {
-            return controller.error(e);
-          }
-        );
-        previousBlockedChunk = chunk$31;
-        chunk.then(function () {
-          previousBlockedChunk === chunk$31 && (previousBlockedChunk = null);
-          resolveModelChunk(response, chunk$31, json, -1);
-        });
+    closed = !1,
+    stream = new ReadableStream({
+      type: type,
+      start: function (c) {
+        controller = c;
       }
-    },
-    close: function () {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk)) controller.close();
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.close();
+    }),
+    previousBlockedChunk = null,
+    flightController = {
+      enqueueModel: function (json) {
+        if (null === previousBlockedChunk) {
+          var chunk = createResolvedModelChunk(response, json, -1);
+          initializeModelChunk(chunk);
+          "fulfilled" === chunk.status
+            ? enqueue(chunk.value)
+            : (chunk.then(enqueue, flightController.error),
+              (previousBlockedChunk = chunk));
+        } else {
+          chunk = previousBlockedChunk;
+          var chunk$32 = new ReactPromise("pending", null, null);
+          chunk$32.then(enqueue, flightController.error);
+          previousBlockedChunk = chunk$32;
+          chunk.then(function () {
+            previousBlockedChunk === chunk$32 && (previousBlockedChunk = null);
+            resolveModelChunk(response, chunk$32, json, -1);
           });
         }
-    },
-    error: function (error) {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk))
-          controller.error(error);
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.error(error);
-          });
-        }
-    }
-  });
-  return type;
+      },
+      close: function () {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.close();
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.close();
+            });
+          }
+      },
+      error: function (error) {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.error(error);
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.error(error);
+            });
+          }
+      }
+    };
+  resolveStream(response, reference, stream, flightController);
+  return stream;
 }
-function asyncIterator() {
+function FlightIterator(next) {
+  this.next = next;
+}
+FlightIterator.prototype = {};
+FlightIterator.prototype[ASYNC_ITERATOR] = function () {
   return this;
-}
-function createIterator(next) {
-  next = { next: next };
-  next[ASYNC_ITERATOR] = asyncIterator;
-  return next;
-}
+};
 function parseAsyncIterable(response, reference, iterator) {
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
@@ -2630,7 +2751,7 @@ function parseAsyncIterable(response, reference, iterator) {
   $jscomp$compprop5 =
     (($jscomp$compprop5[ASYNC_ITERATOR] = function () {
       var nextReadIndex = 0;
-      return createIterator(function (arg) {
+      return new FlightIterator(function (arg) {
         if (void 0 !== arg)
           throw Error(
             "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -2710,17 +2831,28 @@ function parseAsyncIterable(response, reference, iterator) {
   });
   return iterator;
 }
-function parseModelString(response, obj, key, value, reference) {
+function parseModelString(response, obj, key, value, reference, arrayRoot) {
   if ("$" === value[0]) {
     switch (value[1]) {
       case "$":
-        return value.slice(1);
+        return (
+          null !== arrayRoot &&
+            bumpArrayCount(arrayRoot, value.length - 1, response),
+          value.slice(1)
+        );
       case "@":
         return (obj = parseInt(value.slice(2), 16)), getChunk(response, obj);
       case "h":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, loadServerReference$1)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(
+            response,
+            arrayRoot,
+            obj,
+            key,
+            null,
+            loadServerReference$1
+          )
         );
       case "T":
         if (void 0 === reference || void 0 === response._temporaryReferences)
@@ -2733,27 +2865,37 @@ function parseModelString(response, obj, key, value, reference) {
         );
       case "Q":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createMap)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
         );
       case "W":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createSet)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
         obj = value.slice(2);
-        var formPrefix = response._prefix + obj + "_",
-          data = new FormData();
-        response._formData.forEach(function (entry, entryKey) {
-          entryKey.startsWith(formPrefix) &&
-            data.append(entryKey.slice(formPrefix.length), entry);
-        });
-        return data;
+        obj = response._prefix + obj + "_";
+        key = new FormData();
+        response = response._formData;
+        arrayRoot = Array.from(response.keys());
+        for (value = 0; value < arrayRoot.length; value++)
+          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            for (
+              var entries = response.getAll(reference),
+                newKey = reference.slice(obj.length),
+                j = 0;
+              j < entries.length;
+              j++
+            )
+              key.append(newKey, entries[j]);
+            response.delete(reference);
+          }
+        return key;
       case "i":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, extractIterator)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, extractIterator)
         );
       case "I":
         return Infinity;
@@ -2766,35 +2908,147 @@ function parseModelString(response, obj, key, value, reference) {
       case "D":
         return new Date(Date.parse(value.slice(2)));
       case "n":
-        return BigInt(value.slice(2));
+        obj = value.slice(2);
+        if (300 < obj.length)
+          throw Error(
+            "BigInt is too large. Received " +
+              obj.length +
+              " digits but the limit is 300."
+          );
+        null !== arrayRoot && bumpArrayCount(arrayRoot, obj.length, response);
+        return BigInt(obj);
     }
     switch (value[1]) {
       case "A":
-        return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          ArrayBuffer,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "O":
-        return parseTypedArray(response, value, Int8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "o":
-        return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "U":
-        return parseTypedArray(response, value, Uint8ClampedArray, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8ClampedArray,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "S":
-        return parseTypedArray(response, value, Int16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "s":
-        return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "L":
-        return parseTypedArray(response, value, Int32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "l":
-        return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "G":
-        return parseTypedArray(response, value, Float32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "g":
-        return parseTypedArray(response, value, Float64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "M":
-        return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigInt64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "m":
-        return parseTypedArray(response, value, BigUint64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigUint64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "V":
-        return parseTypedArray(response, value, DataView, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          DataView,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
@@ -2812,8 +3066,9 @@ function parseModelString(response, obj, key, value, reference) {
         return parseAsyncIterable(response, value, !0);
     }
     value = value.slice(1);
-    return getOutlinedModel(response, value, obj, key, createModel);
+    return getOutlinedModel(response, value, obj, key, arrayRoot, createModel);
   }
+  null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
   return value;
 }
 function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
@@ -2821,25 +3076,38 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
       3 < arguments.length && void 0 !== arguments[3]
         ? arguments[3]
         : new FormData(),
+    arraySizeLimit =
+      4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
     chunks = new Map();
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
     _formData: backingFormData,
     _chunks: chunks,
-    _temporaryReferences: temporaryReferences
+    _temporaryReferences: temporaryReferences,
+    _rootArrayContexts: new WeakMap(),
+    _arraySizeLimit: arraySizeLimit
   };
 }
 function close(response) {
   reportGlobalError(response, Error("Connection closed."));
 }
-function loadServerReference(bundlerConfig, id, bound) {
+function loadServerReference(bundlerConfig, metaData) {
+  var id = metaData.id;
+  if ("string" !== typeof id) return null;
   var serverReference = resolveServerReference(bundlerConfig, id);
   bundlerConfig = preloadModule(serverReference);
-  return bound
-    ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+  metaData = metaData.bound;
+  return null !== metaData
+    ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
         _ref = _ref[0];
         var fn = requireModule(serverReference);
+        if (1e3 < _ref.length)
+          throw Error(
+            "Server Function has too many bound arguments. Received " +
+              _ref.length +
+              " but the limit is 1000."
+          );
         return fn.bind.apply(fn, [null].concat(_ref));
       })
     : bundlerConfig
@@ -2848,8 +3116,19 @@ function loadServerReference(bundlerConfig, id, bound) {
         })
       : Promise.resolve(requireModule(serverReference));
 }
-function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-  body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+function decodeBoundActionMetaData(
+  body,
+  serverManifest,
+  formFieldPrefix,
+  arraySizeLimit
+) {
+  body = createResponse(
+    serverManifest,
+    formFieldPrefix,
+    void 0,
+    body,
+    arraySizeLimit
+  );
   close(body);
   body = getChunk(body, 0);
   body.then(function () {});
@@ -2865,16 +3144,24 @@ exports.createTemporaryReferenceSet = function () {
 };
 exports.decodeAction = function (body, serverManifest) {
   var formData = new FormData(),
-    action = null;
+    action = null,
+    seenActions = new Set();
   body.forEach(function (value, key) {
     key.startsWith("$ACTION_")
       ? key.startsWith("$ACTION_REF_")
-        ? ((value = "$ACTION_" + key.slice(12) + ":"),
+        ? seenActions.has(key) ||
+          (seenActions.add(key),
+          (value = "$ACTION_" + key.slice(12) + ":"),
           (value = decodeBoundActionMetaData(body, serverManifest, value)),
-          (action = loadServerReference(serverManifest, value.id, value.bound)))
+          (action = loadServerReference(serverManifest, value)))
         : key.startsWith("$ACTION_ID_") &&
-          ((value = key.slice(11)),
-          (action = loadServerReference(serverManifest, value, null)))
+          !seenActions.has(key) &&
+          (seenActions.add(key),
+          (value = key.slice(11)),
+          (action = loadServerReference(serverManifest, {
+            id: value,
+            bound: null
+          })))
       : formData.append(key, value);
   });
   return null === action
@@ -2910,7 +3197,8 @@ exports.decodeReply = function (body, webpackMap, options) {
     webpackMap,
     "",
     options ? options.temporaryReferences : void 0,
-    body
+    body,
+    options ? options.arraySizeLimit : void 0
   );
   webpackMap = getChunk(body, 0);
   close(body);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -1481,6 +1481,13 @@
       value
     ) {
       task.model = value;
+      parentPropertyName === __PROTO__$1 &&
+        callWithDebugContextInDEV(request, task, function () {
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(parent, parentPropertyName)
+          );
+        });
       if (value === REACT_ELEMENT_TYPE) return "$";
       if (null === value) return null;
       if ("object" === typeof value) {
@@ -1651,7 +1658,7 @@
         if (value instanceof Date) return "$D" + value.toJSON();
         elementReference = getPrototypeOf(value);
         if (
-          elementReference !== ObjectPrototype &&
+          elementReference !== ObjectPrototype$1 &&
           (null === elementReference ||
             null !== getPrototypeOf(elementReference))
         )
@@ -2549,12 +2556,12 @@
       this.value = value;
       this.reason = reason;
     }
-    function wakeChunk(response, listeners, value) {
+    function wakeChunk(response, listeners, value, chunk) {
       for (var i = 0; i < listeners.length; i++) {
         var listener = listeners[i];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, chunk.reason);
       }
     }
     function rejectChunk(response, listeners, error) {
@@ -2564,27 +2571,6 @@
           ? listener(error)
           : rejectReference(response, listener.handler, error);
       }
-    }
-    function resolveBlockedCycle(resolvedChunk, reference) {
-      var referencedChunk = reference.handler.chunk;
-      if (null === referencedChunk) return null;
-      if (referencedChunk === resolvedChunk) return reference.handler;
-      reference = referencedChunk.value;
-      if (null !== reference)
-        for (
-          referencedChunk = 0;
-          referencedChunk < reference.length;
-          referencedChunk++
-        ) {
-          var listener = reference[referencedChunk];
-          if (
-            "function" !== typeof listener &&
-            ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-            null !== listener)
-          )
-            return listener;
-        }
-      return null;
     }
     function triggerErrorOnChunk(response, chunk, error) {
       if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2609,57 +2595,25 @@
         chunk.value = value;
         chunk.reason = _defineProperty({ id: id }, RESPONSE_SYMBOL, response);
         if (null !== resolveListeners)
-          a: switch ((initializeModelChunk(chunk), chunk.status)) {
+          switch ((initializeModelChunk(chunk), chunk.status)) {
             case "fulfilled":
-              wakeChunk(response, resolveListeners, chunk.value);
+              wakeChunk(response, resolveListeners, chunk.value, chunk);
               break;
             case "blocked":
-              for (value = 0; value < resolveListeners.length; value++)
-                if (
-                  ((id = resolveListeners[value]), "function" !== typeof id)
-                ) {
-                  var cyclicHandler = resolveBlockedCycle(chunk, id);
-                  if (null !== cyclicHandler)
-                    switch (
-                      (fulfillReference(response, id, cyclicHandler.value),
-                      resolveListeners.splice(value, 1),
-                      value--,
-                      null !== rejectListeners &&
-                        ((id = rejectListeners.indexOf(id)),
-                        -1 !== id && rejectListeners.splice(id, 1)),
-                      chunk.status)
-                    ) {
-                      case "fulfilled":
-                        wakeChunk(response, resolveListeners, chunk.value);
-                        break a;
-                      case "rejected":
-                        null !== rejectListeners &&
-                          rejectChunk(response, rejectListeners, chunk.reason);
-                        break a;
-                    }
-                }
             case "pending":
               if (chunk.value)
-                for (
-                  response = 0;
-                  response < resolveListeners.length;
-                  response++
-                )
-                  chunk.value.push(resolveListeners[response]);
+                for (value = 0; value < resolveListeners.length; value++)
+                  chunk.value.push(resolveListeners[value]);
               else chunk.value = resolveListeners;
               if (chunk.reason) {
                 if (rejectListeners)
-                  for (
-                    resolveListeners = 0;
-                    resolveListeners < rejectListeners.length;
-                    resolveListeners++
-                  )
-                    chunk.reason.push(rejectListeners[resolveListeners]);
+                  for (value = 0; value < rejectListeners.length; value++)
+                    chunk.reason.push(rejectListeners[value]);
               } else chunk.reason = rejectListeners;
               break;
             case "rejected":
               rejectListeners &&
-                wakeChunk(response, rejectListeners, chunk.reason);
+                rejectChunk(response, rejectListeners, chunk.reason);
           }
       }
     }
@@ -2683,15 +2637,51 @@
       );
     }
     function loadServerReference$1(response, metaData, parentObject, key) {
+      function reject(error) {
+        var rejectListeners = blockedPromise.reason,
+          erroredPromise = blockedPromise;
+        erroredPromise.status = "rejected";
+        erroredPromise.value = null;
+        erroredPromise.reason = error;
+        null !== rejectListeners &&
+          rejectChunk(response, rejectListeners, error);
+        rejectReference(response, handler, error);
+      }
       var id = metaData.id;
       if ("string" !== typeof id || "then" === key) return null;
+      var cachedPromise = metaData.$$promise;
+      if (void 0 !== cachedPromise) {
+        if ("fulfilled" === cachedPromise.status)
+          return (
+            (cachedPromise = cachedPromise.value),
+            "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+          );
+        initializingHandler
+          ? ((id = initializingHandler), id.deps++)
+          : (id = initializingHandler =
+              { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+        cachedPromise.then(
+          resolveReference.bind(null, response, id, parentObject, key),
+          rejectReference.bind(null, response, id)
+        );
+        return null;
+      }
+      var blockedPromise = new ReactPromise("blocked", null, null);
+      metaData.$$promise = blockedPromise;
       var serverReference = resolveServerReference(response._bundlerConfig, id);
-      id = metaData.bound;
-      var promise = preloadModule(serverReference);
-      if (promise)
-        id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-      else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-      else return requireModule(serverReference);
+      cachedPromise = metaData.bound;
+      if ((id = preloadModule(serverReference)))
+        cachedPromise instanceof ReactPromise &&
+          (id = Promise.all([id, cachedPromise]));
+      else if (cachedPromise instanceof ReactPromise)
+        id = Promise.resolve(cachedPromise);
+      else
+        return (
+          (cachedPromise = requireModule(serverReference)),
+          (id = blockedPromise),
+          (id.status = "fulfilled"),
+          (id.value = cachedPromise)
+        );
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -2703,92 +2693,106 @@
           deps: 1,
           errored: !1
         };
-      promise.then(
-        function () {
-          var resolvedValue = requireModule(serverReference);
-          if (metaData.bound) {
-            var promiseValue = metaData.bound.value;
-            promiseValue = Array.isArray(promiseValue)
-              ? promiseValue.slice(0)
-              : [];
-            promiseValue.unshift(null);
-            resolvedValue = resolvedValue.bind.apply(
-              resolvedValue,
-              promiseValue
+      id.then(function () {
+        var resolvedValue = requireModule(serverReference);
+        if (metaData.bound) {
+          var promiseValue = metaData.bound.value;
+          promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+          if (promiseValue.length > MAX_BOUND_ARGS) {
+            reject(
+              Error(
+                "Server Function has too many bound arguments. Received " +
+                  promiseValue.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              )
             );
+            return;
           }
-          parentObject[key] = resolvedValue;
-          "" === key &&
-            null === handler.value &&
-            (handler.value = resolvedValue);
-          handler.deps--;
-          0 === handler.deps &&
-            ((resolvedValue = handler.chunk),
-            null !== resolvedValue &&
-              "blocked" === resolvedValue.status &&
-              ((promiseValue = resolvedValue.value),
-              (resolvedValue.status = "fulfilled"),
-              (resolvedValue.value = handler.value),
-              (resolvedValue.reason = null),
-              null !== promiseValue &&
-                wakeChunk(response, promiseValue, handler.value)));
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+          promiseValue.unshift(null);
+          resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
         }
-      );
+        promiseValue = blockedPromise.value;
+        var initializedPromise = blockedPromise;
+        initializedPromise.status = "fulfilled";
+        initializedPromise.value = resolvedValue;
+        initializedPromise.reason = null;
+        null !== promiseValue &&
+          wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+        resolveReference(response, handler, parentObject, key, resolvedValue);
+      }, reject);
       return null;
     }
-    function reviveModel(response, parentObj, parentKey, value, reference) {
+    function reviveModel(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    ) {
       if ("string" === typeof value)
         return parseModelString(
           response,
           parentObj,
           parentKey,
           value,
-          reference
+          reference,
+          arrayRoot
         );
       if ("object" === typeof value && null !== value)
         if (
           (void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
             response._temporaryReferences.set(value, reference),
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
+          isArrayImpl(value))
+        ) {
+          if (null === arrayRoot) {
+            var childContext = { count: 0, fork: !1 };
+            response._rootArrayContexts.set(value, childContext);
+          } else childContext = arrayRoot;
+          1 < value.length && (childContext.fork = !0);
+          bumpArrayCount(childContext, value.length + 1, response);
+          for (parentObj = 0; parentObj < value.length; parentObj++)
+            value[parentObj] = reviveModel(
               response,
               value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
+              "" + parentObj,
+              value[parentObj],
+              void 0 !== reference ? reference + ":" + parentObj : void 0,
+              childContext
             );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj || "__proto__" === i
-                ? (value[i] = parentObj)
-                : delete value[i]);
+        } else
+          for (childContext in value)
+            hasOwnProperty.call(value, childContext) &&
+              ("__proto__" === childContext
+                ? delete value[childContext]
+                : ((parentObj =
+                    void 0 !== reference && -1 === childContext.indexOf(":")
+                      ? reference + ":" + childContext
+                      : void 0),
+                  (parentObj = reviveModel(
+                    response,
+                    value,
+                    childContext,
+                    value[childContext],
+                    parentObj,
+                    null
+                  )),
+                  void 0 !== parentObj
+                    ? (value[childContext] = parentObj)
+                    : delete value[childContext]));
       return value;
+    }
+    function bumpArrayCount(arrayContext, slots, response) {
+      if (
+        (arrayContext.count += slots) > response._arraySizeLimit &&
+        arrayContext.fork
+      )
+        throw Error(
+          "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+        );
     }
     function initializeModelChunk(chunk) {
       var prevHandler = initializingHandler;
@@ -2803,13 +2807,15 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var rawModel = JSON.parse(resolvedModel),
-          value = reviveModel(
+        var rawModel = JSON.parse(resolvedModel);
+        resolvedModel = { count: 0, fork: !1 };
+        var value = reviveModel(
             response,
             { "": rawModel },
             "",
             rawModel,
-            _chunk$reason
+            _chunk$reason,
+            resolvedModel
           ),
           resolveListeners = chunk.value;
         if (null !== resolveListeners)
@@ -2821,19 +2827,20 @@
             var listener = resolveListeners[rawModel];
             "function" === typeof listener
               ? listener(value)
-              : fulfillReference(response, listener, value);
+              : fulfillReference(response, listener, value, resolvedModel);
           }
         if (null !== initializingHandler) {
           if (initializingHandler.errored) throw initializingHandler.reason;
           if (0 < initializingHandler.deps) {
             initializingHandler.value = value;
+            initializingHandler.reason = resolvedModel;
             initializingHandler.chunk = chunk;
             return;
           }
         }
         chunk.status = "fulfilled";
         chunk.value = value;
-        chunk.reason = null;
+        chunk.reason = resolvedModel;
       } catch (error) {
         (chunk.status = "rejected"), (chunk.reason = error);
       } finally {
@@ -2846,7 +2853,8 @@
           ? triggerErrorOnChunk(response, chunk, error)
           : "fulfilled" === chunk.status &&
             null !== chunk.reason &&
-            chunk.reason.error(error);
+            ((chunk = chunk.reason),
+            "function" === typeof chunk.error && chunk.error(error));
       });
     }
     function getChunk(response, id) {
@@ -2865,40 +2873,74 @@
         chunks.set(id, chunk));
       return chunk;
     }
-    function fulfillReference(response, reference, value) {
+    function fulfillReference(response, reference, value, arrayRoot) {
       var handler = reference.handler,
         parentObject = reference.parentObject,
         key = reference.key,
         map = reference.map,
         path = reference.path;
       try {
-        for (var i = 1; i < path.length; i++) {
+        for (
+          var localLength = 0,
+            rootArrayContexts = response._rootArrayContexts,
+            i = 1;
+          i < path.length;
+          i++
+        ) {
           var name = path[i];
           if (
             "object" !== typeof value ||
-            !hasOwnProperty.call(value, name) ||
-            value instanceof Promise
+            null === value ||
+            (getPrototypeOf(value) !== ObjectPrototype &&
+              getPrototypeOf(value) !== ArrayPrototype) ||
+            !hasOwnProperty.call(value, name)
           )
             throw Error("Invalid reference.");
           value = value[name];
+          if (isArrayImpl(value))
+            (localLength = 0),
+              (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+          else if (((arrayRoot = null), "string" === typeof value))
+            localLength = value.length;
+          else if ("bigint" === typeof value) {
+            var n = Math.abs(Number(value));
+            localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+          } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
         }
-        var mappedValue = map(response, value, parentObject, key);
-        parentObject[key] = mappedValue;
-        "" === key && null === handler.value && (handler.value = mappedValue);
+        var resolvedValue = map(response, value, parentObject, key);
+        var referenceArrayRoot = reference.arrayRoot;
+        null !== referenceArrayRoot &&
+          (null !== arrayRoot
+            ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+              bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+            : 0 < localLength &&
+              bumpArrayCount(referenceArrayRoot, localLength, response));
       } catch (error) {
-        rejectReference(response, reference.handler, error);
+        rejectReference(response, handler, error);
         return;
       }
+      resolveReference(response, handler, parentObject, key, resolvedValue);
+    }
+    function resolveReference(
+      response,
+      handler,
+      parentObject,
+      key,
+      resolvedValue
+    ) {
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
+      "" === key && null === handler.value && (handler.value = resolvedValue);
       handler.deps--;
       0 === handler.deps &&
-        ((reference = handler.chunk),
-        null !== reference &&
-          "blocked" === reference.status &&
-          ((value = reference.value),
-          (reference.status = "fulfilled"),
-          (reference.value = handler.value),
-          (reference.reason = handler.reason),
-          null !== value && wakeChunk(response, value, handler.value)));
+        ((parentObject = handler.chunk),
+        null !== parentObject &&
+          "blocked" === parentObject.status &&
+          ((key = parentObject.value),
+          (parentObject.status = "fulfilled"),
+          (parentObject.value = handler.value),
+          (parentObject.reason = handler.reason),
+          null !== key &&
+            wakeChunk(response, key, handler.value, parentObject)));
     }
     function rejectReference(response, handler, error) {
       handler.errored ||
@@ -2910,29 +2952,66 @@
           "blocked" === handler.status &&
           triggerErrorOnChunk(response, handler, error));
     }
-    function getOutlinedModel(response, reference, parentObject, key, map) {
+    function getOutlinedModel(
+      response,
+      reference,
+      parentObject,
+      key,
+      referenceArrayRoot,
+      map
+    ) {
       reference = reference.split(":");
-      var id = parseInt(reference[0], 16);
-      id = getChunk(response, id);
-      switch (id.status) {
+      var id = parseInt(reference[0], 16),
+        chunk = getChunk(response, id);
+      switch (chunk.status) {
         case "resolved_model":
-          initializeModelChunk(id);
+          initializeModelChunk(chunk);
       }
-      switch (id.status) {
+      switch (chunk.status) {
         case "fulfilled":
-          id = id.value;
-          for (var i = 1; i < reference.length; i++) {
-            var name = reference[i];
+          id = chunk.value;
+          chunk = chunk.reason;
+          for (
+            var localLength = 0,
+              rootArrayContexts = response._rootArrayContexts,
+              i = 1;
+            i < reference.length;
+            i++
+          ) {
+            localLength = reference[i];
             if (
               "object" !== typeof id ||
-              !hasOwnProperty.call(id, name) ||
-              id instanceof Promise
+              null === id ||
+              (getPrototypeOf(id) !== ObjectPrototype &&
+                getPrototypeOf(id) !== ArrayPrototype) ||
+              !hasOwnProperty.call(id, localLength)
             )
               throw Error("Invalid reference.");
-            id = id[name];
+            id = id[localLength];
+            isArrayImpl(id)
+              ? ((localLength = 0),
+                (chunk = rootArrayContexts.get(id) || chunk))
+              : ((chunk = null),
+                "string" === typeof id
+                  ? (localLength = id.length)
+                  : "bigint" === typeof id
+                    ? ((localLength = Math.abs(Number(id))),
+                      (localLength =
+                        0 === localLength
+                          ? 1
+                          : Math.floor(Math.log10(localLength)) + 1))
+                    : (localLength = ArrayBuffer.isView(id)
+                        ? id.byteLength
+                        : 0));
           }
-          return map(response, id, parentObject, key);
-        case "pending":
+          parentObject = map(response, id, parentObject, key);
+          null !== referenceArrayRoot &&
+            (null !== chunk
+              ? (chunk.fork && (referenceArrayRoot.fork = !0),
+                bumpArrayCount(referenceArrayRoot, chunk.count, response))
+              : 0 < localLength &&
+                bumpArrayCount(referenceArrayRoot, localLength, response));
+          return parentObject;
         case "blocked":
           return (
             initializingHandler
@@ -2945,31 +3024,34 @@
                     deps: 1,
                     errored: !1
                   }),
-            (parentObject = {
+            (referenceArrayRoot = {
               handler: response,
               parentObject: parentObject,
               key: key,
               map: map,
-              path: reference
+              path: reference,
+              arrayRoot: referenceArrayRoot
             }),
-            null === id.value
-              ? (id.value = [parentObject])
-              : id.value.push(parentObject),
-            null === id.reason
-              ? (id.reason = [parentObject])
-              : id.reason.push(parentObject),
+            null === chunk.value
+              ? (chunk.value = [referenceArrayRoot])
+              : chunk.value.push(referenceArrayRoot),
+            null === chunk.reason
+              ? (chunk.reason = [referenceArrayRoot])
+              : chunk.reason.push(referenceArrayRoot),
             null
           );
+        case "pending":
+          throw Error("Invalid forward reference.");
         default:
           return (
             initializingHandler
               ? ((initializingHandler.errored = !0),
                 (initializingHandler.value = null),
-                (initializingHandler.reason = id.reason))
+                (initializingHandler.reason = chunk.reason))
               : (initializingHandler = {
                   chunk: null,
                   value: null,
-                  reason: id.reason,
+                  reason: chunk.reason,
                   deps: 0,
                   errored: !0
                 }),
@@ -2978,13 +3060,25 @@
       }
     }
     function createMap(response, model) {
-      return new Map(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+      response = new Map(model);
+      model.$$consumed = !0;
+      return response;
     }
     function createSet(response, model) {
-      return new Set(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+      response = new Set(model);
+      model.$$consumed = !0;
+      return response;
     }
     function extractIterator(response, model) {
-      return model[Symbol.iterator]();
+      if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+      response = model[Symbol.iterator]();
+      model.$$consumed = !0;
+      return response;
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -2995,13 +3089,34 @@
       constructor,
       bytesPerElement,
       parentObject,
-      parentKey
+      parentKey,
+      referenceArrayRoot
     ) {
+      function reject(error) {
+        if (!handler.errored) {
+          handler.errored = !0;
+          handler.value = null;
+          handler.reason = error;
+          var chunk = handler.chunk;
+          null !== chunk &&
+            "blocked" === chunk.status &&
+            triggerErrorOnChunk(response, chunk, error);
+        }
+      }
       reference = parseInt(reference.slice(2), 16);
-      bytesPerElement = response._prefix + reference;
-      if (response._chunks.has(reference))
+      var key = response._prefix + reference;
+      bytesPerElement = response._chunks;
+      if (bytesPerElement.has(reference))
         throw Error("Already initialized typed array.");
-      reference = response._formData.get(bytesPerElement).arrayBuffer();
+      bytesPerElement.set(
+        reference,
+        new ReactPromise(
+          "rejected",
+          null,
+          Error("Already initialized typed array.")
+        )
+      );
+      reference = response._formData.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -3013,40 +3128,32 @@
           deps: 1,
           errored: !1
         };
-      reference.then(
-        function (buffer) {
-          buffer =
+      reference.then(function (buffer) {
+        try {
+          null !== referenceArrayRoot &&
+            bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+          var resolvedValue =
             constructor === ArrayBuffer ? buffer : new constructor(buffer);
-          parentObject[parentKey] = buffer;
+          "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
           "" === parentKey &&
             null === handler.value &&
-            (handler.value = buffer);
-          handler.deps--;
-          if (
-            0 === handler.deps &&
-            ((buffer = handler.chunk),
-            null !== buffer && "blocked" === buffer.status)
-          ) {
-            var resolveListeners = buffer.value;
-            buffer.status = "fulfilled";
-            buffer.value = handler.value;
-            buffer.reason = null;
-            null !== resolveListeners &&
-              wakeChunk(response, resolveListeners, handler.value);
-          }
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+            (handler.value = resolvedValue);
+        } catch (x) {
+          reject(x);
+          return;
         }
-      );
+        handler.deps--;
+        0 === handler.deps &&
+          ((buffer = handler.chunk),
+          null !== buffer &&
+            "blocked" === buffer.status &&
+            ((resolvedValue = buffer.value),
+            (buffer.status = "fulfilled"),
+            (buffer.value = handler.value),
+            (buffer.reason = null),
+            null !== resolvedValue &&
+              wakeChunk(response, resolvedValue, handler.value, buffer)));
+      }, reject);
       return null;
     }
     function resolveStream(response, id, stream, controller) {
@@ -3064,90 +3171,78 @@
               : controller.enqueueModel(chunks));
     }
     function parseReadableStream(response, reference, type) {
+      function enqueue(value) {
+        "bytes" !== type || ArrayBuffer.isView(value)
+          ? controller.enqueue(value)
+          : flightController.error(Error("Invalid data for bytes stream."));
+      }
       reference = parseInt(reference.slice(2), 16);
       if (response._chunks.has(reference))
         throw Error("Already initialized stream.");
       var controller = null,
-        closed = !1;
-      type = new ReadableStream({
-        type: type,
-        start: function (c) {
-          controller = c;
-        }
-      });
-      var previousBlockedChunk = null;
-      resolveStream(response, reference, type, {
-        enqueueModel: function (json) {
-          if (null === previousBlockedChunk) {
-            var chunk = new ReactPromise(
-              "resolved_model",
-              json,
-              _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
-            );
-            initializeModelChunk(chunk);
-            "fulfilled" === chunk.status
-              ? controller.enqueue(chunk.value)
-              : (chunk.then(
-                  function (v) {
-                    return controller.enqueue(v);
-                  },
-                  function (e) {
-                    return controller.error(e);
-                  }
-                ),
-                (previousBlockedChunk = chunk));
-          } else {
-            chunk = previousBlockedChunk;
-            var _chunk = new ReactPromise("pending", null, null);
-            _chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            );
-            previousBlockedChunk = _chunk;
-            chunk.then(function () {
-              previousBlockedChunk === _chunk && (previousBlockedChunk = null);
-              resolveModelChunk(response, _chunk, json, -1);
-            });
+        closed = !1,
+        stream = new ReadableStream({
+          type: type,
+          start: function (c) {
+            controller = c;
           }
-        },
-        close: function () {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.close();
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.close();
+        }),
+        previousBlockedChunk = null,
+        flightController = {
+          enqueueModel: function (json) {
+            if (null === previousBlockedChunk) {
+              var chunk = new ReactPromise(
+                "resolved_model",
+                json,
+                _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
+              );
+              initializeModelChunk(chunk);
+              "fulfilled" === chunk.status
+                ? enqueue(chunk.value)
+                : (chunk.then(enqueue, flightController.error),
+                  (previousBlockedChunk = chunk));
+            } else {
+              chunk = previousBlockedChunk;
+              var _chunk = new ReactPromise("pending", null, null);
+              _chunk.then(enqueue, flightController.error);
+              previousBlockedChunk = _chunk;
+              chunk.then(function () {
+                previousBlockedChunk === _chunk &&
+                  (previousBlockedChunk = null);
+                resolveModelChunk(response, _chunk, json, -1);
               });
             }
-        },
-        error: function (error) {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.error(error);
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.error(error);
-              });
-            }
-        }
-      });
-      return type;
+          },
+          close: function () {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.close();
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.close();
+                });
+              }
+          },
+          error: function (error) {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.error(error);
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.error(error);
+                });
+              }
+          }
+        };
+      resolveStream(response, reference, stream, flightController);
+      return stream;
     }
-    function asyncIterator() {
-      return this;
-    }
-    function createIterator(next) {
-      next = { next: next };
-      next[ASYNC_ITERATOR] = asyncIterator;
-      return next;
+    function FlightIterator(next) {
+      this.next = next;
     }
     function parseAsyncIterable(response, reference, iterator) {
       reference = parseInt(reference.slice(2), 16);
@@ -3158,7 +3253,7 @@
         nextWriteIndex = 0,
         iterable = _defineProperty({}, ASYNC_ITERATOR, function () {
           var nextReadIndex = 0;
-          return createIterator(function (arg) {
+          return new FlightIterator(function (arg) {
             if (void 0 !== arg)
               throw Error(
                 "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -3237,19 +3332,30 @@
       });
       return iterator;
     }
-    function parseModelString(response, obj, key, value, reference) {
+    function parseModelString(response, obj, key, value, reference, arrayRoot) {
       if ("$" === value[0]) {
         switch (value[1]) {
           case "$":
-            return value.slice(1);
+            return (
+              null !== arrayRoot &&
+                bumpArrayCount(arrayRoot, value.length - 1, response),
+              value.slice(1)
+            );
           case "@":
             return (
               (obj = parseInt(value.slice(2), 16)), getChunk(response, obj)
             );
           case "h":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, loadServerReference$1)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                loadServerReference$1
+              )
             );
           case "T":
             if (
@@ -3265,27 +3371,44 @@
             );
           case "Q":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createMap)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
             );
           case "W":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createSet)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
             obj = value.slice(2);
-            var formPrefix = response._prefix + obj + "_",
-              data = new FormData();
-            response._formData.forEach(function (entry, entryKey) {
-              entryKey.startsWith(formPrefix) &&
-                data.append(entryKey.slice(formPrefix.length), entry);
-            });
-            return data;
+            obj = response._prefix + obj + "_";
+            key = new FormData();
+            response = response._formData;
+            arrayRoot = Array.from(response.keys());
+            for (value = 0; value < arrayRoot.length; value++)
+              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+                for (
+                  var entries = response.getAll(reference),
+                    newKey = reference.slice(obj.length),
+                    j = 0;
+                  j < entries.length;
+                  j++
+                )
+                  key.append(newKey, entries[j]);
+                response.delete(reference);
+              }
+            return key;
           case "i":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, extractIterator)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                extractIterator
+              )
             );
           case "I":
             return Infinity;
@@ -3298,15 +3421,50 @@
           case "D":
             return new Date(Date.parse(value.slice(2)));
           case "n":
-            return BigInt(value.slice(2));
+            obj = value.slice(2);
+            if (obj.length > MAX_BIGINT_DIGITS)
+              throw Error(
+                "BigInt is too large. Received " +
+                  obj.length +
+                  " digits but the limit is " +
+                  MAX_BIGINT_DIGITS +
+                  "."
+              );
+            null !== arrayRoot &&
+              bumpArrayCount(arrayRoot, obj.length, response);
+            return BigInt(obj);
         }
         switch (value[1]) {
           case "A":
-            return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              ArrayBuffer,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "O":
-            return parseTypedArray(response, value, Int8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "o":
-            return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "U":
             return parseTypedArray(
               response,
@@ -3314,22 +3472,79 @@
               Uint8ClampedArray,
               1,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "S":
-            return parseTypedArray(response, value, Int16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "s":
-            return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "L":
-            return parseTypedArray(response, value, Int32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "l":
-            return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "G":
-            return parseTypedArray(response, value, Float32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "g":
-            return parseTypedArray(response, value, Float64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "M":
-            return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              BigInt64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "m":
             return parseTypedArray(
               response,
@@ -3337,10 +3552,19 @@
               BigUint64Array,
               8,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "V":
-            return parseTypedArray(response, value, DataView, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              DataView,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
@@ -3358,8 +3582,16 @@
             return parseAsyncIterable(response, value, !0);
         }
         value = value.slice(1);
-        return getOutlinedModel(response, value, obj, key, createModel);
+        return getOutlinedModel(
+          response,
+          value,
+          obj,
+          key,
+          arrayRoot,
+          createModel
+        );
       }
+      null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
       return value;
     }
     function createResponse(
@@ -3371,25 +3603,40 @@
           3 < arguments.length && void 0 !== arguments[3]
             ? arguments[3]
             : new FormData(),
+        arraySizeLimit =
+          4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
         chunks = new Map();
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
         _formData: backingFormData,
         _chunks: chunks,
-        _temporaryReferences: temporaryReferences
+        _temporaryReferences: temporaryReferences,
+        _rootArrayContexts: new WeakMap(),
+        _arraySizeLimit: arraySizeLimit
       };
     }
     function close(response) {
       reportGlobalError(response, Error("Connection closed."));
     }
-    function loadServerReference(bundlerConfig, id, bound) {
+    function loadServerReference(bundlerConfig, metaData) {
+      var id = metaData.id;
+      if ("string" !== typeof id) return null;
       var serverReference = resolveServerReference(bundlerConfig, id);
       bundlerConfig = preloadModule(serverReference);
-      return bound
-        ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+      metaData = metaData.bound;
+      return null !== metaData
+        ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
             _ref = _ref[0];
             var fn = requireModule(serverReference);
+            if (_ref.length > MAX_BOUND_ARGS)
+              throw Error(
+                "Server Function has too many bound arguments. Received " +
+                  _ref.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              );
             return fn.bind.apply(fn, [null].concat(_ref));
           })
         : bundlerConfig
@@ -3398,8 +3645,19 @@
             })
           : Promise.resolve(requireModule(serverReference));
     }
-    function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-      body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+    function decodeBoundActionMetaData(
+      body,
+      serverManifest,
+      formFieldPrefix,
+      arraySizeLimit
+    ) {
+      body = createResponse(
+        serverManifest,
+        formFieldPrefix,
+        void 0,
+        body,
+        arraySizeLimit
+      );
       close(body);
       body = getChunk(body, 0);
       body.then(function () {});
@@ -3829,13 +4087,14 @@
       patchConsole(console, "table"),
       patchConsole(console, "trace"),
       patchConsole(console, "warn"));
-    var ObjectPrototype = Object.prototype,
+    var ObjectPrototype$1 = Object.prototype,
       stringify = JSON.stringify,
       PENDING$1 = 0,
       COMPLETED = 1,
       ABORTED = 3,
       ERRORED$1 = 4,
       RENDERING = 5,
+      __PROTO__$1 = "__proto__",
       OPENING = 10,
       ABORTING = 12,
       CLOSING = 13,
@@ -3858,16 +4117,23 @@
         case "fulfilled":
           if ("function" === typeof resolve) {
             for (
-              var inspectedValue = this.value, cycleProtection = 0;
+              var inspectedValue = this.value,
+                cycleProtection = 0,
+                visited = new Set();
               inspectedValue instanceof ReactPromise;
 
             ) {
               cycleProtection++;
-              if (inspectedValue === this || 1e3 < cycleProtection) {
+              if (
+                inspectedValue === this ||
+                visited.has(inspectedValue) ||
+                1e3 < cycleProtection
+              ) {
                 "function" === typeof reject &&
                   reject(Error("Cannot have cyclic thenables."));
                 return;
               }
+              visited.add(inspectedValue);
               if ("fulfilled" === inspectedValue.status)
                 inspectedValue = inspectedValue.value;
               else break;
@@ -3888,7 +4154,15 @@
           "function" === typeof reject && reject(this.reason);
       }
     };
-    var initializingHandler = null;
+    var ObjectPrototype = Object.prototype,
+      ArrayPrototype = Array.prototype,
+      initializingHandler = null;
+    FlightIterator.prototype = {};
+    FlightIterator.prototype[ASYNC_ITERATOR] = function () {
+      return this;
+    };
+    var MAX_BIGINT_DIGITS = 300,
+      MAX_BOUND_ARGS = 1e3;
     exports.createClientModuleProxy = function (moduleId) {
       moduleId = registerClientReferenceImpl({}, moduleId, !1);
       return new Proxy(moduleId, proxyHandlers$1);
@@ -3898,20 +4172,24 @@
     };
     exports.decodeAction = function (body, serverManifest) {
       var formData = new FormData(),
-        action = null;
+        action = null,
+        seenActions = new Set();
       body.forEach(function (value, key) {
         key.startsWith("$ACTION_")
           ? key.startsWith("$ACTION_REF_")
-            ? ((value = "$ACTION_" + key.slice(12) + ":"),
+            ? seenActions.has(key) ||
+              (seenActions.add(key),
+              (value = "$ACTION_" + key.slice(12) + ":"),
               (value = decodeBoundActionMetaData(body, serverManifest, value)),
-              (action = loadServerReference(
-                serverManifest,
-                value.id,
-                value.bound
-              )))
+              (action = loadServerReference(serverManifest, value)))
             : key.startsWith("$ACTION_ID_") &&
-              ((value = key.slice(11)),
-              (action = loadServerReference(serverManifest, value, null)))
+              !seenActions.has(key) &&
+              (seenActions.add(key),
+              (value = key.slice(11)),
+              (action = loadServerReference(serverManifest, {
+                id: value,
+                bound: null
+              })))
           : formData.append(key, value);
       });
       return null === action
@@ -3947,7 +4225,8 @@
         webpackMap,
         "",
         options ? options.temporaryReferences : void 0,
-        body
+        body,
+        options ? options.arraySizeLimit : void 0
       );
       webpackMap = getChunk(body, 0);
       close(body);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -707,7 +707,7 @@ function describeObjectForErrorMessage(objectOrArray, expandedName) {
         "\n  " + str + "\n  " + objectOrArray)
       : "\n  " + str;
 }
-var ObjectPrototype = Object.prototype,
+var ObjectPrototype$1 = Object.prototype,
   stringify = JSON.stringify;
 function defaultErrorHandler(error) {
   console.error(error);
@@ -1534,7 +1534,7 @@ function renderModelDestructive(
     if (value instanceof Date) return "$D" + value.toJSON();
     request = getPrototypeOf(value);
     if (
-      request !== ObjectPrototype &&
+      request !== ObjectPrototype$1 &&
       (null === request || null !== getPrototypeOf(request))
     )
       throw Error(
@@ -2028,16 +2028,23 @@ ReactPromise.prototype.then = function (resolve, reject) {
     case "fulfilled":
       if ("function" === typeof resolve) {
         for (
-          var inspectedValue = this.value, cycleProtection = 0;
+          var inspectedValue = this.value,
+            cycleProtection = 0,
+            visited = new Set();
           inspectedValue instanceof ReactPromise;
 
         ) {
           cycleProtection++;
-          if (inspectedValue === this || 1e3 < cycleProtection) {
+          if (
+            inspectedValue === this ||
+            visited.has(inspectedValue) ||
+            1e3 < cycleProtection
+          ) {
             "function" === typeof reject &&
               reject(Error("Cannot have cyclic thenables."));
             return;
           }
+          visited.add(inspectedValue);
           if ("fulfilled" === inspectedValue.status)
             inspectedValue = inspectedValue.value;
           else break;
@@ -2056,12 +2063,14 @@ ReactPromise.prototype.then = function (resolve, reject) {
       "function" === typeof reject && reject(this.reason);
   }
 };
-function wakeChunk(response, listeners, value) {
+var ObjectPrototype = Object.prototype,
+  ArrayPrototype = Array.prototype;
+function wakeChunk(response, listeners, value, chunk) {
   for (var i = 0; i < listeners.length; i++) {
     var listener = listeners[i];
     "function" === typeof listener
       ? listener(value)
-      : fulfillReference(response, listener, value);
+      : fulfillReference(response, listener, value, chunk.reason);
   }
 }
 function rejectChunk(response, listeners, error) {
@@ -2071,27 +2080,6 @@ function rejectChunk(response, listeners, error) {
       ? listener(error)
       : rejectReference(response, listener.handler, error);
   }
-}
-function resolveBlockedCycle(resolvedChunk, reference) {
-  var referencedChunk = reference.handler.chunk;
-  if (null === referencedChunk) return null;
-  if (referencedChunk === resolvedChunk) return reference.handler;
-  reference = referencedChunk.value;
-  if (null !== reference)
-    for (
-      referencedChunk = 0;
-      referencedChunk < reference.length;
-      referencedChunk++
-    ) {
-      var listener = reference[referencedChunk];
-      if (
-        "function" !== typeof listener &&
-        ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-        null !== listener)
-      )
-        return listener;
-    }
-  return null;
 }
 function triggerErrorOnChunk(response, chunk, error) {
   if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2128,33 +2116,11 @@ function resolveModelChunk(response, chunk, value, id) {
     chunk.reason =
       ((value.id = id), (value[RESPONSE_SYMBOL] = response), value);
     if (null !== resolveListeners)
-      a: switch ((initializeModelChunk(chunk), chunk.status)) {
+      switch ((initializeModelChunk(chunk), chunk.status)) {
         case "fulfilled":
-          wakeChunk(response, resolveListeners, chunk.value);
+          wakeChunk(response, resolveListeners, chunk.value, chunk);
           break;
         case "blocked":
-          for (value = 0; value < resolveListeners.length; value++)
-            if (((id = resolveListeners[value]), "function" !== typeof id)) {
-              var cyclicHandler = resolveBlockedCycle(chunk, id);
-              if (null !== cyclicHandler)
-                switch (
-                  (fulfillReference(response, id, cyclicHandler.value),
-                  resolveListeners.splice(value, 1),
-                  value--,
-                  null !== rejectListeners &&
-                    ((id = rejectListeners.indexOf(id)),
-                    -1 !== id && rejectListeners.splice(id, 1)),
-                  chunk.status)
-                ) {
-                  case "fulfilled":
-                    wakeChunk(response, resolveListeners, chunk.value);
-                    break a;
-                  case "rejected":
-                    null !== rejectListeners &&
-                      rejectChunk(response, rejectListeners, chunk.reason);
-                    break a;
-                }
-            }
         case "pending":
           if (chunk.value)
             for (response = 0; response < resolveListeners.length; response++)
@@ -2171,7 +2137,8 @@ function resolveModelChunk(response, chunk, value, id) {
           } else chunk.reason = rejectListeners;
           break;
         case "rejected":
-          rejectListeners && wakeChunk(response, rejectListeners, chunk.reason);
+          rejectListeners &&
+            rejectChunk(response, rejectListeners, chunk.reason);
       }
   }
 }
@@ -2194,15 +2161,50 @@ function resolveIteratorResultChunk(response, chunk, value, done) {
   );
 }
 function loadServerReference$1(response, metaData, parentObject, key) {
+  function reject(error) {
+    var rejectListeners = blockedPromise.reason,
+      erroredPromise = blockedPromise;
+    erroredPromise.status = "rejected";
+    erroredPromise.value = null;
+    erroredPromise.reason = error;
+    null !== rejectListeners && rejectChunk(response, rejectListeners, error);
+    rejectReference(response, handler, error);
+  }
   var id = metaData.id;
   if ("string" !== typeof id || "then" === key) return null;
+  var cachedPromise = metaData.$$promise;
+  if (void 0 !== cachedPromise) {
+    if ("fulfilled" === cachedPromise.status)
+      return (
+        (cachedPromise = cachedPromise.value),
+        "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+      );
+    initializingHandler
+      ? ((id = initializingHandler), id.deps++)
+      : (id = initializingHandler =
+          { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+    cachedPromise.then(
+      resolveReference.bind(null, response, id, parentObject, key),
+      rejectReference.bind(null, response, id)
+    );
+    return null;
+  }
+  var blockedPromise = new ReactPromise("blocked", null, null);
+  metaData.$$promise = blockedPromise;
   var serverReference = resolveServerReference(response._bundlerConfig, id);
-  id = metaData.bound;
-  var promise = preloadModule(serverReference);
-  if (promise)
-    id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-  else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-  else return requireModule(serverReference);
+  cachedPromise = metaData.bound;
+  if ((id = preloadModule(serverReference)))
+    cachedPromise instanceof ReactPromise &&
+      (id = Promise.all([id, cachedPromise]));
+  else if (cachedPromise instanceof ReactPromise)
+    id = Promise.resolve(cachedPromise);
+  else
+    return (
+      (cachedPromise = requireModule(serverReference)),
+      (id = blockedPromise),
+      (id.status = "fulfilled"),
+      (id.value = cachedPromise)
+    );
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2214,73 +2216,104 @@ function loadServerReference$1(response, metaData, parentObject, key) {
       deps: 1,
       errored: !1
     };
-  promise.then(
-    function () {
-      var resolvedValue = requireModule(serverReference);
-      if (metaData.bound) {
-        var promiseValue = metaData.bound.value;
-        promiseValue = Array.isArray(promiseValue) ? promiseValue.slice(0) : [];
-        promiseValue.unshift(null);
-        resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
+  id.then(function () {
+    var resolvedValue = requireModule(serverReference);
+    if (metaData.bound) {
+      var promiseValue = metaData.bound.value;
+      promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+      if (1e3 < promiseValue.length) {
+        reject(
+          Error(
+            "Server Function has too many bound arguments. Received " +
+              promiseValue.length +
+              " but the limit is 1000."
+          )
+        );
+        return;
       }
-      parentObject[key] = resolvedValue;
-      "" === key && null === handler.value && (handler.value = resolvedValue);
-      handler.deps--;
-      0 === handler.deps &&
-        ((resolvedValue = handler.chunk),
-        null !== resolvedValue &&
-          "blocked" === resolvedValue.status &&
-          ((promiseValue = resolvedValue.value),
-          (resolvedValue.status = "fulfilled"),
-          (resolvedValue.value = handler.value),
-          (resolvedValue.reason = null),
-          null !== promiseValue &&
-            wakeChunk(response, promiseValue, handler.value)));
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+      promiseValue.unshift(null);
+      resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
     }
-  );
+    promiseValue = blockedPromise.value;
+    var initializedPromise = blockedPromise;
+    initializedPromise.status = "fulfilled";
+    initializedPromise.value = resolvedValue;
+    initializedPromise.reason = null;
+    null !== promiseValue &&
+      wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+    resolveReference(response, handler, parentObject, key, resolvedValue);
+  }, reject);
   return null;
 }
-function reviveModel(response, parentObj, parentKey, value, reference) {
+function reviveModel(
+  response,
+  parentObj,
+  parentKey,
+  value,
+  reference,
+  arrayRoot
+) {
   if ("string" === typeof value)
-    return parseModelString(response, parentObj, parentKey, value, reference);
+    return parseModelString(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    );
   if ("object" === typeof value && null !== value)
     if (
       (void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
         response._temporaryReferences.set(value, reference),
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
+      isArrayImpl(value))
+    ) {
+      if (null === arrayRoot) {
+        var childContext = { count: 0, fork: !1 };
+        response._rootArrayContexts.set(value, childContext);
+      } else childContext = arrayRoot;
+      1 < value.length && (childContext.fork = !0);
+      bumpArrayCount(childContext, value.length + 1, response);
+      for (parentObj = 0; parentObj < value.length; parentObj++)
+        value[parentObj] = reviveModel(
           response,
           value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
+          "" + parentObj,
+          value[parentObj],
+          void 0 !== reference ? reference + ":" + parentObj : void 0,
+          childContext
         );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj || "__proto__" === i
-            ? (value[i] = parentObj)
-            : delete value[i]);
+    } else
+      for (childContext in value)
+        hasOwnProperty.call(value, childContext) &&
+          ("__proto__" === childContext
+            ? delete value[childContext]
+            : ((parentObj =
+                void 0 !== reference && -1 === childContext.indexOf(":")
+                  ? reference + ":" + childContext
+                  : void 0),
+              (parentObj = reviveModel(
+                response,
+                value,
+                childContext,
+                value[childContext],
+                parentObj,
+                null
+              )),
+              void 0 !== parentObj
+                ? (value[childContext] = parentObj)
+                : delete value[childContext]));
   return value;
+}
+function bumpArrayCount(arrayContext, slots, response) {
+  if (
+    (arrayContext.count += slots) > response._arraySizeLimit &&
+    arrayContext.fork
+  )
+    throw Error(
+      "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+    );
 }
 var initializingHandler = null;
 function initializeModelChunk(chunk) {
@@ -2295,13 +2328,15 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var rawModel = JSON.parse(resolvedModel),
-      value = reviveModel(
+    var rawModel = JSON.parse(resolvedModel);
+    resolvedModel = { count: 0, fork: !1 };
+    var value = reviveModel(
         response,
         { "": rawModel },
         "",
         rawModel,
-        _chunk$reason
+        _chunk$reason,
+        resolvedModel
       ),
       resolveListeners = chunk.value;
     if (null !== resolveListeners)
@@ -2313,19 +2348,20 @@ function initializeModelChunk(chunk) {
         var listener = resolveListeners[rawModel];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, resolvedModel);
       }
     if (null !== initializingHandler) {
       if (initializingHandler.errored) throw initializingHandler.reason;
       if (0 < initializingHandler.deps) {
         initializingHandler.value = value;
+        initializingHandler.reason = resolvedModel;
         initializingHandler.chunk = chunk;
         return;
       }
     }
     chunk.status = "fulfilled";
     chunk.value = value;
-    chunk.reason = null;
+    chunk.reason = resolvedModel;
   } catch (error) {
     (chunk.status = "rejected"), (chunk.reason = error);
   } finally {
@@ -2338,7 +2374,8 @@ function reportGlobalError(response, error) {
       ? triggerErrorOnChunk(response, chunk, error)
       : "fulfilled" === chunk.status &&
         null !== chunk.reason &&
-        chunk.reason.error(error);
+        ((chunk = chunk.reason),
+        "function" === typeof chunk.error && chunk.error(error));
   });
 }
 function getChunk(response, id) {
@@ -2353,40 +2390,67 @@ function getChunk(response, id) {
     chunks.set(id, chunk));
   return chunk;
 }
-function fulfillReference(response, reference, value) {
+function fulfillReference(response, reference, value, arrayRoot) {
   var handler = reference.handler,
     parentObject = reference.parentObject,
     key = reference.key,
     map = reference.map,
     path = reference.path;
   try {
-    for (var i = 1; i < path.length; i++) {
+    for (
+      var localLength = 0,
+        rootArrayContexts = response._rootArrayContexts,
+        i = 1;
+      i < path.length;
+      i++
+    ) {
       var name = path[i];
       if (
         "object" !== typeof value ||
-        !hasOwnProperty.call(value, name) ||
-        value instanceof Promise
+        null === value ||
+        (getPrototypeOf(value) !== ObjectPrototype &&
+          getPrototypeOf(value) !== ArrayPrototype) ||
+        !hasOwnProperty.call(value, name)
       )
         throw Error("Invalid reference.");
       value = value[name];
+      if (isArrayImpl(value))
+        (localLength = 0),
+          (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+      else if (((arrayRoot = null), "string" === typeof value))
+        localLength = value.length;
+      else if ("bigint" === typeof value) {
+        var n = Math.abs(Number(value));
+        localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+      } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
     }
-    var mappedValue = map(response, value, parentObject, key);
-    parentObject[key] = mappedValue;
-    "" === key && null === handler.value && (handler.value = mappedValue);
+    var resolvedValue = map(response, value, parentObject, key);
+    var referenceArrayRoot = reference.arrayRoot;
+    null !== referenceArrayRoot &&
+      (null !== arrayRoot
+        ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+          bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+        : 0 < localLength &&
+          bumpArrayCount(referenceArrayRoot, localLength, response));
   } catch (error) {
-    rejectReference(response, reference.handler, error);
+    rejectReference(response, handler, error);
     return;
   }
+  resolveReference(response, handler, parentObject, key, resolvedValue);
+}
+function resolveReference(response, handler, parentObject, key, resolvedValue) {
+  "__proto__" !== key && (parentObject[key] = resolvedValue);
+  "" === key && null === handler.value && (handler.value = resolvedValue);
   handler.deps--;
   0 === handler.deps &&
-    ((reference = handler.chunk),
-    null !== reference &&
-      "blocked" === reference.status &&
-      ((value = reference.value),
-      (reference.status = "fulfilled"),
-      (reference.value = handler.value),
-      (reference.reason = handler.reason),
-      null !== value && wakeChunk(response, value, handler.value)));
+    ((parentObject = handler.chunk),
+    null !== parentObject &&
+      "blocked" === parentObject.status &&
+      ((key = parentObject.value),
+      (parentObject.status = "fulfilled"),
+      (parentObject.value = handler.value),
+      (parentObject.reason = handler.reason),
+      null !== key && wakeChunk(response, key, handler.value, parentObject)));
 }
 function rejectReference(response, handler, error) {
   handler.errored ||
@@ -2398,60 +2462,97 @@ function rejectReference(response, handler, error) {
       "blocked" === handler.status &&
       triggerErrorOnChunk(response, handler, error));
 }
-function getOutlinedModel(response, reference, parentObject, key, map) {
+function getOutlinedModel(
+  response,
+  reference,
+  parentObject,
+  key,
+  referenceArrayRoot,
+  map
+) {
   reference = reference.split(":");
-  var id = parseInt(reference[0], 16);
-  id = getChunk(response, id);
-  switch (id.status) {
+  var id = parseInt(reference[0], 16),
+    chunk = getChunk(response, id);
+  switch (chunk.status) {
     case "resolved_model":
-      initializeModelChunk(id);
+      initializeModelChunk(chunk);
   }
-  switch (id.status) {
+  switch (chunk.status) {
     case "fulfilled":
-      id = id.value;
-      for (var i = 1; i < reference.length; i++) {
-        var name = reference[i];
+      id = chunk.value;
+      chunk = chunk.reason;
+      for (
+        var localLength = 0,
+          rootArrayContexts = response._rootArrayContexts,
+          i = 1;
+        i < reference.length;
+        i++
+      ) {
+        localLength = reference[i];
         if (
           "object" !== typeof id ||
-          !hasOwnProperty.call(id, name) ||
-          id instanceof Promise
+          null === id ||
+          (getPrototypeOf(id) !== ObjectPrototype &&
+            getPrototypeOf(id) !== ArrayPrototype) ||
+          !hasOwnProperty.call(id, localLength)
         )
           throw Error("Invalid reference.");
-        id = id[name];
+        id = id[localLength];
+        isArrayImpl(id)
+          ? ((localLength = 0), (chunk = rootArrayContexts.get(id) || chunk))
+          : ((chunk = null),
+            "string" === typeof id
+              ? (localLength = id.length)
+              : "bigint" === typeof id
+                ? ((localLength = Math.abs(Number(id))),
+                  (localLength =
+                    0 === localLength
+                      ? 1
+                      : Math.floor(Math.log10(localLength)) + 1))
+                : (localLength = ArrayBuffer.isView(id) ? id.byteLength : 0));
       }
-      return map(response, id, parentObject, key);
-    case "pending":
+      parentObject = map(response, id, parentObject, key);
+      null !== referenceArrayRoot &&
+        (null !== chunk
+          ? (chunk.fork && (referenceArrayRoot.fork = !0),
+            bumpArrayCount(referenceArrayRoot, chunk.count, response))
+          : 0 < localLength &&
+            bumpArrayCount(referenceArrayRoot, localLength, response));
+      return parentObject;
     case "blocked":
       return (
         initializingHandler
           ? ((response = initializingHandler), response.deps++)
           : (response = initializingHandler =
               { chunk: null, value: null, reason: null, deps: 1, errored: !1 }),
-        (parentObject = {
+        (referenceArrayRoot = {
           handler: response,
           parentObject: parentObject,
           key: key,
           map: map,
-          path: reference
+          path: reference,
+          arrayRoot: referenceArrayRoot
         }),
-        null === id.value
-          ? (id.value = [parentObject])
-          : id.value.push(parentObject),
-        null === id.reason
-          ? (id.reason = [parentObject])
-          : id.reason.push(parentObject),
+        null === chunk.value
+          ? (chunk.value = [referenceArrayRoot])
+          : chunk.value.push(referenceArrayRoot),
+        null === chunk.reason
+          ? (chunk.reason = [referenceArrayRoot])
+          : chunk.reason.push(referenceArrayRoot),
         null
       );
+    case "pending":
+      throw Error("Invalid forward reference.");
     default:
       return (
         initializingHandler
           ? ((initializingHandler.errored = !0),
             (initializingHandler.value = null),
-            (initializingHandler.reason = id.reason))
+            (initializingHandler.reason = chunk.reason))
           : (initializingHandler = {
               chunk: null,
               value: null,
-              reason: id.reason,
+              reason: chunk.reason,
               deps: 0,
               errored: !0
             }),
@@ -2460,13 +2561,25 @@ function getOutlinedModel(response, reference, parentObject, key, map) {
   }
 }
 function createMap(response, model) {
-  return new Map(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+  response = new Map(model);
+  model.$$consumed = !0;
+  return response;
 }
 function createSet(response, model) {
-  return new Set(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+  response = new Set(model);
+  model.$$consumed = !0;
+  return response;
 }
 function extractIterator(response, model) {
-  return model[Symbol.iterator]();
+  if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+  response = model[Symbol.iterator]();
+  model.$$consumed = !0;
+  return response;
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2477,13 +2590,34 @@ function parseTypedArray(
   constructor,
   bytesPerElement,
   parentObject,
-  parentKey
+  parentKey,
+  referenceArrayRoot
 ) {
+  function reject(error) {
+    if (!handler.errored) {
+      handler.errored = !0;
+      handler.value = null;
+      handler.reason = error;
+      var chunk = handler.chunk;
+      null !== chunk &&
+        "blocked" === chunk.status &&
+        triggerErrorOnChunk(response, chunk, error);
+    }
+  }
   reference = parseInt(reference.slice(2), 16);
-  bytesPerElement = response._prefix + reference;
-  if (response._chunks.has(reference))
+  var key = response._prefix + reference;
+  bytesPerElement = response._chunks;
+  if (bytesPerElement.has(reference))
     throw Error("Already initialized typed array.");
-  reference = response._formData.get(bytesPerElement).arrayBuffer();
+  bytesPerElement.set(
+    reference,
+    new ReactPromise(
+      "rejected",
+      null,
+      Error("Already initialized typed array.")
+    )
+  );
+  reference = response._formData.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2495,37 +2629,32 @@ function parseTypedArray(
       deps: 1,
       errored: !1
     };
-  reference.then(
-    function (buffer) {
-      buffer = constructor === ArrayBuffer ? buffer : new constructor(buffer);
-      parentObject[parentKey] = buffer;
-      "" === parentKey && null === handler.value && (handler.value = buffer);
-      handler.deps--;
-      if (
-        0 === handler.deps &&
-        ((buffer = handler.chunk),
-        null !== buffer && "blocked" === buffer.status)
-      ) {
-        var resolveListeners = buffer.value;
-        buffer.status = "fulfilled";
-        buffer.value = handler.value;
-        buffer.reason = null;
-        null !== resolveListeners &&
-          wakeChunk(response, resolveListeners, handler.value);
-      }
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+  reference.then(function (buffer) {
+    try {
+      null !== referenceArrayRoot &&
+        bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+      var resolvedValue =
+        constructor === ArrayBuffer ? buffer : new constructor(buffer);
+      "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
+      "" === parentKey &&
+        null === handler.value &&
+        (handler.value = resolvedValue);
+    } catch (x) {
+      reject(x);
+      return;
     }
-  );
+    handler.deps--;
+    0 === handler.deps &&
+      ((buffer = handler.chunk),
+      null !== buffer &&
+        "blocked" === buffer.status &&
+        ((resolvedValue = buffer.value),
+        (buffer.status = "fulfilled"),
+        (buffer.value = handler.value),
+        (buffer.reason = null),
+        null !== resolvedValue &&
+          wakeChunk(response, resolvedValue, handler.value, buffer)));
+  }, reject);
   return null;
 }
 function resolveStream(response, id, stream, controller) {
@@ -2541,86 +2670,78 @@ function resolveStream(response, id, stream, controller) {
           : controller.enqueueModel(chunks));
 }
 function parseReadableStream(response, reference, type) {
+  function enqueue(value) {
+    "bytes" !== type || ArrayBuffer.isView(value)
+      ? controller.enqueue(value)
+      : flightController.error(Error("Invalid data for bytes stream."));
+  }
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
     throw Error("Already initialized stream.");
   var controller = null,
-    closed = !1;
-  type = new ReadableStream({
-    type: type,
-    start: function (c) {
-      controller = c;
-    }
-  });
-  var previousBlockedChunk = null;
-  resolveStream(response, reference, type, {
-    enqueueModel: function (json) {
-      if (null === previousBlockedChunk) {
-        var chunk = createResolvedModelChunk(response, json, -1);
-        initializeModelChunk(chunk);
-        "fulfilled" === chunk.status
-          ? controller.enqueue(chunk.value)
-          : (chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            ),
-            (previousBlockedChunk = chunk));
-      } else {
-        chunk = previousBlockedChunk;
-        var chunk$31 = new ReactPromise("pending", null, null);
-        chunk$31.then(
-          function (v) {
-            return controller.enqueue(v);
-          },
-          function (e) {
-            return controller.error(e);
-          }
-        );
-        previousBlockedChunk = chunk$31;
-        chunk.then(function () {
-          previousBlockedChunk === chunk$31 && (previousBlockedChunk = null);
-          resolveModelChunk(response, chunk$31, json, -1);
-        });
+    closed = !1,
+    stream = new ReadableStream({
+      type: type,
+      start: function (c) {
+        controller = c;
       }
-    },
-    close: function () {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk)) controller.close();
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.close();
+    }),
+    previousBlockedChunk = null,
+    flightController = {
+      enqueueModel: function (json) {
+        if (null === previousBlockedChunk) {
+          var chunk = createResolvedModelChunk(response, json, -1);
+          initializeModelChunk(chunk);
+          "fulfilled" === chunk.status
+            ? enqueue(chunk.value)
+            : (chunk.then(enqueue, flightController.error),
+              (previousBlockedChunk = chunk));
+        } else {
+          chunk = previousBlockedChunk;
+          var chunk$32 = new ReactPromise("pending", null, null);
+          chunk$32.then(enqueue, flightController.error);
+          previousBlockedChunk = chunk$32;
+          chunk.then(function () {
+            previousBlockedChunk === chunk$32 && (previousBlockedChunk = null);
+            resolveModelChunk(response, chunk$32, json, -1);
           });
         }
-    },
-    error: function (error) {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk))
-          controller.error(error);
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.error(error);
-          });
-        }
-    }
-  });
-  return type;
+      },
+      close: function () {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.close();
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.close();
+            });
+          }
+      },
+      error: function (error) {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.error(error);
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.error(error);
+            });
+          }
+      }
+    };
+  resolveStream(response, reference, stream, flightController);
+  return stream;
 }
-function asyncIterator() {
+function FlightIterator(next) {
+  this.next = next;
+}
+FlightIterator.prototype = {};
+FlightIterator.prototype[ASYNC_ITERATOR] = function () {
   return this;
-}
-function createIterator(next) {
-  next = { next: next };
-  next[ASYNC_ITERATOR] = asyncIterator;
-  return next;
-}
+};
 function parseAsyncIterable(response, reference, iterator) {
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
@@ -2632,7 +2753,7 @@ function parseAsyncIterable(response, reference, iterator) {
   $jscomp$compprop5 =
     (($jscomp$compprop5[ASYNC_ITERATOR] = function () {
       var nextReadIndex = 0;
-      return createIterator(function (arg) {
+      return new FlightIterator(function (arg) {
         if (void 0 !== arg)
           throw Error(
             "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -2712,17 +2833,28 @@ function parseAsyncIterable(response, reference, iterator) {
   });
   return iterator;
 }
-function parseModelString(response, obj, key, value, reference) {
+function parseModelString(response, obj, key, value, reference, arrayRoot) {
   if ("$" === value[0]) {
     switch (value[1]) {
       case "$":
-        return value.slice(1);
+        return (
+          null !== arrayRoot &&
+            bumpArrayCount(arrayRoot, value.length - 1, response),
+          value.slice(1)
+        );
       case "@":
         return (obj = parseInt(value.slice(2), 16)), getChunk(response, obj);
       case "h":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, loadServerReference$1)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(
+            response,
+            arrayRoot,
+            obj,
+            key,
+            null,
+            loadServerReference$1
+          )
         );
       case "T":
         if (void 0 === reference || void 0 === response._temporaryReferences)
@@ -2735,27 +2867,37 @@ function parseModelString(response, obj, key, value, reference) {
         );
       case "Q":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createMap)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
         );
       case "W":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createSet)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
         obj = value.slice(2);
-        var formPrefix = response._prefix + obj + "_",
-          data = new FormData();
-        response._formData.forEach(function (entry, entryKey) {
-          entryKey.startsWith(formPrefix) &&
-            data.append(entryKey.slice(formPrefix.length), entry);
-        });
-        return data;
+        obj = response._prefix + obj + "_";
+        key = new FormData();
+        response = response._formData;
+        arrayRoot = Array.from(response.keys());
+        for (value = 0; value < arrayRoot.length; value++)
+          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            for (
+              var entries = response.getAll(reference),
+                newKey = reference.slice(obj.length),
+                j = 0;
+              j < entries.length;
+              j++
+            )
+              key.append(newKey, entries[j]);
+            response.delete(reference);
+          }
+        return key;
       case "i":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, extractIterator)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, extractIterator)
         );
       case "I":
         return Infinity;
@@ -2768,35 +2910,147 @@ function parseModelString(response, obj, key, value, reference) {
       case "D":
         return new Date(Date.parse(value.slice(2)));
       case "n":
-        return BigInt(value.slice(2));
+        obj = value.slice(2);
+        if (300 < obj.length)
+          throw Error(
+            "BigInt is too large. Received " +
+              obj.length +
+              " digits but the limit is 300."
+          );
+        null !== arrayRoot && bumpArrayCount(arrayRoot, obj.length, response);
+        return BigInt(obj);
     }
     switch (value[1]) {
       case "A":
-        return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          ArrayBuffer,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "O":
-        return parseTypedArray(response, value, Int8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "o":
-        return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "U":
-        return parseTypedArray(response, value, Uint8ClampedArray, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8ClampedArray,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "S":
-        return parseTypedArray(response, value, Int16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "s":
-        return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "L":
-        return parseTypedArray(response, value, Int32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "l":
-        return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "G":
-        return parseTypedArray(response, value, Float32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "g":
-        return parseTypedArray(response, value, Float64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "M":
-        return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigInt64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "m":
-        return parseTypedArray(response, value, BigUint64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigUint64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "V":
-        return parseTypedArray(response, value, DataView, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          DataView,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
@@ -2814,8 +3068,9 @@ function parseModelString(response, obj, key, value, reference) {
         return parseAsyncIterable(response, value, !0);
     }
     value = value.slice(1);
-    return getOutlinedModel(response, value, obj, key, createModel);
+    return getOutlinedModel(response, value, obj, key, arrayRoot, createModel);
   }
+  null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
   return value;
 }
 function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
@@ -2823,25 +3078,38 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
       3 < arguments.length && void 0 !== arguments[3]
         ? arguments[3]
         : new FormData(),
+    arraySizeLimit =
+      4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
     chunks = new Map();
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
     _formData: backingFormData,
     _chunks: chunks,
-    _temporaryReferences: temporaryReferences
+    _temporaryReferences: temporaryReferences,
+    _rootArrayContexts: new WeakMap(),
+    _arraySizeLimit: arraySizeLimit
   };
 }
 function close(response) {
   reportGlobalError(response, Error("Connection closed."));
 }
-function loadServerReference(bundlerConfig, id, bound) {
+function loadServerReference(bundlerConfig, metaData) {
+  var id = metaData.id;
+  if ("string" !== typeof id) return null;
   var serverReference = resolveServerReference(bundlerConfig, id);
   bundlerConfig = preloadModule(serverReference);
-  return bound
-    ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+  metaData = metaData.bound;
+  return null !== metaData
+    ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
         _ref = _ref[0];
         var fn = requireModule(serverReference);
+        if (1e3 < _ref.length)
+          throw Error(
+            "Server Function has too many bound arguments. Received " +
+              _ref.length +
+              " but the limit is 1000."
+          );
         return fn.bind.apply(fn, [null].concat(_ref));
       })
     : bundlerConfig
@@ -2850,8 +3118,19 @@ function loadServerReference(bundlerConfig, id, bound) {
         })
       : Promise.resolve(requireModule(serverReference));
 }
-function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-  body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+function decodeBoundActionMetaData(
+  body,
+  serverManifest,
+  formFieldPrefix,
+  arraySizeLimit
+) {
+  body = createResponse(
+    serverManifest,
+    formFieldPrefix,
+    void 0,
+    body,
+    arraySizeLimit
+  );
   close(body);
   body = getChunk(body, 0);
   body.then(function () {});
@@ -2867,16 +3146,24 @@ exports.createTemporaryReferenceSet = function () {
 };
 exports.decodeAction = function (body, serverManifest) {
   var formData = new FormData(),
-    action = null;
+    action = null,
+    seenActions = new Set();
   body.forEach(function (value, key) {
     key.startsWith("$ACTION_")
       ? key.startsWith("$ACTION_REF_")
-        ? ((value = "$ACTION_" + key.slice(12) + ":"),
+        ? seenActions.has(key) ||
+          (seenActions.add(key),
+          (value = "$ACTION_" + key.slice(12) + ":"),
           (value = decodeBoundActionMetaData(body, serverManifest, value)),
-          (action = loadServerReference(serverManifest, value.id, value.bound)))
+          (action = loadServerReference(serverManifest, value)))
         : key.startsWith("$ACTION_ID_") &&
-          ((value = key.slice(11)),
-          (action = loadServerReference(serverManifest, value, null)))
+          !seenActions.has(key) &&
+          (seenActions.add(key),
+          (value = key.slice(11)),
+          (action = loadServerReference(serverManifest, {
+            id: value,
+            bound: null
+          })))
       : formData.append(key, value);
   });
   return null === action
@@ -2912,7 +3199,8 @@ exports.decodeReply = function (body, webpackMap, options) {
     webpackMap,
     "",
     options ? options.temporaryReferences : void 0,
-    body
+    body,
+    options ? options.arraySizeLimit : void 0
   );
   webpackMap = getChunk(body, 0);
   close(body);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -1497,6 +1497,13 @@
       value
     ) {
       task.model = value;
+      parentPropertyName === __PROTO__$1 &&
+        callWithDebugContextInDEV(request, task, function () {
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(parent, parentPropertyName)
+          );
+        });
       if (value === REACT_ELEMENT_TYPE) return "$";
       if (null === value) return null;
       if ("object" === typeof value) {
@@ -1667,7 +1674,7 @@
         if (value instanceof Date) return "$D" + value.toJSON();
         elementReference = getPrototypeOf(value);
         if (
-          elementReference !== ObjectPrototype &&
+          elementReference !== ObjectPrototype$1 &&
           (null === elementReference ||
             null !== getPrototypeOf(elementReference))
         )
@@ -2560,12 +2567,12 @@
       this.value = value;
       this.reason = reason;
     }
-    function wakeChunk(response, listeners, value) {
+    function wakeChunk(response, listeners, value, chunk) {
       for (var i = 0; i < listeners.length; i++) {
         var listener = listeners[i];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, chunk.reason);
       }
     }
     function rejectChunk(response, listeners, error) {
@@ -2575,27 +2582,6 @@
           ? listener(error)
           : rejectReference(response, listener.handler, error);
       }
-    }
-    function resolveBlockedCycle(resolvedChunk, reference) {
-      var referencedChunk = reference.handler.chunk;
-      if (null === referencedChunk) return null;
-      if (referencedChunk === resolvedChunk) return reference.handler;
-      reference = referencedChunk.value;
-      if (null !== reference)
-        for (
-          referencedChunk = 0;
-          referencedChunk < reference.length;
-          referencedChunk++
-        ) {
-          var listener = reference[referencedChunk];
-          if (
-            "function" !== typeof listener &&
-            ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-            null !== listener)
-          )
-            return listener;
-        }
-      return null;
     }
     function triggerErrorOnChunk(response, chunk, error) {
       if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2620,57 +2606,25 @@
         chunk.value = value;
         chunk.reason = _defineProperty({ id: id }, RESPONSE_SYMBOL, response);
         if (null !== resolveListeners)
-          a: switch ((initializeModelChunk(chunk), chunk.status)) {
+          switch ((initializeModelChunk(chunk), chunk.status)) {
             case "fulfilled":
-              wakeChunk(response, resolveListeners, chunk.value);
+              wakeChunk(response, resolveListeners, chunk.value, chunk);
               break;
             case "blocked":
-              for (value = 0; value < resolveListeners.length; value++)
-                if (
-                  ((id = resolveListeners[value]), "function" !== typeof id)
-                ) {
-                  var cyclicHandler = resolveBlockedCycle(chunk, id);
-                  if (null !== cyclicHandler)
-                    switch (
-                      (fulfillReference(response, id, cyclicHandler.value),
-                      resolveListeners.splice(value, 1),
-                      value--,
-                      null !== rejectListeners &&
-                        ((id = rejectListeners.indexOf(id)),
-                        -1 !== id && rejectListeners.splice(id, 1)),
-                      chunk.status)
-                    ) {
-                      case "fulfilled":
-                        wakeChunk(response, resolveListeners, chunk.value);
-                        break a;
-                      case "rejected":
-                        null !== rejectListeners &&
-                          rejectChunk(response, rejectListeners, chunk.reason);
-                        break a;
-                    }
-                }
             case "pending":
               if (chunk.value)
-                for (
-                  response = 0;
-                  response < resolveListeners.length;
-                  response++
-                )
-                  chunk.value.push(resolveListeners[response]);
+                for (value = 0; value < resolveListeners.length; value++)
+                  chunk.value.push(resolveListeners[value]);
               else chunk.value = resolveListeners;
               if (chunk.reason) {
                 if (rejectListeners)
-                  for (
-                    resolveListeners = 0;
-                    resolveListeners < rejectListeners.length;
-                    resolveListeners++
-                  )
-                    chunk.reason.push(rejectListeners[resolveListeners]);
+                  for (value = 0; value < rejectListeners.length; value++)
+                    chunk.reason.push(rejectListeners[value]);
               } else chunk.reason = rejectListeners;
               break;
             case "rejected":
               rejectListeners &&
-                wakeChunk(response, rejectListeners, chunk.reason);
+                rejectChunk(response, rejectListeners, chunk.reason);
           }
       }
     }
@@ -2694,15 +2648,51 @@
       );
     }
     function loadServerReference$1(response, metaData, parentObject, key) {
+      function reject(error) {
+        var rejectListeners = blockedPromise.reason,
+          erroredPromise = blockedPromise;
+        erroredPromise.status = "rejected";
+        erroredPromise.value = null;
+        erroredPromise.reason = error;
+        null !== rejectListeners &&
+          rejectChunk(response, rejectListeners, error);
+        rejectReference(response, handler, error);
+      }
       var id = metaData.id;
       if ("string" !== typeof id || "then" === key) return null;
+      var cachedPromise = metaData.$$promise;
+      if (void 0 !== cachedPromise) {
+        if ("fulfilled" === cachedPromise.status)
+          return (
+            (cachedPromise = cachedPromise.value),
+            "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+          );
+        initializingHandler
+          ? ((id = initializingHandler), id.deps++)
+          : (id = initializingHandler =
+              { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+        cachedPromise.then(
+          resolveReference.bind(null, response, id, parentObject, key),
+          rejectReference.bind(null, response, id)
+        );
+        return null;
+      }
+      var blockedPromise = new ReactPromise("blocked", null, null);
+      metaData.$$promise = blockedPromise;
       var serverReference = resolveServerReference(response._bundlerConfig, id);
-      id = metaData.bound;
-      var promise = preloadModule(serverReference);
-      if (promise)
-        id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-      else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-      else return requireModule(serverReference);
+      cachedPromise = metaData.bound;
+      if ((id = preloadModule(serverReference)))
+        cachedPromise instanceof ReactPromise &&
+          (id = Promise.all([id, cachedPromise]));
+      else if (cachedPromise instanceof ReactPromise)
+        id = Promise.resolve(cachedPromise);
+      else
+        return (
+          (cachedPromise = requireModule(serverReference)),
+          (id = blockedPromise),
+          (id.status = "fulfilled"),
+          (id.value = cachedPromise)
+        );
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -2714,92 +2704,106 @@
           deps: 1,
           errored: !1
         };
-      promise.then(
-        function () {
-          var resolvedValue = requireModule(serverReference);
-          if (metaData.bound) {
-            var promiseValue = metaData.bound.value;
-            promiseValue = Array.isArray(promiseValue)
-              ? promiseValue.slice(0)
-              : [];
-            promiseValue.unshift(null);
-            resolvedValue = resolvedValue.bind.apply(
-              resolvedValue,
-              promiseValue
+      id.then(function () {
+        var resolvedValue = requireModule(serverReference);
+        if (metaData.bound) {
+          var promiseValue = metaData.bound.value;
+          promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+          if (promiseValue.length > MAX_BOUND_ARGS) {
+            reject(
+              Error(
+                "Server Function has too many bound arguments. Received " +
+                  promiseValue.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              )
             );
+            return;
           }
-          parentObject[key] = resolvedValue;
-          "" === key &&
-            null === handler.value &&
-            (handler.value = resolvedValue);
-          handler.deps--;
-          0 === handler.deps &&
-            ((resolvedValue = handler.chunk),
-            null !== resolvedValue &&
-              "blocked" === resolvedValue.status &&
-              ((promiseValue = resolvedValue.value),
-              (resolvedValue.status = "fulfilled"),
-              (resolvedValue.value = handler.value),
-              (resolvedValue.reason = null),
-              null !== promiseValue &&
-                wakeChunk(response, promiseValue, handler.value)));
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+          promiseValue.unshift(null);
+          resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
         }
-      );
+        promiseValue = blockedPromise.value;
+        var initializedPromise = blockedPromise;
+        initializedPromise.status = "fulfilled";
+        initializedPromise.value = resolvedValue;
+        initializedPromise.reason = null;
+        null !== promiseValue &&
+          wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+        resolveReference(response, handler, parentObject, key, resolvedValue);
+      }, reject);
       return null;
     }
-    function reviveModel(response, parentObj, parentKey, value, reference) {
+    function reviveModel(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    ) {
       if ("string" === typeof value)
         return parseModelString(
           response,
           parentObj,
           parentKey,
           value,
-          reference
+          reference,
+          arrayRoot
         );
       if ("object" === typeof value && null !== value)
         if (
           (void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
             response._temporaryReferences.set(value, reference),
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
+          isArrayImpl(value))
+        ) {
+          if (null === arrayRoot) {
+            var childContext = { count: 0, fork: !1 };
+            response._rootArrayContexts.set(value, childContext);
+          } else childContext = arrayRoot;
+          1 < value.length && (childContext.fork = !0);
+          bumpArrayCount(childContext, value.length + 1, response);
+          for (parentObj = 0; parentObj < value.length; parentObj++)
+            value[parentObj] = reviveModel(
               response,
               value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
+              "" + parentObj,
+              value[parentObj],
+              void 0 !== reference ? reference + ":" + parentObj : void 0,
+              childContext
             );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj || "__proto__" === i
-                ? (value[i] = parentObj)
-                : delete value[i]);
+        } else
+          for (childContext in value)
+            hasOwnProperty.call(value, childContext) &&
+              ("__proto__" === childContext
+                ? delete value[childContext]
+                : ((parentObj =
+                    void 0 !== reference && -1 === childContext.indexOf(":")
+                      ? reference + ":" + childContext
+                      : void 0),
+                  (parentObj = reviveModel(
+                    response,
+                    value,
+                    childContext,
+                    value[childContext],
+                    parentObj,
+                    null
+                  )),
+                  void 0 !== parentObj
+                    ? (value[childContext] = parentObj)
+                    : delete value[childContext]));
       return value;
+    }
+    function bumpArrayCount(arrayContext, slots, response) {
+      if (
+        (arrayContext.count += slots) > response._arraySizeLimit &&
+        arrayContext.fork
+      )
+        throw Error(
+          "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+        );
     }
     function initializeModelChunk(chunk) {
       var prevHandler = initializingHandler;
@@ -2814,13 +2818,15 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var rawModel = JSON.parse(resolvedModel),
-          value = reviveModel(
+        var rawModel = JSON.parse(resolvedModel);
+        resolvedModel = { count: 0, fork: !1 };
+        var value = reviveModel(
             response,
             { "": rawModel },
             "",
             rawModel,
-            _chunk$reason
+            _chunk$reason,
+            resolvedModel
           ),
           resolveListeners = chunk.value;
         if (null !== resolveListeners)
@@ -2832,19 +2838,20 @@
             var listener = resolveListeners[rawModel];
             "function" === typeof listener
               ? listener(value)
-              : fulfillReference(response, listener, value);
+              : fulfillReference(response, listener, value, resolvedModel);
           }
         if (null !== initializingHandler) {
           if (initializingHandler.errored) throw initializingHandler.reason;
           if (0 < initializingHandler.deps) {
             initializingHandler.value = value;
+            initializingHandler.reason = resolvedModel;
             initializingHandler.chunk = chunk;
             return;
           }
         }
         chunk.status = "fulfilled";
         chunk.value = value;
-        chunk.reason = null;
+        chunk.reason = resolvedModel;
       } catch (error) {
         (chunk.status = "rejected"), (chunk.reason = error);
       } finally {
@@ -2857,7 +2864,8 @@
           ? triggerErrorOnChunk(response, chunk, error)
           : "fulfilled" === chunk.status &&
             null !== chunk.reason &&
-            chunk.reason.error(error);
+            ((chunk = chunk.reason),
+            "function" === typeof chunk.error && chunk.error(error));
       });
     }
     function getChunk(response, id) {
@@ -2876,40 +2884,74 @@
         chunks.set(id, chunk));
       return chunk;
     }
-    function fulfillReference(response, reference, value) {
+    function fulfillReference(response, reference, value, arrayRoot) {
       var handler = reference.handler,
         parentObject = reference.parentObject,
         key = reference.key,
         map = reference.map,
         path = reference.path;
       try {
-        for (var i = 1; i < path.length; i++) {
+        for (
+          var localLength = 0,
+            rootArrayContexts = response._rootArrayContexts,
+            i = 1;
+          i < path.length;
+          i++
+        ) {
           var name = path[i];
           if (
             "object" !== typeof value ||
-            !hasOwnProperty.call(value, name) ||
-            value instanceof Promise
+            null === value ||
+            (getPrototypeOf(value) !== ObjectPrototype &&
+              getPrototypeOf(value) !== ArrayPrototype) ||
+            !hasOwnProperty.call(value, name)
           )
             throw Error("Invalid reference.");
           value = value[name];
+          if (isArrayImpl(value))
+            (localLength = 0),
+              (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+          else if (((arrayRoot = null), "string" === typeof value))
+            localLength = value.length;
+          else if ("bigint" === typeof value) {
+            var n = Math.abs(Number(value));
+            localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+          } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
         }
-        var mappedValue = map(response, value, parentObject, key);
-        parentObject[key] = mappedValue;
-        "" === key && null === handler.value && (handler.value = mappedValue);
+        var resolvedValue = map(response, value, parentObject, key);
+        var referenceArrayRoot = reference.arrayRoot;
+        null !== referenceArrayRoot &&
+          (null !== arrayRoot
+            ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+              bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+            : 0 < localLength &&
+              bumpArrayCount(referenceArrayRoot, localLength, response));
       } catch (error) {
-        rejectReference(response, reference.handler, error);
+        rejectReference(response, handler, error);
         return;
       }
+      resolveReference(response, handler, parentObject, key, resolvedValue);
+    }
+    function resolveReference(
+      response,
+      handler,
+      parentObject,
+      key,
+      resolvedValue
+    ) {
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
+      "" === key && null === handler.value && (handler.value = resolvedValue);
       handler.deps--;
       0 === handler.deps &&
-        ((reference = handler.chunk),
-        null !== reference &&
-          "blocked" === reference.status &&
-          ((value = reference.value),
-          (reference.status = "fulfilled"),
-          (reference.value = handler.value),
-          (reference.reason = handler.reason),
-          null !== value && wakeChunk(response, value, handler.value)));
+        ((parentObject = handler.chunk),
+        null !== parentObject &&
+          "blocked" === parentObject.status &&
+          ((key = parentObject.value),
+          (parentObject.status = "fulfilled"),
+          (parentObject.value = handler.value),
+          (parentObject.reason = handler.reason),
+          null !== key &&
+            wakeChunk(response, key, handler.value, parentObject)));
     }
     function rejectReference(response, handler, error) {
       handler.errored ||
@@ -2921,29 +2963,66 @@
           "blocked" === handler.status &&
           triggerErrorOnChunk(response, handler, error));
     }
-    function getOutlinedModel(response, reference, parentObject, key, map) {
+    function getOutlinedModel(
+      response,
+      reference,
+      parentObject,
+      key,
+      referenceArrayRoot,
+      map
+    ) {
       reference = reference.split(":");
-      var id = parseInt(reference[0], 16);
-      id = getChunk(response, id);
-      switch (id.status) {
+      var id = parseInt(reference[0], 16),
+        chunk = getChunk(response, id);
+      switch (chunk.status) {
         case "resolved_model":
-          initializeModelChunk(id);
+          initializeModelChunk(chunk);
       }
-      switch (id.status) {
+      switch (chunk.status) {
         case "fulfilled":
-          id = id.value;
-          for (var i = 1; i < reference.length; i++) {
-            var name = reference[i];
+          id = chunk.value;
+          chunk = chunk.reason;
+          for (
+            var localLength = 0,
+              rootArrayContexts = response._rootArrayContexts,
+              i = 1;
+            i < reference.length;
+            i++
+          ) {
+            localLength = reference[i];
             if (
               "object" !== typeof id ||
-              !hasOwnProperty.call(id, name) ||
-              id instanceof Promise
+              null === id ||
+              (getPrototypeOf(id) !== ObjectPrototype &&
+                getPrototypeOf(id) !== ArrayPrototype) ||
+              !hasOwnProperty.call(id, localLength)
             )
               throw Error("Invalid reference.");
-            id = id[name];
+            id = id[localLength];
+            isArrayImpl(id)
+              ? ((localLength = 0),
+                (chunk = rootArrayContexts.get(id) || chunk))
+              : ((chunk = null),
+                "string" === typeof id
+                  ? (localLength = id.length)
+                  : "bigint" === typeof id
+                    ? ((localLength = Math.abs(Number(id))),
+                      (localLength =
+                        0 === localLength
+                          ? 1
+                          : Math.floor(Math.log10(localLength)) + 1))
+                    : (localLength = ArrayBuffer.isView(id)
+                        ? id.byteLength
+                        : 0));
           }
-          return map(response, id, parentObject, key);
-        case "pending":
+          parentObject = map(response, id, parentObject, key);
+          null !== referenceArrayRoot &&
+            (null !== chunk
+              ? (chunk.fork && (referenceArrayRoot.fork = !0),
+                bumpArrayCount(referenceArrayRoot, chunk.count, response))
+              : 0 < localLength &&
+                bumpArrayCount(referenceArrayRoot, localLength, response));
+          return parentObject;
         case "blocked":
           return (
             initializingHandler
@@ -2956,31 +3035,34 @@
                     deps: 1,
                     errored: !1
                   }),
-            (parentObject = {
+            (referenceArrayRoot = {
               handler: response,
               parentObject: parentObject,
               key: key,
               map: map,
-              path: reference
+              path: reference,
+              arrayRoot: referenceArrayRoot
             }),
-            null === id.value
-              ? (id.value = [parentObject])
-              : id.value.push(parentObject),
-            null === id.reason
-              ? (id.reason = [parentObject])
-              : id.reason.push(parentObject),
+            null === chunk.value
+              ? (chunk.value = [referenceArrayRoot])
+              : chunk.value.push(referenceArrayRoot),
+            null === chunk.reason
+              ? (chunk.reason = [referenceArrayRoot])
+              : chunk.reason.push(referenceArrayRoot),
             null
           );
+        case "pending":
+          throw Error("Invalid forward reference.");
         default:
           return (
             initializingHandler
               ? ((initializingHandler.errored = !0),
                 (initializingHandler.value = null),
-                (initializingHandler.reason = id.reason))
+                (initializingHandler.reason = chunk.reason))
               : (initializingHandler = {
                   chunk: null,
                   value: null,
-                  reason: id.reason,
+                  reason: chunk.reason,
                   deps: 0,
                   errored: !0
                 }),
@@ -2989,13 +3071,25 @@
       }
     }
     function createMap(response, model) {
-      return new Map(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+      response = new Map(model);
+      model.$$consumed = !0;
+      return response;
     }
     function createSet(response, model) {
-      return new Set(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+      response = new Set(model);
+      model.$$consumed = !0;
+      return response;
     }
     function extractIterator(response, model) {
-      return model[Symbol.iterator]();
+      if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+      response = model[Symbol.iterator]();
+      model.$$consumed = !0;
+      return response;
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -3006,13 +3100,34 @@
       constructor,
       bytesPerElement,
       parentObject,
-      parentKey
+      parentKey,
+      referenceArrayRoot
     ) {
+      function reject(error) {
+        if (!handler.errored) {
+          handler.errored = !0;
+          handler.value = null;
+          handler.reason = error;
+          var chunk = handler.chunk;
+          null !== chunk &&
+            "blocked" === chunk.status &&
+            triggerErrorOnChunk(response, chunk, error);
+        }
+      }
       reference = parseInt(reference.slice(2), 16);
-      bytesPerElement = response._prefix + reference;
-      if (response._chunks.has(reference))
+      var key = response._prefix + reference;
+      bytesPerElement = response._chunks;
+      if (bytesPerElement.has(reference))
         throw Error("Already initialized typed array.");
-      reference = response._formData.get(bytesPerElement).arrayBuffer();
+      bytesPerElement.set(
+        reference,
+        new ReactPromise(
+          "rejected",
+          null,
+          Error("Already initialized typed array.")
+        )
+      );
+      reference = response._formData.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -3024,40 +3139,32 @@
           deps: 1,
           errored: !1
         };
-      reference.then(
-        function (buffer) {
-          buffer =
+      reference.then(function (buffer) {
+        try {
+          null !== referenceArrayRoot &&
+            bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+          var resolvedValue =
             constructor === ArrayBuffer ? buffer : new constructor(buffer);
-          parentObject[parentKey] = buffer;
+          "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
           "" === parentKey &&
             null === handler.value &&
-            (handler.value = buffer);
-          handler.deps--;
-          if (
-            0 === handler.deps &&
-            ((buffer = handler.chunk),
-            null !== buffer && "blocked" === buffer.status)
-          ) {
-            var resolveListeners = buffer.value;
-            buffer.status = "fulfilled";
-            buffer.value = handler.value;
-            buffer.reason = null;
-            null !== resolveListeners &&
-              wakeChunk(response, resolveListeners, handler.value);
-          }
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+            (handler.value = resolvedValue);
+        } catch (x) {
+          reject(x);
+          return;
         }
-      );
+        handler.deps--;
+        0 === handler.deps &&
+          ((buffer = handler.chunk),
+          null !== buffer &&
+            "blocked" === buffer.status &&
+            ((resolvedValue = buffer.value),
+            (buffer.status = "fulfilled"),
+            (buffer.value = handler.value),
+            (buffer.reason = null),
+            null !== resolvedValue &&
+              wakeChunk(response, resolvedValue, handler.value, buffer)));
+      }, reject);
       return null;
     }
     function resolveStream(response, id, stream, controller) {
@@ -3075,90 +3182,78 @@
               : controller.enqueueModel(chunks));
     }
     function parseReadableStream(response, reference, type) {
+      function enqueue(value) {
+        "bytes" !== type || ArrayBuffer.isView(value)
+          ? controller.enqueue(value)
+          : flightController.error(Error("Invalid data for bytes stream."));
+      }
       reference = parseInt(reference.slice(2), 16);
       if (response._chunks.has(reference))
         throw Error("Already initialized stream.");
       var controller = null,
-        closed = !1;
-      type = new ReadableStream({
-        type: type,
-        start: function (c) {
-          controller = c;
-        }
-      });
-      var previousBlockedChunk = null;
-      resolveStream(response, reference, type, {
-        enqueueModel: function (json) {
-          if (null === previousBlockedChunk) {
-            var chunk = new ReactPromise(
-              "resolved_model",
-              json,
-              _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
-            );
-            initializeModelChunk(chunk);
-            "fulfilled" === chunk.status
-              ? controller.enqueue(chunk.value)
-              : (chunk.then(
-                  function (v) {
-                    return controller.enqueue(v);
-                  },
-                  function (e) {
-                    return controller.error(e);
-                  }
-                ),
-                (previousBlockedChunk = chunk));
-          } else {
-            chunk = previousBlockedChunk;
-            var _chunk = new ReactPromise("pending", null, null);
-            _chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            );
-            previousBlockedChunk = _chunk;
-            chunk.then(function () {
-              previousBlockedChunk === _chunk && (previousBlockedChunk = null);
-              resolveModelChunk(response, _chunk, json, -1);
-            });
+        closed = !1,
+        stream = new ReadableStream({
+          type: type,
+          start: function (c) {
+            controller = c;
           }
-        },
-        close: function () {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.close();
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.close();
+        }),
+        previousBlockedChunk = null,
+        flightController = {
+          enqueueModel: function (json) {
+            if (null === previousBlockedChunk) {
+              var chunk = new ReactPromise(
+                "resolved_model",
+                json,
+                _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
+              );
+              initializeModelChunk(chunk);
+              "fulfilled" === chunk.status
+                ? enqueue(chunk.value)
+                : (chunk.then(enqueue, flightController.error),
+                  (previousBlockedChunk = chunk));
+            } else {
+              chunk = previousBlockedChunk;
+              var _chunk = new ReactPromise("pending", null, null);
+              _chunk.then(enqueue, flightController.error);
+              previousBlockedChunk = _chunk;
+              chunk.then(function () {
+                previousBlockedChunk === _chunk &&
+                  (previousBlockedChunk = null);
+                resolveModelChunk(response, _chunk, json, -1);
               });
             }
-        },
-        error: function (error) {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.error(error);
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.error(error);
-              });
-            }
-        }
-      });
-      return type;
+          },
+          close: function () {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.close();
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.close();
+                });
+              }
+          },
+          error: function (error) {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.error(error);
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.error(error);
+                });
+              }
+          }
+        };
+      resolveStream(response, reference, stream, flightController);
+      return stream;
     }
-    function asyncIterator() {
-      return this;
-    }
-    function createIterator(next) {
-      next = { next: next };
-      next[ASYNC_ITERATOR] = asyncIterator;
-      return next;
+    function FlightIterator(next) {
+      this.next = next;
     }
     function parseAsyncIterable(response, reference, iterator) {
       reference = parseInt(reference.slice(2), 16);
@@ -3169,7 +3264,7 @@
         nextWriteIndex = 0,
         iterable = _defineProperty({}, ASYNC_ITERATOR, function () {
           var nextReadIndex = 0;
-          return createIterator(function (arg) {
+          return new FlightIterator(function (arg) {
             if (void 0 !== arg)
               throw Error(
                 "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -3248,19 +3343,30 @@
       });
       return iterator;
     }
-    function parseModelString(response, obj, key, value, reference) {
+    function parseModelString(response, obj, key, value, reference, arrayRoot) {
       if ("$" === value[0]) {
         switch (value[1]) {
           case "$":
-            return value.slice(1);
+            return (
+              null !== arrayRoot &&
+                bumpArrayCount(arrayRoot, value.length - 1, response),
+              value.slice(1)
+            );
           case "@":
             return (
               (obj = parseInt(value.slice(2), 16)), getChunk(response, obj)
             );
           case "h":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, loadServerReference$1)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                loadServerReference$1
+              )
             );
           case "T":
             if (
@@ -3276,27 +3382,44 @@
             );
           case "Q":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createMap)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
             );
           case "W":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createSet)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
             obj = value.slice(2);
-            var formPrefix = response._prefix + obj + "_",
-              data = new FormData();
-            response._formData.forEach(function (entry, entryKey) {
-              entryKey.startsWith(formPrefix) &&
-                data.append(entryKey.slice(formPrefix.length), entry);
-            });
-            return data;
+            obj = response._prefix + obj + "_";
+            key = new FormData();
+            response = response._formData;
+            arrayRoot = Array.from(response.keys());
+            for (value = 0; value < arrayRoot.length; value++)
+              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+                for (
+                  var entries = response.getAll(reference),
+                    newKey = reference.slice(obj.length),
+                    j = 0;
+                  j < entries.length;
+                  j++
+                )
+                  key.append(newKey, entries[j]);
+                response.delete(reference);
+              }
+            return key;
           case "i":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, extractIterator)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                extractIterator
+              )
             );
           case "I":
             return Infinity;
@@ -3309,15 +3432,50 @@
           case "D":
             return new Date(Date.parse(value.slice(2)));
           case "n":
-            return BigInt(value.slice(2));
+            obj = value.slice(2);
+            if (obj.length > MAX_BIGINT_DIGITS)
+              throw Error(
+                "BigInt is too large. Received " +
+                  obj.length +
+                  " digits but the limit is " +
+                  MAX_BIGINT_DIGITS +
+                  "."
+              );
+            null !== arrayRoot &&
+              bumpArrayCount(arrayRoot, obj.length, response);
+            return BigInt(obj);
         }
         switch (value[1]) {
           case "A":
-            return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              ArrayBuffer,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "O":
-            return parseTypedArray(response, value, Int8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "o":
-            return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "U":
             return parseTypedArray(
               response,
@@ -3325,22 +3483,79 @@
               Uint8ClampedArray,
               1,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "S":
-            return parseTypedArray(response, value, Int16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "s":
-            return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "L":
-            return parseTypedArray(response, value, Int32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "l":
-            return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "G":
-            return parseTypedArray(response, value, Float32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "g":
-            return parseTypedArray(response, value, Float64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "M":
-            return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              BigInt64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "m":
             return parseTypedArray(
               response,
@@ -3348,10 +3563,19 @@
               BigUint64Array,
               8,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "V":
-            return parseTypedArray(response, value, DataView, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              DataView,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
@@ -3369,8 +3593,16 @@
             return parseAsyncIterable(response, value, !0);
         }
         value = value.slice(1);
-        return getOutlinedModel(response, value, obj, key, createModel);
+        return getOutlinedModel(
+          response,
+          value,
+          obj,
+          key,
+          arrayRoot,
+          createModel
+        );
       }
+      null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
       return value;
     }
     function createResponse(
@@ -3382,13 +3614,17 @@
           3 < arguments.length && void 0 !== arguments[3]
             ? arguments[3]
             : new FormData(),
+        arraySizeLimit =
+          4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
         chunks = new Map();
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
         _formData: backingFormData,
         _chunks: chunks,
-        _temporaryReferences: temporaryReferences
+        _temporaryReferences: temporaryReferences,
+        _rootArrayContexts: new WeakMap(),
+        _arraySizeLimit: arraySizeLimit
       };
     }
     function resolveField(response, key, value) {
@@ -3404,13 +3640,24 @@
     function close(response) {
       reportGlobalError(response, Error("Connection closed."));
     }
-    function loadServerReference(bundlerConfig, id, bound) {
+    function loadServerReference(bundlerConfig, metaData) {
+      var id = metaData.id;
+      if ("string" !== typeof id) return null;
       var serverReference = resolveServerReference(bundlerConfig, id);
       bundlerConfig = preloadModule(serverReference);
-      return bound
-        ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+      metaData = metaData.bound;
+      return null !== metaData
+        ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
             _ref = _ref[0];
             var fn = requireModule(serverReference);
+            if (_ref.length > MAX_BOUND_ARGS)
+              throw Error(
+                "Server Function has too many bound arguments. Received " +
+                  _ref.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              );
             return fn.bind.apply(fn, [null].concat(_ref));
           })
         : bundlerConfig
@@ -3419,8 +3666,19 @@
             })
           : Promise.resolve(requireModule(serverReference));
     }
-    function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-      body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+    function decodeBoundActionMetaData(
+      body,
+      serverManifest,
+      formFieldPrefix,
+      arraySizeLimit
+    ) {
+      body = createResponse(
+        serverManifest,
+        formFieldPrefix,
+        void 0,
+        body,
+        arraySizeLimit
+      );
       close(body);
       body = getChunk(body, 0);
       body.then(function () {});
@@ -3847,13 +4105,14 @@
       patchConsole(console, "table"),
       patchConsole(console, "trace"),
       patchConsole(console, "warn"));
-    var ObjectPrototype = Object.prototype,
+    var ObjectPrototype$1 = Object.prototype,
       stringify = JSON.stringify,
       PENDING$1 = 0,
       COMPLETED = 1,
       ABORTED = 3,
       ERRORED$1 = 4,
       RENDERING = 5,
+      __PROTO__$1 = "__proto__",
       OPENING = 10,
       ABORTING = 12,
       CLOSING = 13,
@@ -3876,16 +4135,23 @@
         case "fulfilled":
           if ("function" === typeof resolve) {
             for (
-              var inspectedValue = this.value, cycleProtection = 0;
+              var inspectedValue = this.value,
+                cycleProtection = 0,
+                visited = new Set();
               inspectedValue instanceof ReactPromise;
 
             ) {
               cycleProtection++;
-              if (inspectedValue === this || 1e3 < cycleProtection) {
+              if (
+                inspectedValue === this ||
+                visited.has(inspectedValue) ||
+                1e3 < cycleProtection
+              ) {
                 "function" === typeof reject &&
                   reject(Error("Cannot have cyclic thenables."));
                 return;
               }
+              visited.add(inspectedValue);
               if ("fulfilled" === inspectedValue.status)
                 inspectedValue = inspectedValue.value;
               else break;
@@ -3906,7 +4172,15 @@
           "function" === typeof reject && reject(this.reason);
       }
     };
-    var initializingHandler = null;
+    var ObjectPrototype = Object.prototype,
+      ArrayPrototype = Array.prototype,
+      initializingHandler = null;
+    FlightIterator.prototype = {};
+    FlightIterator.prototype[ASYNC_ITERATOR] = function () {
+      return this;
+    };
+    var MAX_BIGINT_DIGITS = 300,
+      MAX_BOUND_ARGS = 1e3;
     exports.createClientModuleProxy = function (moduleId) {
       moduleId = registerClientReferenceImpl({}, moduleId, !1);
       return new Proxy(moduleId, proxyHandlers$1);
@@ -3916,20 +4190,24 @@
     };
     exports.decodeAction = function (body, serverManifest) {
       var formData = new FormData(),
-        action = null;
+        action = null,
+        seenActions = new Set();
       body.forEach(function (value, key) {
         key.startsWith("$ACTION_")
           ? key.startsWith("$ACTION_REF_")
-            ? ((value = "$ACTION_" + key.slice(12) + ":"),
+            ? seenActions.has(key) ||
+              (seenActions.add(key),
+              (value = "$ACTION_" + key.slice(12) + ":"),
               (value = decodeBoundActionMetaData(body, serverManifest, value)),
-              (action = loadServerReference(
-                serverManifest,
-                value.id,
-                value.bound
-              )))
+              (action = loadServerReference(serverManifest, value)))
             : key.startsWith("$ACTION_ID_") &&
-              ((value = key.slice(11)),
-              (action = loadServerReference(serverManifest, value, null)))
+              !seenActions.has(key) &&
+              (seenActions.add(key),
+              (value = key.slice(11)),
+              (action = loadServerReference(serverManifest, {
+                id: value,
+                bound: null
+              })))
           : formData.append(key, value);
       });
       return null === action
@@ -3965,7 +4243,8 @@
         webpackMap,
         "",
         options ? options.temporaryReferences : void 0,
-        body
+        body,
+        options ? options.arraySizeLimit : void 0
       );
       webpackMap = getChunk(body, 0);
       close(body);
@@ -3979,7 +4258,9 @@
       var response = createResponse(
           webpackMap,
           "",
-          options ? options.temporaryReferences : void 0
+          options ? options.temporaryReferences : void 0,
+          void 0,
+          options ? options.arraySizeLimit : void 0
         ),
         pendingFiles = 0,
         queuedFields = [];
@@ -4003,13 +4284,13 @@
           );
         else {
           pendingFiles++;
-          var JSCompiler_object_inline_chunks_154 = [];
+          var JSCompiler_object_inline_chunks_149 = [];
           value.on("data", function (chunk) {
-            JSCompiler_object_inline_chunks_154.push(chunk);
+            JSCompiler_object_inline_chunks_149.push(chunk);
           });
           value.on("end", function () {
             try {
-              var blob = new Blob(JSCompiler_object_inline_chunks_154, {
+              var blob = new Blob(JSCompiler_object_inline_chunks_149, {
                 type: mimeType
               });
               response._formData.append(name, blob, filename);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -726,7 +726,7 @@ function describeObjectForErrorMessage(objectOrArray, expandedName) {
         "\n  " + str + "\n  " + objectOrArray)
       : "\n  " + str;
 }
-var ObjectPrototype = Object.prototype,
+var ObjectPrototype$1 = Object.prototype,
   stringify = JSON.stringify;
 function defaultErrorHandler(error) {
   console.error(error);
@@ -1547,7 +1547,7 @@ function renderModelDestructive(
     if (value instanceof Date) return "$D" + value.toJSON();
     request = getPrototypeOf(value);
     if (
-      request !== ObjectPrototype &&
+      request !== ObjectPrototype$1 &&
       (null === request || null !== getPrototypeOf(request))
     )
       throw Error(
@@ -2064,16 +2064,23 @@ ReactPromise.prototype.then = function (resolve, reject) {
     case "fulfilled":
       if ("function" === typeof resolve) {
         for (
-          var inspectedValue = this.value, cycleProtection = 0;
+          var inspectedValue = this.value,
+            cycleProtection = 0,
+            visited = new Set();
           inspectedValue instanceof ReactPromise;
 
         ) {
           cycleProtection++;
-          if (inspectedValue === this || 1e3 < cycleProtection) {
+          if (
+            inspectedValue === this ||
+            visited.has(inspectedValue) ||
+            1e3 < cycleProtection
+          ) {
             "function" === typeof reject &&
               reject(Error("Cannot have cyclic thenables."));
             return;
           }
+          visited.add(inspectedValue);
           if ("fulfilled" === inspectedValue.status)
             inspectedValue = inspectedValue.value;
           else break;
@@ -2092,12 +2099,14 @@ ReactPromise.prototype.then = function (resolve, reject) {
       "function" === typeof reject && reject(this.reason);
   }
 };
-function wakeChunk(response, listeners, value) {
+var ObjectPrototype = Object.prototype,
+  ArrayPrototype = Array.prototype;
+function wakeChunk(response, listeners, value, chunk) {
   for (var i = 0; i < listeners.length; i++) {
     var listener = listeners[i];
     "function" === typeof listener
       ? listener(value)
-      : fulfillReference(response, listener, value);
+      : fulfillReference(response, listener, value, chunk.reason);
   }
 }
 function rejectChunk(response, listeners, error) {
@@ -2107,27 +2116,6 @@ function rejectChunk(response, listeners, error) {
       ? listener(error)
       : rejectReference(response, listener.handler, error);
   }
-}
-function resolveBlockedCycle(resolvedChunk, reference) {
-  var referencedChunk = reference.handler.chunk;
-  if (null === referencedChunk) return null;
-  if (referencedChunk === resolvedChunk) return reference.handler;
-  reference = referencedChunk.value;
-  if (null !== reference)
-    for (
-      referencedChunk = 0;
-      referencedChunk < reference.length;
-      referencedChunk++
-    ) {
-      var listener = reference[referencedChunk];
-      if (
-        "function" !== typeof listener &&
-        ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-        null !== listener)
-      )
-        return listener;
-    }
-  return null;
 }
 function triggerErrorOnChunk(response, chunk, error) {
   if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2164,33 +2152,11 @@ function resolveModelChunk(response, chunk, value, id) {
     chunk.reason =
       ((value.id = id), (value[RESPONSE_SYMBOL] = response), value);
     if (null !== resolveListeners)
-      a: switch ((initializeModelChunk(chunk), chunk.status)) {
+      switch ((initializeModelChunk(chunk), chunk.status)) {
         case "fulfilled":
-          wakeChunk(response, resolveListeners, chunk.value);
+          wakeChunk(response, resolveListeners, chunk.value, chunk);
           break;
         case "blocked":
-          for (value = 0; value < resolveListeners.length; value++)
-            if (((id = resolveListeners[value]), "function" !== typeof id)) {
-              var cyclicHandler = resolveBlockedCycle(chunk, id);
-              if (null !== cyclicHandler)
-                switch (
-                  (fulfillReference(response, id, cyclicHandler.value),
-                  resolveListeners.splice(value, 1),
-                  value--,
-                  null !== rejectListeners &&
-                    ((id = rejectListeners.indexOf(id)),
-                    -1 !== id && rejectListeners.splice(id, 1)),
-                  chunk.status)
-                ) {
-                  case "fulfilled":
-                    wakeChunk(response, resolveListeners, chunk.value);
-                    break a;
-                  case "rejected":
-                    null !== rejectListeners &&
-                      rejectChunk(response, rejectListeners, chunk.reason);
-                    break a;
-                }
-            }
         case "pending":
           if (chunk.value)
             for (response = 0; response < resolveListeners.length; response++)
@@ -2207,7 +2173,8 @@ function resolveModelChunk(response, chunk, value, id) {
           } else chunk.reason = rejectListeners;
           break;
         case "rejected":
-          rejectListeners && wakeChunk(response, rejectListeners, chunk.reason);
+          rejectListeners &&
+            rejectChunk(response, rejectListeners, chunk.reason);
       }
   }
 }
@@ -2230,15 +2197,50 @@ function resolveIteratorResultChunk(response, chunk, value, done) {
   );
 }
 function loadServerReference$1(response, metaData, parentObject, key) {
+  function reject(error) {
+    var rejectListeners = blockedPromise.reason,
+      erroredPromise = blockedPromise;
+    erroredPromise.status = "rejected";
+    erroredPromise.value = null;
+    erroredPromise.reason = error;
+    null !== rejectListeners && rejectChunk(response, rejectListeners, error);
+    rejectReference(response, handler, error);
+  }
   var id = metaData.id;
   if ("string" !== typeof id || "then" === key) return null;
+  var cachedPromise = metaData.$$promise;
+  if (void 0 !== cachedPromise) {
+    if ("fulfilled" === cachedPromise.status)
+      return (
+        (cachedPromise = cachedPromise.value),
+        "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+      );
+    initializingHandler
+      ? ((id = initializingHandler), id.deps++)
+      : (id = initializingHandler =
+          { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+    cachedPromise.then(
+      resolveReference.bind(null, response, id, parentObject, key),
+      rejectReference.bind(null, response, id)
+    );
+    return null;
+  }
+  var blockedPromise = new ReactPromise("blocked", null, null);
+  metaData.$$promise = blockedPromise;
   var serverReference = resolveServerReference(response._bundlerConfig, id);
-  id = metaData.bound;
-  var promise = preloadModule(serverReference);
-  if (promise)
-    id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-  else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-  else return requireModule(serverReference);
+  cachedPromise = metaData.bound;
+  if ((id = preloadModule(serverReference)))
+    cachedPromise instanceof ReactPromise &&
+      (id = Promise.all([id, cachedPromise]));
+  else if (cachedPromise instanceof ReactPromise)
+    id = Promise.resolve(cachedPromise);
+  else
+    return (
+      (cachedPromise = requireModule(serverReference)),
+      (id = blockedPromise),
+      (id.status = "fulfilled"),
+      (id.value = cachedPromise)
+    );
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2250,73 +2252,104 @@ function loadServerReference$1(response, metaData, parentObject, key) {
       deps: 1,
       errored: !1
     };
-  promise.then(
-    function () {
-      var resolvedValue = requireModule(serverReference);
-      if (metaData.bound) {
-        var promiseValue = metaData.bound.value;
-        promiseValue = Array.isArray(promiseValue) ? promiseValue.slice(0) : [];
-        promiseValue.unshift(null);
-        resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
+  id.then(function () {
+    var resolvedValue = requireModule(serverReference);
+    if (metaData.bound) {
+      var promiseValue = metaData.bound.value;
+      promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+      if (1e3 < promiseValue.length) {
+        reject(
+          Error(
+            "Server Function has too many bound arguments. Received " +
+              promiseValue.length +
+              " but the limit is 1000."
+          )
+        );
+        return;
       }
-      parentObject[key] = resolvedValue;
-      "" === key && null === handler.value && (handler.value = resolvedValue);
-      handler.deps--;
-      0 === handler.deps &&
-        ((resolvedValue = handler.chunk),
-        null !== resolvedValue &&
-          "blocked" === resolvedValue.status &&
-          ((promiseValue = resolvedValue.value),
-          (resolvedValue.status = "fulfilled"),
-          (resolvedValue.value = handler.value),
-          (resolvedValue.reason = null),
-          null !== promiseValue &&
-            wakeChunk(response, promiseValue, handler.value)));
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+      promiseValue.unshift(null);
+      resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
     }
-  );
+    promiseValue = blockedPromise.value;
+    var initializedPromise = blockedPromise;
+    initializedPromise.status = "fulfilled";
+    initializedPromise.value = resolvedValue;
+    initializedPromise.reason = null;
+    null !== promiseValue &&
+      wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+    resolveReference(response, handler, parentObject, key, resolvedValue);
+  }, reject);
   return null;
 }
-function reviveModel(response, parentObj, parentKey, value, reference) {
+function reviveModel(
+  response,
+  parentObj,
+  parentKey,
+  value,
+  reference,
+  arrayRoot
+) {
   if ("string" === typeof value)
-    return parseModelString(response, parentObj, parentKey, value, reference);
+    return parseModelString(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    );
   if ("object" === typeof value && null !== value)
     if (
       (void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
         response._temporaryReferences.set(value, reference),
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
+      isArrayImpl(value))
+    ) {
+      if (null === arrayRoot) {
+        var childContext = { count: 0, fork: !1 };
+        response._rootArrayContexts.set(value, childContext);
+      } else childContext = arrayRoot;
+      1 < value.length && (childContext.fork = !0);
+      bumpArrayCount(childContext, value.length + 1, response);
+      for (parentObj = 0; parentObj < value.length; parentObj++)
+        value[parentObj] = reviveModel(
           response,
           value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
+          "" + parentObj,
+          value[parentObj],
+          void 0 !== reference ? reference + ":" + parentObj : void 0,
+          childContext
         );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj || "__proto__" === i
-            ? (value[i] = parentObj)
-            : delete value[i]);
+    } else
+      for (childContext in value)
+        hasOwnProperty.call(value, childContext) &&
+          ("__proto__" === childContext
+            ? delete value[childContext]
+            : ((parentObj =
+                void 0 !== reference && -1 === childContext.indexOf(":")
+                  ? reference + ":" + childContext
+                  : void 0),
+              (parentObj = reviveModel(
+                response,
+                value,
+                childContext,
+                value[childContext],
+                parentObj,
+                null
+              )),
+              void 0 !== parentObj
+                ? (value[childContext] = parentObj)
+                : delete value[childContext]));
   return value;
+}
+function bumpArrayCount(arrayContext, slots, response) {
+  if (
+    (arrayContext.count += slots) > response._arraySizeLimit &&
+    arrayContext.fork
+  )
+    throw Error(
+      "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+    );
 }
 var initializingHandler = null;
 function initializeModelChunk(chunk) {
@@ -2331,13 +2364,15 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var rawModel = JSON.parse(resolvedModel),
-      value = reviveModel(
+    var rawModel = JSON.parse(resolvedModel);
+    resolvedModel = { count: 0, fork: !1 };
+    var value = reviveModel(
         response,
         { "": rawModel },
         "",
         rawModel,
-        _chunk$reason
+        _chunk$reason,
+        resolvedModel
       ),
       resolveListeners = chunk.value;
     if (null !== resolveListeners)
@@ -2349,19 +2384,20 @@ function initializeModelChunk(chunk) {
         var listener = resolveListeners[rawModel];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, resolvedModel);
       }
     if (null !== initializingHandler) {
       if (initializingHandler.errored) throw initializingHandler.reason;
       if (0 < initializingHandler.deps) {
         initializingHandler.value = value;
+        initializingHandler.reason = resolvedModel;
         initializingHandler.chunk = chunk;
         return;
       }
     }
     chunk.status = "fulfilled";
     chunk.value = value;
-    chunk.reason = null;
+    chunk.reason = resolvedModel;
   } catch (error) {
     (chunk.status = "rejected"), (chunk.reason = error);
   } finally {
@@ -2374,7 +2410,8 @@ function reportGlobalError(response, error) {
       ? triggerErrorOnChunk(response, chunk, error)
       : "fulfilled" === chunk.status &&
         null !== chunk.reason &&
-        chunk.reason.error(error);
+        ((chunk = chunk.reason),
+        "function" === typeof chunk.error && chunk.error(error));
   });
 }
 function getChunk(response, id) {
@@ -2389,40 +2426,67 @@ function getChunk(response, id) {
     chunks.set(id, chunk));
   return chunk;
 }
-function fulfillReference(response, reference, value) {
+function fulfillReference(response, reference, value, arrayRoot) {
   var handler = reference.handler,
     parentObject = reference.parentObject,
     key = reference.key,
     map = reference.map,
     path = reference.path;
   try {
-    for (var i = 1; i < path.length; i++) {
+    for (
+      var localLength = 0,
+        rootArrayContexts = response._rootArrayContexts,
+        i = 1;
+      i < path.length;
+      i++
+    ) {
       var name = path[i];
       if (
         "object" !== typeof value ||
-        !hasOwnProperty.call(value, name) ||
-        value instanceof Promise
+        null === value ||
+        (getPrototypeOf(value) !== ObjectPrototype &&
+          getPrototypeOf(value) !== ArrayPrototype) ||
+        !hasOwnProperty.call(value, name)
       )
         throw Error("Invalid reference.");
       value = value[name];
+      if (isArrayImpl(value))
+        (localLength = 0),
+          (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+      else if (((arrayRoot = null), "string" === typeof value))
+        localLength = value.length;
+      else if ("bigint" === typeof value) {
+        var n = Math.abs(Number(value));
+        localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+      } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
     }
-    var mappedValue = map(response, value, parentObject, key);
-    parentObject[key] = mappedValue;
-    "" === key && null === handler.value && (handler.value = mappedValue);
+    var resolvedValue = map(response, value, parentObject, key);
+    var referenceArrayRoot = reference.arrayRoot;
+    null !== referenceArrayRoot &&
+      (null !== arrayRoot
+        ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+          bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+        : 0 < localLength &&
+          bumpArrayCount(referenceArrayRoot, localLength, response));
   } catch (error) {
-    rejectReference(response, reference.handler, error);
+    rejectReference(response, handler, error);
     return;
   }
+  resolveReference(response, handler, parentObject, key, resolvedValue);
+}
+function resolveReference(response, handler, parentObject, key, resolvedValue) {
+  "__proto__" !== key && (parentObject[key] = resolvedValue);
+  "" === key && null === handler.value && (handler.value = resolvedValue);
   handler.deps--;
   0 === handler.deps &&
-    ((reference = handler.chunk),
-    null !== reference &&
-      "blocked" === reference.status &&
-      ((value = reference.value),
-      (reference.status = "fulfilled"),
-      (reference.value = handler.value),
-      (reference.reason = handler.reason),
-      null !== value && wakeChunk(response, value, handler.value)));
+    ((parentObject = handler.chunk),
+    null !== parentObject &&
+      "blocked" === parentObject.status &&
+      ((key = parentObject.value),
+      (parentObject.status = "fulfilled"),
+      (parentObject.value = handler.value),
+      (parentObject.reason = handler.reason),
+      null !== key && wakeChunk(response, key, handler.value, parentObject)));
 }
 function rejectReference(response, handler, error) {
   handler.errored ||
@@ -2434,60 +2498,97 @@ function rejectReference(response, handler, error) {
       "blocked" === handler.status &&
       triggerErrorOnChunk(response, handler, error));
 }
-function getOutlinedModel(response, reference, parentObject, key, map) {
+function getOutlinedModel(
+  response,
+  reference,
+  parentObject,
+  key,
+  referenceArrayRoot,
+  map
+) {
   reference = reference.split(":");
-  var id = parseInt(reference[0], 16);
-  id = getChunk(response, id);
-  switch (id.status) {
+  var id = parseInt(reference[0], 16),
+    chunk = getChunk(response, id);
+  switch (chunk.status) {
     case "resolved_model":
-      initializeModelChunk(id);
+      initializeModelChunk(chunk);
   }
-  switch (id.status) {
+  switch (chunk.status) {
     case "fulfilled":
-      id = id.value;
-      for (var i = 1; i < reference.length; i++) {
-        var name = reference[i];
+      id = chunk.value;
+      chunk = chunk.reason;
+      for (
+        var localLength = 0,
+          rootArrayContexts = response._rootArrayContexts,
+          i = 1;
+        i < reference.length;
+        i++
+      ) {
+        localLength = reference[i];
         if (
           "object" !== typeof id ||
-          !hasOwnProperty.call(id, name) ||
-          id instanceof Promise
+          null === id ||
+          (getPrototypeOf(id) !== ObjectPrototype &&
+            getPrototypeOf(id) !== ArrayPrototype) ||
+          !hasOwnProperty.call(id, localLength)
         )
           throw Error("Invalid reference.");
-        id = id[name];
+        id = id[localLength];
+        isArrayImpl(id)
+          ? ((localLength = 0), (chunk = rootArrayContexts.get(id) || chunk))
+          : ((chunk = null),
+            "string" === typeof id
+              ? (localLength = id.length)
+              : "bigint" === typeof id
+                ? ((localLength = Math.abs(Number(id))),
+                  (localLength =
+                    0 === localLength
+                      ? 1
+                      : Math.floor(Math.log10(localLength)) + 1))
+                : (localLength = ArrayBuffer.isView(id) ? id.byteLength : 0));
       }
-      return map(response, id, parentObject, key);
-    case "pending":
+      parentObject = map(response, id, parentObject, key);
+      null !== referenceArrayRoot &&
+        (null !== chunk
+          ? (chunk.fork && (referenceArrayRoot.fork = !0),
+            bumpArrayCount(referenceArrayRoot, chunk.count, response))
+          : 0 < localLength &&
+            bumpArrayCount(referenceArrayRoot, localLength, response));
+      return parentObject;
     case "blocked":
       return (
         initializingHandler
           ? ((response = initializingHandler), response.deps++)
           : (response = initializingHandler =
               { chunk: null, value: null, reason: null, deps: 1, errored: !1 }),
-        (parentObject = {
+        (referenceArrayRoot = {
           handler: response,
           parentObject: parentObject,
           key: key,
           map: map,
-          path: reference
+          path: reference,
+          arrayRoot: referenceArrayRoot
         }),
-        null === id.value
-          ? (id.value = [parentObject])
-          : id.value.push(parentObject),
-        null === id.reason
-          ? (id.reason = [parentObject])
-          : id.reason.push(parentObject),
+        null === chunk.value
+          ? (chunk.value = [referenceArrayRoot])
+          : chunk.value.push(referenceArrayRoot),
+        null === chunk.reason
+          ? (chunk.reason = [referenceArrayRoot])
+          : chunk.reason.push(referenceArrayRoot),
         null
       );
+    case "pending":
+      throw Error("Invalid forward reference.");
     default:
       return (
         initializingHandler
           ? ((initializingHandler.errored = !0),
             (initializingHandler.value = null),
-            (initializingHandler.reason = id.reason))
+            (initializingHandler.reason = chunk.reason))
           : (initializingHandler = {
               chunk: null,
               value: null,
-              reason: id.reason,
+              reason: chunk.reason,
               deps: 0,
               errored: !0
             }),
@@ -2496,13 +2597,25 @@ function getOutlinedModel(response, reference, parentObject, key, map) {
   }
 }
 function createMap(response, model) {
-  return new Map(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+  response = new Map(model);
+  model.$$consumed = !0;
+  return response;
 }
 function createSet(response, model) {
-  return new Set(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+  response = new Set(model);
+  model.$$consumed = !0;
+  return response;
 }
 function extractIterator(response, model) {
-  return model[Symbol.iterator]();
+  if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+  response = model[Symbol.iterator]();
+  model.$$consumed = !0;
+  return response;
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2513,13 +2626,34 @@ function parseTypedArray(
   constructor,
   bytesPerElement,
   parentObject,
-  parentKey
+  parentKey,
+  referenceArrayRoot
 ) {
+  function reject(error) {
+    if (!handler.errored) {
+      handler.errored = !0;
+      handler.value = null;
+      handler.reason = error;
+      var chunk = handler.chunk;
+      null !== chunk &&
+        "blocked" === chunk.status &&
+        triggerErrorOnChunk(response, chunk, error);
+    }
+  }
   reference = parseInt(reference.slice(2), 16);
-  bytesPerElement = response._prefix + reference;
-  if (response._chunks.has(reference))
+  var key = response._prefix + reference;
+  bytesPerElement = response._chunks;
+  if (bytesPerElement.has(reference))
     throw Error("Already initialized typed array.");
-  reference = response._formData.get(bytesPerElement).arrayBuffer();
+  bytesPerElement.set(
+    reference,
+    new ReactPromise(
+      "rejected",
+      null,
+      Error("Already initialized typed array.")
+    )
+  );
+  reference = response._formData.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2531,37 +2665,32 @@ function parseTypedArray(
       deps: 1,
       errored: !1
     };
-  reference.then(
-    function (buffer) {
-      buffer = constructor === ArrayBuffer ? buffer : new constructor(buffer);
-      parentObject[parentKey] = buffer;
-      "" === parentKey && null === handler.value && (handler.value = buffer);
-      handler.deps--;
-      if (
-        0 === handler.deps &&
-        ((buffer = handler.chunk),
-        null !== buffer && "blocked" === buffer.status)
-      ) {
-        var resolveListeners = buffer.value;
-        buffer.status = "fulfilled";
-        buffer.value = handler.value;
-        buffer.reason = null;
-        null !== resolveListeners &&
-          wakeChunk(response, resolveListeners, handler.value);
-      }
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+  reference.then(function (buffer) {
+    try {
+      null !== referenceArrayRoot &&
+        bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+      var resolvedValue =
+        constructor === ArrayBuffer ? buffer : new constructor(buffer);
+      "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
+      "" === parentKey &&
+        null === handler.value &&
+        (handler.value = resolvedValue);
+    } catch (x) {
+      reject(x);
+      return;
     }
-  );
+    handler.deps--;
+    0 === handler.deps &&
+      ((buffer = handler.chunk),
+      null !== buffer &&
+        "blocked" === buffer.status &&
+        ((resolvedValue = buffer.value),
+        (buffer.status = "fulfilled"),
+        (buffer.value = handler.value),
+        (buffer.reason = null),
+        null !== resolvedValue &&
+          wakeChunk(response, resolvedValue, handler.value, buffer)));
+  }, reject);
   return null;
 }
 function resolveStream(response, id, stream, controller) {
@@ -2577,86 +2706,78 @@ function resolveStream(response, id, stream, controller) {
           : controller.enqueueModel(chunks));
 }
 function parseReadableStream(response, reference, type) {
+  function enqueue(value) {
+    "bytes" !== type || ArrayBuffer.isView(value)
+      ? controller.enqueue(value)
+      : flightController.error(Error("Invalid data for bytes stream."));
+  }
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
     throw Error("Already initialized stream.");
   var controller = null,
-    closed = !1;
-  type = new ReadableStream({
-    type: type,
-    start: function (c) {
-      controller = c;
-    }
-  });
-  var previousBlockedChunk = null;
-  resolveStream(response, reference, type, {
-    enqueueModel: function (json) {
-      if (null === previousBlockedChunk) {
-        var chunk = createResolvedModelChunk(response, json, -1);
-        initializeModelChunk(chunk);
-        "fulfilled" === chunk.status
-          ? controller.enqueue(chunk.value)
-          : (chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            ),
-            (previousBlockedChunk = chunk));
-      } else {
-        chunk = previousBlockedChunk;
-        var chunk$31 = new ReactPromise("pending", null, null);
-        chunk$31.then(
-          function (v) {
-            return controller.enqueue(v);
-          },
-          function (e) {
-            return controller.error(e);
-          }
-        );
-        previousBlockedChunk = chunk$31;
-        chunk.then(function () {
-          previousBlockedChunk === chunk$31 && (previousBlockedChunk = null);
-          resolveModelChunk(response, chunk$31, json, -1);
-        });
+    closed = !1,
+    stream = new ReadableStream({
+      type: type,
+      start: function (c) {
+        controller = c;
       }
-    },
-    close: function () {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk)) controller.close();
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.close();
+    }),
+    previousBlockedChunk = null,
+    flightController = {
+      enqueueModel: function (json) {
+        if (null === previousBlockedChunk) {
+          var chunk = createResolvedModelChunk(response, json, -1);
+          initializeModelChunk(chunk);
+          "fulfilled" === chunk.status
+            ? enqueue(chunk.value)
+            : (chunk.then(enqueue, flightController.error),
+              (previousBlockedChunk = chunk));
+        } else {
+          chunk = previousBlockedChunk;
+          var chunk$32 = new ReactPromise("pending", null, null);
+          chunk$32.then(enqueue, flightController.error);
+          previousBlockedChunk = chunk$32;
+          chunk.then(function () {
+            previousBlockedChunk === chunk$32 && (previousBlockedChunk = null);
+            resolveModelChunk(response, chunk$32, json, -1);
           });
         }
-    },
-    error: function (error) {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk))
-          controller.error(error);
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.error(error);
-          });
-        }
-    }
-  });
-  return type;
+      },
+      close: function () {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.close();
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.close();
+            });
+          }
+      },
+      error: function (error) {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.error(error);
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.error(error);
+            });
+          }
+      }
+    };
+  resolveStream(response, reference, stream, flightController);
+  return stream;
 }
-function asyncIterator() {
+function FlightIterator(next) {
+  this.next = next;
+}
+FlightIterator.prototype = {};
+FlightIterator.prototype[ASYNC_ITERATOR] = function () {
   return this;
-}
-function createIterator(next) {
-  next = { next: next };
-  next[ASYNC_ITERATOR] = asyncIterator;
-  return next;
-}
+};
 function parseAsyncIterable(response, reference, iterator) {
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
@@ -2668,7 +2789,7 @@ function parseAsyncIterable(response, reference, iterator) {
   $jscomp$compprop5 =
     (($jscomp$compprop5[ASYNC_ITERATOR] = function () {
       var nextReadIndex = 0;
-      return createIterator(function (arg) {
+      return new FlightIterator(function (arg) {
         if (void 0 !== arg)
           throw Error(
             "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -2748,17 +2869,28 @@ function parseAsyncIterable(response, reference, iterator) {
   });
   return iterator;
 }
-function parseModelString(response, obj, key, value, reference) {
+function parseModelString(response, obj, key, value, reference, arrayRoot) {
   if ("$" === value[0]) {
     switch (value[1]) {
       case "$":
-        return value.slice(1);
+        return (
+          null !== arrayRoot &&
+            bumpArrayCount(arrayRoot, value.length - 1, response),
+          value.slice(1)
+        );
       case "@":
         return (obj = parseInt(value.slice(2), 16)), getChunk(response, obj);
       case "h":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, loadServerReference$1)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(
+            response,
+            arrayRoot,
+            obj,
+            key,
+            null,
+            loadServerReference$1
+          )
         );
       case "T":
         if (void 0 === reference || void 0 === response._temporaryReferences)
@@ -2771,27 +2903,37 @@ function parseModelString(response, obj, key, value, reference) {
         );
       case "Q":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createMap)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
         );
       case "W":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createSet)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
         obj = value.slice(2);
-        var formPrefix = response._prefix + obj + "_",
-          data = new FormData();
-        response._formData.forEach(function (entry, entryKey) {
-          entryKey.startsWith(formPrefix) &&
-            data.append(entryKey.slice(formPrefix.length), entry);
-        });
-        return data;
+        obj = response._prefix + obj + "_";
+        key = new FormData();
+        response = response._formData;
+        arrayRoot = Array.from(response.keys());
+        for (value = 0; value < arrayRoot.length; value++)
+          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            for (
+              var entries = response.getAll(reference),
+                newKey = reference.slice(obj.length),
+                j = 0;
+              j < entries.length;
+              j++
+            )
+              key.append(newKey, entries[j]);
+            response.delete(reference);
+          }
+        return key;
       case "i":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, extractIterator)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, extractIterator)
         );
       case "I":
         return Infinity;
@@ -2804,35 +2946,147 @@ function parseModelString(response, obj, key, value, reference) {
       case "D":
         return new Date(Date.parse(value.slice(2)));
       case "n":
-        return BigInt(value.slice(2));
+        obj = value.slice(2);
+        if (300 < obj.length)
+          throw Error(
+            "BigInt is too large. Received " +
+              obj.length +
+              " digits but the limit is 300."
+          );
+        null !== arrayRoot && bumpArrayCount(arrayRoot, obj.length, response);
+        return BigInt(obj);
     }
     switch (value[1]) {
       case "A":
-        return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          ArrayBuffer,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "O":
-        return parseTypedArray(response, value, Int8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "o":
-        return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "U":
-        return parseTypedArray(response, value, Uint8ClampedArray, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8ClampedArray,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "S":
-        return parseTypedArray(response, value, Int16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "s":
-        return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "L":
-        return parseTypedArray(response, value, Int32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "l":
-        return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "G":
-        return parseTypedArray(response, value, Float32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "g":
-        return parseTypedArray(response, value, Float64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "M":
-        return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigInt64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "m":
-        return parseTypedArray(response, value, BigUint64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigUint64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "V":
-        return parseTypedArray(response, value, DataView, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          DataView,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
@@ -2850,8 +3104,9 @@ function parseModelString(response, obj, key, value, reference) {
         return parseAsyncIterable(response, value, !0);
     }
     value = value.slice(1);
-    return getOutlinedModel(response, value, obj, key, createModel);
+    return getOutlinedModel(response, value, obj, key, arrayRoot, createModel);
   }
+  null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
   return value;
 }
 function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
@@ -2859,13 +3114,17 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
       3 < arguments.length && void 0 !== arguments[3]
         ? arguments[3]
         : new FormData(),
+    arraySizeLimit =
+      4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
     chunks = new Map();
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
     _formData: backingFormData,
     _chunks: chunks,
-    _temporaryReferences: temporaryReferences
+    _temporaryReferences: temporaryReferences,
+    _rootArrayContexts: new WeakMap(),
+    _arraySizeLimit: arraySizeLimit
   };
 }
 function resolveField(response, key, value) {
@@ -2881,13 +3140,22 @@ function resolveField(response, key, value) {
 function close(response) {
   reportGlobalError(response, Error("Connection closed."));
 }
-function loadServerReference(bundlerConfig, id, bound) {
+function loadServerReference(bundlerConfig, metaData) {
+  var id = metaData.id;
+  if ("string" !== typeof id) return null;
   var serverReference = resolveServerReference(bundlerConfig, id);
   bundlerConfig = preloadModule(serverReference);
-  return bound
-    ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+  metaData = metaData.bound;
+  return null !== metaData
+    ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
         _ref = _ref[0];
         var fn = requireModule(serverReference);
+        if (1e3 < _ref.length)
+          throw Error(
+            "Server Function has too many bound arguments. Received " +
+              _ref.length +
+              " but the limit is 1000."
+          );
         return fn.bind.apply(fn, [null].concat(_ref));
       })
     : bundlerConfig
@@ -2896,8 +3164,19 @@ function loadServerReference(bundlerConfig, id, bound) {
         })
       : Promise.resolve(requireModule(serverReference));
 }
-function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-  body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+function decodeBoundActionMetaData(
+  body,
+  serverManifest,
+  formFieldPrefix,
+  arraySizeLimit
+) {
+  body = createResponse(
+    serverManifest,
+    formFieldPrefix,
+    void 0,
+    body,
+    arraySizeLimit
+  );
   close(body);
   body = getChunk(body, 0);
   body.then(function () {});
@@ -2924,16 +3203,24 @@ exports.createTemporaryReferenceSet = function () {
 };
 exports.decodeAction = function (body, serverManifest) {
   var formData = new FormData(),
-    action = null;
+    action = null,
+    seenActions = new Set();
   body.forEach(function (value, key) {
     key.startsWith("$ACTION_")
       ? key.startsWith("$ACTION_REF_")
-        ? ((value = "$ACTION_" + key.slice(12) + ":"),
+        ? seenActions.has(key) ||
+          (seenActions.add(key),
+          (value = "$ACTION_" + key.slice(12) + ":"),
           (value = decodeBoundActionMetaData(body, serverManifest, value)),
-          (action = loadServerReference(serverManifest, value.id, value.bound)))
+          (action = loadServerReference(serverManifest, value)))
         : key.startsWith("$ACTION_ID_") &&
-          ((value = key.slice(11)),
-          (action = loadServerReference(serverManifest, value, null)))
+          !seenActions.has(key) &&
+          (seenActions.add(key),
+          (value = key.slice(11)),
+          (action = loadServerReference(serverManifest, {
+            id: value,
+            bound: null
+          })))
       : formData.append(key, value);
   });
   return null === action
@@ -2969,7 +3256,8 @@ exports.decodeReply = function (body, webpackMap, options) {
     webpackMap,
     "",
     options ? options.temporaryReferences : void 0,
-    body
+    body,
+    options ? options.arraySizeLimit : void 0
   );
   webpackMap = getChunk(body, 0);
   close(body);
@@ -2979,7 +3267,9 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
   var response = createResponse(
       webpackMap,
       "",
-      options ? options.temporaryReferences : void 0
+      options ? options.temporaryReferences : void 0,
+      void 0,
+      options ? options.arraySizeLimit : void 0
     ),
     pendingFiles = 0,
     queuedFields = [];
@@ -3003,13 +3293,13 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
       );
     else {
       pendingFiles++;
-      var JSCompiler_object_inline_chunks_233 = [];
+      var JSCompiler_object_inline_chunks_229 = [];
       value.on("data", function (chunk) {
-        JSCompiler_object_inline_chunks_233.push(chunk);
+        JSCompiler_object_inline_chunks_229.push(chunk);
       });
       value.on("end", function () {
         try {
-          var blob = new Blob(JSCompiler_object_inline_chunks_233, {
+          var blob = new Blob(JSCompiler_object_inline_chunks_229, {
             type: mimeType
           });
           response._formData.append(name, blob, filename);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -1497,6 +1497,13 @@
       value
     ) {
       task.model = value;
+      parentPropertyName === __PROTO__$1 &&
+        callWithDebugContextInDEV(request, task, function () {
+          console.error(
+            "Expected not to serialize an object with own property `__proto__`. When parsed this property will be omitted.%s",
+            describeObjectForErrorMessage(parent, parentPropertyName)
+          );
+        });
       if (value === REACT_ELEMENT_TYPE) return "$";
       if (null === value) return null;
       if ("object" === typeof value) {
@@ -1667,7 +1674,7 @@
         if (value instanceof Date) return "$D" + value.toJSON();
         elementReference = getPrototypeOf(value);
         if (
-          elementReference !== ObjectPrototype &&
+          elementReference !== ObjectPrototype$1 &&
           (null === elementReference ||
             null !== getPrototypeOf(elementReference))
         )
@@ -2524,12 +2531,12 @@
       this.value = value;
       this.reason = reason;
     }
-    function wakeChunk(response, listeners, value) {
+    function wakeChunk(response, listeners, value, chunk) {
       for (var i = 0; i < listeners.length; i++) {
         var listener = listeners[i];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, chunk.reason);
       }
     }
     function rejectChunk(response, listeners, error) {
@@ -2539,27 +2546,6 @@
           ? listener(error)
           : rejectReference(response, listener.handler, error);
       }
-    }
-    function resolveBlockedCycle(resolvedChunk, reference) {
-      var referencedChunk = reference.handler.chunk;
-      if (null === referencedChunk) return null;
-      if (referencedChunk === resolvedChunk) return reference.handler;
-      reference = referencedChunk.value;
-      if (null !== reference)
-        for (
-          referencedChunk = 0;
-          referencedChunk < reference.length;
-          referencedChunk++
-        ) {
-          var listener = reference[referencedChunk];
-          if (
-            "function" !== typeof listener &&
-            ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-            null !== listener)
-          )
-            return listener;
-        }
-      return null;
     }
     function triggerErrorOnChunk(response, chunk, error) {
       if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2584,57 +2570,25 @@
         chunk.value = value;
         chunk.reason = _defineProperty({ id: id }, RESPONSE_SYMBOL, response);
         if (null !== resolveListeners)
-          a: switch ((initializeModelChunk(chunk), chunk.status)) {
+          switch ((initializeModelChunk(chunk), chunk.status)) {
             case "fulfilled":
-              wakeChunk(response, resolveListeners, chunk.value);
+              wakeChunk(response, resolveListeners, chunk.value, chunk);
               break;
             case "blocked":
-              for (value = 0; value < resolveListeners.length; value++)
-                if (
-                  ((id = resolveListeners[value]), "function" !== typeof id)
-                ) {
-                  var cyclicHandler = resolveBlockedCycle(chunk, id);
-                  if (null !== cyclicHandler)
-                    switch (
-                      (fulfillReference(response, id, cyclicHandler.value),
-                      resolveListeners.splice(value, 1),
-                      value--,
-                      null !== rejectListeners &&
-                        ((id = rejectListeners.indexOf(id)),
-                        -1 !== id && rejectListeners.splice(id, 1)),
-                      chunk.status)
-                    ) {
-                      case "fulfilled":
-                        wakeChunk(response, resolveListeners, chunk.value);
-                        break a;
-                      case "rejected":
-                        null !== rejectListeners &&
-                          rejectChunk(response, rejectListeners, chunk.reason);
-                        break a;
-                    }
-                }
             case "pending":
               if (chunk.value)
-                for (
-                  response = 0;
-                  response < resolveListeners.length;
-                  response++
-                )
-                  chunk.value.push(resolveListeners[response]);
+                for (value = 0; value < resolveListeners.length; value++)
+                  chunk.value.push(resolveListeners[value]);
               else chunk.value = resolveListeners;
               if (chunk.reason) {
                 if (rejectListeners)
-                  for (
-                    resolveListeners = 0;
-                    resolveListeners < rejectListeners.length;
-                    resolveListeners++
-                  )
-                    chunk.reason.push(rejectListeners[resolveListeners]);
+                  for (value = 0; value < rejectListeners.length; value++)
+                    chunk.reason.push(rejectListeners[value]);
               } else chunk.reason = rejectListeners;
               break;
             case "rejected":
               rejectListeners &&
-                wakeChunk(response, rejectListeners, chunk.reason);
+                rejectChunk(response, rejectListeners, chunk.reason);
           }
       }
     }
@@ -2658,15 +2612,51 @@
       );
     }
     function loadServerReference$1(response, metaData, parentObject, key) {
+      function reject(error) {
+        var rejectListeners = blockedPromise.reason,
+          erroredPromise = blockedPromise;
+        erroredPromise.status = "rejected";
+        erroredPromise.value = null;
+        erroredPromise.reason = error;
+        null !== rejectListeners &&
+          rejectChunk(response, rejectListeners, error);
+        rejectReference(response, handler, error);
+      }
       var id = metaData.id;
       if ("string" !== typeof id || "then" === key) return null;
+      var cachedPromise = metaData.$$promise;
+      if (void 0 !== cachedPromise) {
+        if ("fulfilled" === cachedPromise.status)
+          return (
+            (cachedPromise = cachedPromise.value),
+            "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+          );
+        initializingHandler
+          ? ((id = initializingHandler), id.deps++)
+          : (id = initializingHandler =
+              { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+        cachedPromise.then(
+          resolveReference.bind(null, response, id, parentObject, key),
+          rejectReference.bind(null, response, id)
+        );
+        return null;
+      }
+      var blockedPromise = new ReactPromise("blocked", null, null);
+      metaData.$$promise = blockedPromise;
       var serverReference = resolveServerReference(response._bundlerConfig, id);
-      id = metaData.bound;
-      var promise = preloadModule(serverReference);
-      if (promise)
-        id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-      else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-      else return requireModule(serverReference);
+      cachedPromise = metaData.bound;
+      if ((id = preloadModule(serverReference)))
+        cachedPromise instanceof ReactPromise &&
+          (id = Promise.all([id, cachedPromise]));
+      else if (cachedPromise instanceof ReactPromise)
+        id = Promise.resolve(cachedPromise);
+      else
+        return (
+          (cachedPromise = requireModule(serverReference)),
+          (id = blockedPromise),
+          (id.status = "fulfilled"),
+          (id.value = cachedPromise)
+        );
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -2678,92 +2668,106 @@
           deps: 1,
           errored: !1
         };
-      promise.then(
-        function () {
-          var resolvedValue = requireModule(serverReference);
-          if (metaData.bound) {
-            var promiseValue = metaData.bound.value;
-            promiseValue = Array.isArray(promiseValue)
-              ? promiseValue.slice(0)
-              : [];
-            promiseValue.unshift(null);
-            resolvedValue = resolvedValue.bind.apply(
-              resolvedValue,
-              promiseValue
+      id.then(function () {
+        var resolvedValue = requireModule(serverReference);
+        if (metaData.bound) {
+          var promiseValue = metaData.bound.value;
+          promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+          if (promiseValue.length > MAX_BOUND_ARGS) {
+            reject(
+              Error(
+                "Server Function has too many bound arguments. Received " +
+                  promiseValue.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              )
             );
+            return;
           }
-          parentObject[key] = resolvedValue;
-          "" === key &&
-            null === handler.value &&
-            (handler.value = resolvedValue);
-          handler.deps--;
-          0 === handler.deps &&
-            ((resolvedValue = handler.chunk),
-            null !== resolvedValue &&
-              "blocked" === resolvedValue.status &&
-              ((promiseValue = resolvedValue.value),
-              (resolvedValue.status = "fulfilled"),
-              (resolvedValue.value = handler.value),
-              (resolvedValue.reason = null),
-              null !== promiseValue &&
-                wakeChunk(response, promiseValue, handler.value)));
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+          promiseValue.unshift(null);
+          resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
         }
-      );
+        promiseValue = blockedPromise.value;
+        var initializedPromise = blockedPromise;
+        initializedPromise.status = "fulfilled";
+        initializedPromise.value = resolvedValue;
+        initializedPromise.reason = null;
+        null !== promiseValue &&
+          wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+        resolveReference(response, handler, parentObject, key, resolvedValue);
+      }, reject);
       return null;
     }
-    function reviveModel(response, parentObj, parentKey, value, reference) {
+    function reviveModel(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    ) {
       if ("string" === typeof value)
         return parseModelString(
           response,
           parentObj,
           parentKey,
           value,
-          reference
+          reference,
+          arrayRoot
         );
       if ("object" === typeof value && null !== value)
         if (
           (void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
             response._temporaryReferences.set(value, reference),
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
+          isArrayImpl(value))
+        ) {
+          if (null === arrayRoot) {
+            var childContext = { count: 0, fork: !1 };
+            response._rootArrayContexts.set(value, childContext);
+          } else childContext = arrayRoot;
+          1 < value.length && (childContext.fork = !0);
+          bumpArrayCount(childContext, value.length + 1, response);
+          for (parentObj = 0; parentObj < value.length; parentObj++)
+            value[parentObj] = reviveModel(
               response,
               value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
+              "" + parentObj,
+              value[parentObj],
+              void 0 !== reference ? reference + ":" + parentObj : void 0,
+              childContext
             );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj || "__proto__" === i
-                ? (value[i] = parentObj)
-                : delete value[i]);
+        } else
+          for (childContext in value)
+            hasOwnProperty.call(value, childContext) &&
+              ("__proto__" === childContext
+                ? delete value[childContext]
+                : ((parentObj =
+                    void 0 !== reference && -1 === childContext.indexOf(":")
+                      ? reference + ":" + childContext
+                      : void 0),
+                  (parentObj = reviveModel(
+                    response,
+                    value,
+                    childContext,
+                    value[childContext],
+                    parentObj,
+                    null
+                  )),
+                  void 0 !== parentObj
+                    ? (value[childContext] = parentObj)
+                    : delete value[childContext]));
       return value;
+    }
+    function bumpArrayCount(arrayContext, slots, response) {
+      if (
+        (arrayContext.count += slots) > response._arraySizeLimit &&
+        arrayContext.fork
+      )
+        throw Error(
+          "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+        );
     }
     function initializeModelChunk(chunk) {
       var prevHandler = initializingHandler;
@@ -2778,13 +2782,15 @@
       chunk.value = null;
       chunk.reason = null;
       try {
-        var rawModel = JSON.parse(resolvedModel),
-          value = reviveModel(
+        var rawModel = JSON.parse(resolvedModel);
+        resolvedModel = { count: 0, fork: !1 };
+        var value = reviveModel(
             response,
             { "": rawModel },
             "",
             rawModel,
-            _chunk$reason
+            _chunk$reason,
+            resolvedModel
           ),
           resolveListeners = chunk.value;
         if (null !== resolveListeners)
@@ -2796,19 +2802,20 @@
             var listener = resolveListeners[rawModel];
             "function" === typeof listener
               ? listener(value)
-              : fulfillReference(response, listener, value);
+              : fulfillReference(response, listener, value, resolvedModel);
           }
         if (null !== initializingHandler) {
           if (initializingHandler.errored) throw initializingHandler.reason;
           if (0 < initializingHandler.deps) {
             initializingHandler.value = value;
+            initializingHandler.reason = resolvedModel;
             initializingHandler.chunk = chunk;
             return;
           }
         }
         chunk.status = "fulfilled";
         chunk.value = value;
-        chunk.reason = null;
+        chunk.reason = resolvedModel;
       } catch (error) {
         (chunk.status = "rejected"), (chunk.reason = error);
       } finally {
@@ -2821,7 +2828,8 @@
           ? triggerErrorOnChunk(response, chunk, error)
           : "fulfilled" === chunk.status &&
             null !== chunk.reason &&
-            chunk.reason.error(error);
+            ((chunk = chunk.reason),
+            "function" === typeof chunk.error && chunk.error(error));
       });
     }
     function getChunk(response, id) {
@@ -2840,40 +2848,74 @@
         chunks.set(id, chunk));
       return chunk;
     }
-    function fulfillReference(response, reference, value) {
+    function fulfillReference(response, reference, value, arrayRoot) {
       var handler = reference.handler,
         parentObject = reference.parentObject,
         key = reference.key,
         map = reference.map,
         path = reference.path;
       try {
-        for (var i = 1; i < path.length; i++) {
+        for (
+          var localLength = 0,
+            rootArrayContexts = response._rootArrayContexts,
+            i = 1;
+          i < path.length;
+          i++
+        ) {
           var name = path[i];
           if (
             "object" !== typeof value ||
-            !hasOwnProperty.call(value, name) ||
-            value instanceof Promise
+            null === value ||
+            (getPrototypeOf(value) !== ObjectPrototype &&
+              getPrototypeOf(value) !== ArrayPrototype) ||
+            !hasOwnProperty.call(value, name)
           )
             throw Error("Invalid reference.");
           value = value[name];
+          if (isArrayImpl(value))
+            (localLength = 0),
+              (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+          else if (((arrayRoot = null), "string" === typeof value))
+            localLength = value.length;
+          else if ("bigint" === typeof value) {
+            var n = Math.abs(Number(value));
+            localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+          } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
         }
-        var mappedValue = map(response, value, parentObject, key);
-        parentObject[key] = mappedValue;
-        "" === key && null === handler.value && (handler.value = mappedValue);
+        var resolvedValue = map(response, value, parentObject, key);
+        var referenceArrayRoot = reference.arrayRoot;
+        null !== referenceArrayRoot &&
+          (null !== arrayRoot
+            ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+              bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+            : 0 < localLength &&
+              bumpArrayCount(referenceArrayRoot, localLength, response));
       } catch (error) {
-        rejectReference(response, reference.handler, error);
+        rejectReference(response, handler, error);
         return;
       }
+      resolveReference(response, handler, parentObject, key, resolvedValue);
+    }
+    function resolveReference(
+      response,
+      handler,
+      parentObject,
+      key,
+      resolvedValue
+    ) {
+      "__proto__" !== key && (parentObject[key] = resolvedValue);
+      "" === key && null === handler.value && (handler.value = resolvedValue);
       handler.deps--;
       0 === handler.deps &&
-        ((reference = handler.chunk),
-        null !== reference &&
-          "blocked" === reference.status &&
-          ((value = reference.value),
-          (reference.status = "fulfilled"),
-          (reference.value = handler.value),
-          (reference.reason = handler.reason),
-          null !== value && wakeChunk(response, value, handler.value)));
+        ((parentObject = handler.chunk),
+        null !== parentObject &&
+          "blocked" === parentObject.status &&
+          ((key = parentObject.value),
+          (parentObject.status = "fulfilled"),
+          (parentObject.value = handler.value),
+          (parentObject.reason = handler.reason),
+          null !== key &&
+            wakeChunk(response, key, handler.value, parentObject)));
     }
     function rejectReference(response, handler, error) {
       handler.errored ||
@@ -2885,29 +2927,66 @@
           "blocked" === handler.status &&
           triggerErrorOnChunk(response, handler, error));
     }
-    function getOutlinedModel(response, reference, parentObject, key, map) {
+    function getOutlinedModel(
+      response,
+      reference,
+      parentObject,
+      key,
+      referenceArrayRoot,
+      map
+    ) {
       reference = reference.split(":");
-      var id = parseInt(reference[0], 16);
-      id = getChunk(response, id);
-      switch (id.status) {
+      var id = parseInt(reference[0], 16),
+        chunk = getChunk(response, id);
+      switch (chunk.status) {
         case "resolved_model":
-          initializeModelChunk(id);
+          initializeModelChunk(chunk);
       }
-      switch (id.status) {
+      switch (chunk.status) {
         case "fulfilled":
-          id = id.value;
-          for (var i = 1; i < reference.length; i++) {
-            var name = reference[i];
+          id = chunk.value;
+          chunk = chunk.reason;
+          for (
+            var localLength = 0,
+              rootArrayContexts = response._rootArrayContexts,
+              i = 1;
+            i < reference.length;
+            i++
+          ) {
+            localLength = reference[i];
             if (
               "object" !== typeof id ||
-              !hasOwnProperty.call(id, name) ||
-              id instanceof Promise
+              null === id ||
+              (getPrototypeOf(id) !== ObjectPrototype &&
+                getPrototypeOf(id) !== ArrayPrototype) ||
+              !hasOwnProperty.call(id, localLength)
             )
               throw Error("Invalid reference.");
-            id = id[name];
+            id = id[localLength];
+            isArrayImpl(id)
+              ? ((localLength = 0),
+                (chunk = rootArrayContexts.get(id) || chunk))
+              : ((chunk = null),
+                "string" === typeof id
+                  ? (localLength = id.length)
+                  : "bigint" === typeof id
+                    ? ((localLength = Math.abs(Number(id))),
+                      (localLength =
+                        0 === localLength
+                          ? 1
+                          : Math.floor(Math.log10(localLength)) + 1))
+                    : (localLength = ArrayBuffer.isView(id)
+                        ? id.byteLength
+                        : 0));
           }
-          return map(response, id, parentObject, key);
-        case "pending":
+          parentObject = map(response, id, parentObject, key);
+          null !== referenceArrayRoot &&
+            (null !== chunk
+              ? (chunk.fork && (referenceArrayRoot.fork = !0),
+                bumpArrayCount(referenceArrayRoot, chunk.count, response))
+              : 0 < localLength &&
+                bumpArrayCount(referenceArrayRoot, localLength, response));
+          return parentObject;
         case "blocked":
           return (
             initializingHandler
@@ -2920,31 +2999,34 @@
                     deps: 1,
                     errored: !1
                   }),
-            (parentObject = {
+            (referenceArrayRoot = {
               handler: response,
               parentObject: parentObject,
               key: key,
               map: map,
-              path: reference
+              path: reference,
+              arrayRoot: referenceArrayRoot
             }),
-            null === id.value
-              ? (id.value = [parentObject])
-              : id.value.push(parentObject),
-            null === id.reason
-              ? (id.reason = [parentObject])
-              : id.reason.push(parentObject),
+            null === chunk.value
+              ? (chunk.value = [referenceArrayRoot])
+              : chunk.value.push(referenceArrayRoot),
+            null === chunk.reason
+              ? (chunk.reason = [referenceArrayRoot])
+              : chunk.reason.push(referenceArrayRoot),
             null
           );
+        case "pending":
+          throw Error("Invalid forward reference.");
         default:
           return (
             initializingHandler
               ? ((initializingHandler.errored = !0),
                 (initializingHandler.value = null),
-                (initializingHandler.reason = id.reason))
+                (initializingHandler.reason = chunk.reason))
               : (initializingHandler = {
                   chunk: null,
                   value: null,
-                  reason: id.reason,
+                  reason: chunk.reason,
                   deps: 0,
                   errored: !0
                 }),
@@ -2953,13 +3035,25 @@
       }
     }
     function createMap(response, model) {
-      return new Map(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+      response = new Map(model);
+      model.$$consumed = !0;
+      return response;
     }
     function createSet(response, model) {
-      return new Set(model);
+      if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+      response = new Set(model);
+      model.$$consumed = !0;
+      return response;
     }
     function extractIterator(response, model) {
-      return model[Symbol.iterator]();
+      if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+      if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+      response = model[Symbol.iterator]();
+      model.$$consumed = !0;
+      return response;
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -2970,13 +3064,34 @@
       constructor,
       bytesPerElement,
       parentObject,
-      parentKey
+      parentKey,
+      referenceArrayRoot
     ) {
+      function reject(error) {
+        if (!handler.errored) {
+          handler.errored = !0;
+          handler.value = null;
+          handler.reason = error;
+          var chunk = handler.chunk;
+          null !== chunk &&
+            "blocked" === chunk.status &&
+            triggerErrorOnChunk(response, chunk, error);
+        }
+      }
       reference = parseInt(reference.slice(2), 16);
-      bytesPerElement = response._prefix + reference;
-      if (response._chunks.has(reference))
+      var key = response._prefix + reference;
+      bytesPerElement = response._chunks;
+      if (bytesPerElement.has(reference))
         throw Error("Already initialized typed array.");
-      reference = response._formData.get(bytesPerElement).arrayBuffer();
+      bytesPerElement.set(
+        reference,
+        new ReactPromise(
+          "rejected",
+          null,
+          Error("Already initialized typed array.")
+        )
+      );
+      reference = response._formData.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -2988,40 +3103,32 @@
           deps: 1,
           errored: !1
         };
-      reference.then(
-        function (buffer) {
-          buffer =
+      reference.then(function (buffer) {
+        try {
+          null !== referenceArrayRoot &&
+            bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+          var resolvedValue =
             constructor === ArrayBuffer ? buffer : new constructor(buffer);
-          parentObject[parentKey] = buffer;
+          "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
           "" === parentKey &&
             null === handler.value &&
-            (handler.value = buffer);
-          handler.deps--;
-          if (
-            0 === handler.deps &&
-            ((buffer = handler.chunk),
-            null !== buffer && "blocked" === buffer.status)
-          ) {
-            var resolveListeners = buffer.value;
-            buffer.status = "fulfilled";
-            buffer.value = handler.value;
-            buffer.reason = null;
-            null !== resolveListeners &&
-              wakeChunk(response, resolveListeners, handler.value);
-          }
-        },
-        function (error) {
-          if (!handler.errored) {
-            handler.errored = !0;
-            handler.value = null;
-            handler.reason = error;
-            var chunk = handler.chunk;
-            null !== chunk &&
-              "blocked" === chunk.status &&
-              triggerErrorOnChunk(response, chunk, error);
-          }
+            (handler.value = resolvedValue);
+        } catch (x) {
+          reject(x);
+          return;
         }
-      );
+        handler.deps--;
+        0 === handler.deps &&
+          ((buffer = handler.chunk),
+          null !== buffer &&
+            "blocked" === buffer.status &&
+            ((resolvedValue = buffer.value),
+            (buffer.status = "fulfilled"),
+            (buffer.value = handler.value),
+            (buffer.reason = null),
+            null !== resolvedValue &&
+              wakeChunk(response, resolvedValue, handler.value, buffer)));
+      }, reject);
       return null;
     }
     function resolveStream(response, id, stream, controller) {
@@ -3039,90 +3146,78 @@
               : controller.enqueueModel(chunks));
     }
     function parseReadableStream(response, reference, type) {
+      function enqueue(value) {
+        "bytes" !== type || ArrayBuffer.isView(value)
+          ? controller.enqueue(value)
+          : flightController.error(Error("Invalid data for bytes stream."));
+      }
       reference = parseInt(reference.slice(2), 16);
       if (response._chunks.has(reference))
         throw Error("Already initialized stream.");
       var controller = null,
-        closed = !1;
-      type = new ReadableStream({
-        type: type,
-        start: function (c) {
-          controller = c;
-        }
-      });
-      var previousBlockedChunk = null;
-      resolveStream(response, reference, type, {
-        enqueueModel: function (json) {
-          if (null === previousBlockedChunk) {
-            var chunk = new ReactPromise(
-              "resolved_model",
-              json,
-              _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
-            );
-            initializeModelChunk(chunk);
-            "fulfilled" === chunk.status
-              ? controller.enqueue(chunk.value)
-              : (chunk.then(
-                  function (v) {
-                    return controller.enqueue(v);
-                  },
-                  function (e) {
-                    return controller.error(e);
-                  }
-                ),
-                (previousBlockedChunk = chunk));
-          } else {
-            chunk = previousBlockedChunk;
-            var _chunk = new ReactPromise("pending", null, null);
-            _chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            );
-            previousBlockedChunk = _chunk;
-            chunk.then(function () {
-              previousBlockedChunk === _chunk && (previousBlockedChunk = null);
-              resolveModelChunk(response, _chunk, json, -1);
-            });
+        closed = !1,
+        stream = new ReadableStream({
+          type: type,
+          start: function (c) {
+            controller = c;
           }
-        },
-        close: function () {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.close();
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.close();
+        }),
+        previousBlockedChunk = null,
+        flightController = {
+          enqueueModel: function (json) {
+            if (null === previousBlockedChunk) {
+              var chunk = new ReactPromise(
+                "resolved_model",
+                json,
+                _defineProperty({ id: -1 }, RESPONSE_SYMBOL, response)
+              );
+              initializeModelChunk(chunk);
+              "fulfilled" === chunk.status
+                ? enqueue(chunk.value)
+                : (chunk.then(enqueue, flightController.error),
+                  (previousBlockedChunk = chunk));
+            } else {
+              chunk = previousBlockedChunk;
+              var _chunk = new ReactPromise("pending", null, null);
+              _chunk.then(enqueue, flightController.error);
+              previousBlockedChunk = _chunk;
+              chunk.then(function () {
+                previousBlockedChunk === _chunk &&
+                  (previousBlockedChunk = null);
+                resolveModelChunk(response, _chunk, json, -1);
               });
             }
-        },
-        error: function (error) {
-          if (!closed)
-            if (((closed = !0), null === previousBlockedChunk))
-              controller.error(error);
-            else {
-              var blockedChunk = previousBlockedChunk;
-              previousBlockedChunk = null;
-              blockedChunk.then(function () {
-                return controller.error(error);
-              });
-            }
-        }
-      });
-      return type;
+          },
+          close: function () {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.close();
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.close();
+                });
+              }
+          },
+          error: function (error) {
+            if (!closed)
+              if (((closed = !0), null === previousBlockedChunk))
+                controller.error(error);
+              else {
+                var blockedChunk = previousBlockedChunk;
+                previousBlockedChunk = null;
+                blockedChunk.then(function () {
+                  return controller.error(error);
+                });
+              }
+          }
+        };
+      resolveStream(response, reference, stream, flightController);
+      return stream;
     }
-    function asyncIterator() {
-      return this;
-    }
-    function createIterator(next) {
-      next = { next: next };
-      next[ASYNC_ITERATOR] = asyncIterator;
-      return next;
+    function FlightIterator(next) {
+      this.next = next;
     }
     function parseAsyncIterable(response, reference, iterator) {
       reference = parseInt(reference.slice(2), 16);
@@ -3133,7 +3228,7 @@
         nextWriteIndex = 0,
         iterable = _defineProperty({}, ASYNC_ITERATOR, function () {
           var nextReadIndex = 0;
-          return createIterator(function (arg) {
+          return new FlightIterator(function (arg) {
             if (void 0 !== arg)
               throw Error(
                 "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -3212,19 +3307,30 @@
       });
       return iterator;
     }
-    function parseModelString(response, obj, key, value, reference) {
+    function parseModelString(response, obj, key, value, reference, arrayRoot) {
       if ("$" === value[0]) {
         switch (value[1]) {
           case "$":
-            return value.slice(1);
+            return (
+              null !== arrayRoot &&
+                bumpArrayCount(arrayRoot, value.length - 1, response),
+              value.slice(1)
+            );
           case "@":
             return (
               (obj = parseInt(value.slice(2), 16)), getChunk(response, obj)
             );
           case "h":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, loadServerReference$1)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                loadServerReference$1
+              )
             );
           case "T":
             if (
@@ -3240,27 +3346,44 @@
             );
           case "Q":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createMap)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
             );
           case "W":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, createSet)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
             obj = value.slice(2);
-            var formPrefix = response._prefix + obj + "_",
-              data = new FormData();
-            response._formData.forEach(function (entry, entryKey) {
-              entryKey.startsWith(formPrefix) &&
-                data.append(entryKey.slice(formPrefix.length), entry);
-            });
-            return data;
+            obj = response._prefix + obj + "_";
+            key = new FormData();
+            response = response._formData;
+            arrayRoot = Array.from(response.keys());
+            for (value = 0; value < arrayRoot.length; value++)
+              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+                for (
+                  var entries = response.getAll(reference),
+                    newKey = reference.slice(obj.length),
+                    j = 0;
+                  j < entries.length;
+                  j++
+                )
+                  key.append(newKey, entries[j]);
+                response.delete(reference);
+              }
+            return key;
           case "i":
             return (
-              (value = value.slice(2)),
-              getOutlinedModel(response, value, obj, key, extractIterator)
+              (arrayRoot = value.slice(2)),
+              getOutlinedModel(
+                response,
+                arrayRoot,
+                obj,
+                key,
+                null,
+                extractIterator
+              )
             );
           case "I":
             return Infinity;
@@ -3273,15 +3396,50 @@
           case "D":
             return new Date(Date.parse(value.slice(2)));
           case "n":
-            return BigInt(value.slice(2));
+            obj = value.slice(2);
+            if (obj.length > MAX_BIGINT_DIGITS)
+              throw Error(
+                "BigInt is too large. Received " +
+                  obj.length +
+                  " digits but the limit is " +
+                  MAX_BIGINT_DIGITS +
+                  "."
+              );
+            null !== arrayRoot &&
+              bumpArrayCount(arrayRoot, obj.length, response);
+            return BigInt(obj);
         }
         switch (value[1]) {
           case "A":
-            return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              ArrayBuffer,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "O":
-            return parseTypedArray(response, value, Int8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "o":
-            return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint8Array,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "U":
             return parseTypedArray(
               response,
@@ -3289,22 +3447,79 @@
               Uint8ClampedArray,
               1,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "S":
-            return parseTypedArray(response, value, Int16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "s":
-            return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint16Array,
+              2,
+              obj,
+              key,
+              arrayRoot
+            );
           case "L":
-            return parseTypedArray(response, value, Int32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Int32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "l":
-            return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Uint32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "G":
-            return parseTypedArray(response, value, Float32Array, 4, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float32Array,
+              4,
+              obj,
+              key,
+              arrayRoot
+            );
           case "g":
-            return parseTypedArray(response, value, Float64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              Float64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "M":
-            return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              BigInt64Array,
+              8,
+              obj,
+              key,
+              arrayRoot
+            );
           case "m":
             return parseTypedArray(
               response,
@@ -3312,10 +3527,19 @@
               BigUint64Array,
               8,
               obj,
-              key
+              key,
+              arrayRoot
             );
           case "V":
-            return parseTypedArray(response, value, DataView, 1, obj, key);
+            return parseTypedArray(
+              response,
+              value,
+              DataView,
+              1,
+              obj,
+              key,
+              arrayRoot
+            );
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
@@ -3333,8 +3557,16 @@
             return parseAsyncIterable(response, value, !0);
         }
         value = value.slice(1);
-        return getOutlinedModel(response, value, obj, key, createModel);
+        return getOutlinedModel(
+          response,
+          value,
+          obj,
+          key,
+          arrayRoot,
+          createModel
+        );
       }
+      null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
       return value;
     }
     function createResponse(
@@ -3346,13 +3578,17 @@
           3 < arguments.length && void 0 !== arguments[3]
             ? arguments[3]
             : new FormData(),
+        arraySizeLimit =
+          4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
         chunks = new Map();
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
         _formData: backingFormData,
         _chunks: chunks,
-        _temporaryReferences: temporaryReferences
+        _temporaryReferences: temporaryReferences,
+        _rootArrayContexts: new WeakMap(),
+        _arraySizeLimit: arraySizeLimit
       };
     }
     function resolveField(response, key, value) {
@@ -3368,13 +3604,24 @@
     function close(response) {
       reportGlobalError(response, Error("Connection closed."));
     }
-    function loadServerReference(bundlerConfig, id, bound) {
+    function loadServerReference(bundlerConfig, metaData) {
+      var id = metaData.id;
+      if ("string" !== typeof id) return null;
       var serverReference = resolveServerReference(bundlerConfig, id);
       bundlerConfig = preloadModule(serverReference);
-      return bound
-        ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+      metaData = metaData.bound;
+      return null !== metaData
+        ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
             _ref = _ref[0];
             var fn = requireModule(serverReference);
+            if (_ref.length > MAX_BOUND_ARGS)
+              throw Error(
+                "Server Function has too many bound arguments. Received " +
+                  _ref.length +
+                  " but the limit is " +
+                  MAX_BOUND_ARGS +
+                  "."
+              );
             return fn.bind.apply(fn, [null].concat(_ref));
           })
         : bundlerConfig
@@ -3383,8 +3630,19 @@
             })
           : Promise.resolve(requireModule(serverReference));
     }
-    function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-      body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+    function decodeBoundActionMetaData(
+      body,
+      serverManifest,
+      formFieldPrefix,
+      arraySizeLimit
+    ) {
+      body = createResponse(
+        serverManifest,
+        formFieldPrefix,
+        void 0,
+        body,
+        arraySizeLimit
+      );
       close(body);
       body = getChunk(body, 0);
       body.then(function () {});
@@ -3811,13 +4069,14 @@
       patchConsole(console, "table"),
       patchConsole(console, "trace"),
       patchConsole(console, "warn"));
-    var ObjectPrototype = Object.prototype,
+    var ObjectPrototype$1 = Object.prototype,
       stringify = JSON.stringify,
       PENDING$1 = 0,
       COMPLETED = 1,
       ABORTED = 3,
       ERRORED$1 = 4,
       RENDERING = 5,
+      __PROTO__$1 = "__proto__",
       OPENING = 10,
       ABORTING = 12,
       CLOSING = 13,
@@ -3840,16 +4099,23 @@
         case "fulfilled":
           if ("function" === typeof resolve) {
             for (
-              var inspectedValue = this.value, cycleProtection = 0;
+              var inspectedValue = this.value,
+                cycleProtection = 0,
+                visited = new Set();
               inspectedValue instanceof ReactPromise;
 
             ) {
               cycleProtection++;
-              if (inspectedValue === this || 1e3 < cycleProtection) {
+              if (
+                inspectedValue === this ||
+                visited.has(inspectedValue) ||
+                1e3 < cycleProtection
+              ) {
                 "function" === typeof reject &&
                   reject(Error("Cannot have cyclic thenables."));
                 return;
               }
+              visited.add(inspectedValue);
               if ("fulfilled" === inspectedValue.status)
                 inspectedValue = inspectedValue.value;
               else break;
@@ -3870,7 +4136,15 @@
           "function" === typeof reject && reject(this.reason);
       }
     };
-    var initializingHandler = null;
+    var ObjectPrototype = Object.prototype,
+      ArrayPrototype = Array.prototype,
+      initializingHandler = null;
+    FlightIterator.prototype = {};
+    FlightIterator.prototype[ASYNC_ITERATOR] = function () {
+      return this;
+    };
+    var MAX_BIGINT_DIGITS = 300,
+      MAX_BOUND_ARGS = 1e3;
     exports.createClientModuleProxy = function (moduleId) {
       moduleId = registerClientReferenceImpl({}, moduleId, !1);
       return new Proxy(moduleId, proxyHandlers$1);
@@ -3880,20 +4154,24 @@
     };
     exports.decodeAction = function (body, serverManifest) {
       var formData = new FormData(),
-        action = null;
+        action = null,
+        seenActions = new Set();
       body.forEach(function (value, key) {
         key.startsWith("$ACTION_")
           ? key.startsWith("$ACTION_REF_")
-            ? ((value = "$ACTION_" + key.slice(12) + ":"),
+            ? seenActions.has(key) ||
+              (seenActions.add(key),
+              (value = "$ACTION_" + key.slice(12) + ":"),
               (value = decodeBoundActionMetaData(body, serverManifest, value)),
-              (action = loadServerReference(
-                serverManifest,
-                value.id,
-                value.bound
-              )))
+              (action = loadServerReference(serverManifest, value)))
             : key.startsWith("$ACTION_ID_") &&
-              ((value = key.slice(11)),
-              (action = loadServerReference(serverManifest, value, null)))
+              !seenActions.has(key) &&
+              (seenActions.add(key),
+              (value = key.slice(11)),
+              (action = loadServerReference(serverManifest, {
+                id: value,
+                bound: null
+              })))
           : formData.append(key, value);
       });
       return null === action
@@ -3929,7 +4207,8 @@
         webpackMap,
         "",
         options ? options.temporaryReferences : void 0,
-        body
+        body,
+        options ? options.arraySizeLimit : void 0
       );
       webpackMap = getChunk(body, 0);
       close(body);
@@ -3943,7 +4222,9 @@
       var response = createResponse(
           webpackMap,
           "",
-          options ? options.temporaryReferences : void 0
+          options ? options.temporaryReferences : void 0,
+          void 0,
+          options ? options.arraySizeLimit : void 0
         ),
         pendingFiles = 0,
         queuedFields = [];
@@ -3967,13 +4248,13 @@
           );
         else {
           pendingFiles++;
-          var JSCompiler_object_inline_chunks_154 = [];
+          var JSCompiler_object_inline_chunks_149 = [];
           value.on("data", function (chunk) {
-            JSCompiler_object_inline_chunks_154.push(chunk);
+            JSCompiler_object_inline_chunks_149.push(chunk);
           });
           value.on("end", function () {
             try {
-              var blob = new Blob(JSCompiler_object_inline_chunks_154, {
+              var blob = new Blob(JSCompiler_object_inline_chunks_149, {
                 type: mimeType
               });
               response._formData.append(name, blob, filename);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -726,7 +726,7 @@ function describeObjectForErrorMessage(objectOrArray, expandedName) {
         "\n  " + str + "\n  " + objectOrArray)
       : "\n  " + str;
 }
-var ObjectPrototype = Object.prototype,
+var ObjectPrototype$1 = Object.prototype,
   stringify = JSON.stringify;
 function defaultErrorHandler(error) {
   console.error(error);
@@ -1547,7 +1547,7 @@ function renderModelDestructive(
     if (value instanceof Date) return "$D" + value.toJSON();
     request = getPrototypeOf(value);
     if (
-      request !== ObjectPrototype &&
+      request !== ObjectPrototype$1 &&
       (null === request || null !== getPrototypeOf(request))
     )
       throw Error(
@@ -2031,16 +2031,23 @@ ReactPromise.prototype.then = function (resolve, reject) {
     case "fulfilled":
       if ("function" === typeof resolve) {
         for (
-          var inspectedValue = this.value, cycleProtection = 0;
+          var inspectedValue = this.value,
+            cycleProtection = 0,
+            visited = new Set();
           inspectedValue instanceof ReactPromise;
 
         ) {
           cycleProtection++;
-          if (inspectedValue === this || 1e3 < cycleProtection) {
+          if (
+            inspectedValue === this ||
+            visited.has(inspectedValue) ||
+            1e3 < cycleProtection
+          ) {
             "function" === typeof reject &&
               reject(Error("Cannot have cyclic thenables."));
             return;
           }
+          visited.add(inspectedValue);
           if ("fulfilled" === inspectedValue.status)
             inspectedValue = inspectedValue.value;
           else break;
@@ -2059,12 +2066,14 @@ ReactPromise.prototype.then = function (resolve, reject) {
       "function" === typeof reject && reject(this.reason);
   }
 };
-function wakeChunk(response, listeners, value) {
+var ObjectPrototype = Object.prototype,
+  ArrayPrototype = Array.prototype;
+function wakeChunk(response, listeners, value, chunk) {
   for (var i = 0; i < listeners.length; i++) {
     var listener = listeners[i];
     "function" === typeof listener
       ? listener(value)
-      : fulfillReference(response, listener, value);
+      : fulfillReference(response, listener, value, chunk.reason);
   }
 }
 function rejectChunk(response, listeners, error) {
@@ -2074,27 +2083,6 @@ function rejectChunk(response, listeners, error) {
       ? listener(error)
       : rejectReference(response, listener.handler, error);
   }
-}
-function resolveBlockedCycle(resolvedChunk, reference) {
-  var referencedChunk = reference.handler.chunk;
-  if (null === referencedChunk) return null;
-  if (referencedChunk === resolvedChunk) return reference.handler;
-  reference = referencedChunk.value;
-  if (null !== reference)
-    for (
-      referencedChunk = 0;
-      referencedChunk < reference.length;
-      referencedChunk++
-    ) {
-      var listener = reference[referencedChunk];
-      if (
-        "function" !== typeof listener &&
-        ((listener = resolveBlockedCycle(resolvedChunk, listener)),
-        null !== listener)
-      )
-        return listener;
-    }
-  return null;
 }
 function triggerErrorOnChunk(response, chunk, error) {
   if ("pending" !== chunk.status && "blocked" !== chunk.status)
@@ -2131,33 +2119,11 @@ function resolveModelChunk(response, chunk, value, id) {
     chunk.reason =
       ((value.id = id), (value[RESPONSE_SYMBOL] = response), value);
     if (null !== resolveListeners)
-      a: switch ((initializeModelChunk(chunk), chunk.status)) {
+      switch ((initializeModelChunk(chunk), chunk.status)) {
         case "fulfilled":
-          wakeChunk(response, resolveListeners, chunk.value);
+          wakeChunk(response, resolveListeners, chunk.value, chunk);
           break;
         case "blocked":
-          for (value = 0; value < resolveListeners.length; value++)
-            if (((id = resolveListeners[value]), "function" !== typeof id)) {
-              var cyclicHandler = resolveBlockedCycle(chunk, id);
-              if (null !== cyclicHandler)
-                switch (
-                  (fulfillReference(response, id, cyclicHandler.value),
-                  resolveListeners.splice(value, 1),
-                  value--,
-                  null !== rejectListeners &&
-                    ((id = rejectListeners.indexOf(id)),
-                    -1 !== id && rejectListeners.splice(id, 1)),
-                  chunk.status)
-                ) {
-                  case "fulfilled":
-                    wakeChunk(response, resolveListeners, chunk.value);
-                    break a;
-                  case "rejected":
-                    null !== rejectListeners &&
-                      rejectChunk(response, rejectListeners, chunk.reason);
-                    break a;
-                }
-            }
         case "pending":
           if (chunk.value)
             for (response = 0; response < resolveListeners.length; response++)
@@ -2174,7 +2140,8 @@ function resolveModelChunk(response, chunk, value, id) {
           } else chunk.reason = rejectListeners;
           break;
         case "rejected":
-          rejectListeners && wakeChunk(response, rejectListeners, chunk.reason);
+          rejectListeners &&
+            rejectChunk(response, rejectListeners, chunk.reason);
       }
   }
 }
@@ -2197,15 +2164,50 @@ function resolveIteratorResultChunk(response, chunk, value, done) {
   );
 }
 function loadServerReference$1(response, metaData, parentObject, key) {
+  function reject(error) {
+    var rejectListeners = blockedPromise.reason,
+      erroredPromise = blockedPromise;
+    erroredPromise.status = "rejected";
+    erroredPromise.value = null;
+    erroredPromise.reason = error;
+    null !== rejectListeners && rejectChunk(response, rejectListeners, error);
+    rejectReference(response, handler, error);
+  }
   var id = metaData.id;
   if ("string" !== typeof id || "then" === key) return null;
+  var cachedPromise = metaData.$$promise;
+  if (void 0 !== cachedPromise) {
+    if ("fulfilled" === cachedPromise.status)
+      return (
+        (cachedPromise = cachedPromise.value),
+        "__proto__" === key ? null : (parentObject[key] = cachedPromise)
+      );
+    initializingHandler
+      ? ((id = initializingHandler), id.deps++)
+      : (id = initializingHandler =
+          { chunk: null, value: null, reason: null, deps: 1, errored: !1 });
+    cachedPromise.then(
+      resolveReference.bind(null, response, id, parentObject, key),
+      rejectReference.bind(null, response, id)
+    );
+    return null;
+  }
+  var blockedPromise = new ReactPromise("blocked", null, null);
+  metaData.$$promise = blockedPromise;
   var serverReference = resolveServerReference(response._bundlerConfig, id);
-  id = metaData.bound;
-  var promise = preloadModule(serverReference);
-  if (promise)
-    id instanceof ReactPromise && (promise = Promise.all([promise, id]));
-  else if (id instanceof ReactPromise) promise = Promise.resolve(id);
-  else return requireModule(serverReference);
+  cachedPromise = metaData.bound;
+  if ((id = preloadModule(serverReference)))
+    cachedPromise instanceof ReactPromise &&
+      (id = Promise.all([id, cachedPromise]));
+  else if (cachedPromise instanceof ReactPromise)
+    id = Promise.resolve(cachedPromise);
+  else
+    return (
+      (cachedPromise = requireModule(serverReference)),
+      (id = blockedPromise),
+      (id.status = "fulfilled"),
+      (id.value = cachedPromise)
+    );
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2217,73 +2219,104 @@ function loadServerReference$1(response, metaData, parentObject, key) {
       deps: 1,
       errored: !1
     };
-  promise.then(
-    function () {
-      var resolvedValue = requireModule(serverReference);
-      if (metaData.bound) {
-        var promiseValue = metaData.bound.value;
-        promiseValue = Array.isArray(promiseValue) ? promiseValue.slice(0) : [];
-        promiseValue.unshift(null);
-        resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
+  id.then(function () {
+    var resolvedValue = requireModule(serverReference);
+    if (metaData.bound) {
+      var promiseValue = metaData.bound.value;
+      promiseValue = isArrayImpl(promiseValue) ? promiseValue.slice(0) : [];
+      if (1e3 < promiseValue.length) {
+        reject(
+          Error(
+            "Server Function has too many bound arguments. Received " +
+              promiseValue.length +
+              " but the limit is 1000."
+          )
+        );
+        return;
       }
-      parentObject[key] = resolvedValue;
-      "" === key && null === handler.value && (handler.value = resolvedValue);
-      handler.deps--;
-      0 === handler.deps &&
-        ((resolvedValue = handler.chunk),
-        null !== resolvedValue &&
-          "blocked" === resolvedValue.status &&
-          ((promiseValue = resolvedValue.value),
-          (resolvedValue.status = "fulfilled"),
-          (resolvedValue.value = handler.value),
-          (resolvedValue.reason = null),
-          null !== promiseValue &&
-            wakeChunk(response, promiseValue, handler.value)));
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+      promiseValue.unshift(null);
+      resolvedValue = resolvedValue.bind.apply(resolvedValue, promiseValue);
     }
-  );
+    promiseValue = blockedPromise.value;
+    var initializedPromise = blockedPromise;
+    initializedPromise.status = "fulfilled";
+    initializedPromise.value = resolvedValue;
+    initializedPromise.reason = null;
+    null !== promiseValue &&
+      wakeChunk(response, promiseValue, resolvedValue, initializedPromise);
+    resolveReference(response, handler, parentObject, key, resolvedValue);
+  }, reject);
   return null;
 }
-function reviveModel(response, parentObj, parentKey, value, reference) {
+function reviveModel(
+  response,
+  parentObj,
+  parentKey,
+  value,
+  reference,
+  arrayRoot
+) {
   if ("string" === typeof value)
-    return parseModelString(response, parentObj, parentKey, value, reference);
+    return parseModelString(
+      response,
+      parentObj,
+      parentKey,
+      value,
+      reference,
+      arrayRoot
+    );
   if ("object" === typeof value && null !== value)
     if (
       (void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
         response._temporaryReferences.set(value, reference),
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
+      isArrayImpl(value))
+    ) {
+      if (null === arrayRoot) {
+        var childContext = { count: 0, fork: !1 };
+        response._rootArrayContexts.set(value, childContext);
+      } else childContext = arrayRoot;
+      1 < value.length && (childContext.fork = !0);
+      bumpArrayCount(childContext, value.length + 1, response);
+      for (parentObj = 0; parentObj < value.length; parentObj++)
+        value[parentObj] = reviveModel(
           response,
           value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
+          "" + parentObj,
+          value[parentObj],
+          void 0 !== reference ? reference + ":" + parentObj : void 0,
+          childContext
         );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj || "__proto__" === i
-            ? (value[i] = parentObj)
-            : delete value[i]);
+    } else
+      for (childContext in value)
+        hasOwnProperty.call(value, childContext) &&
+          ("__proto__" === childContext
+            ? delete value[childContext]
+            : ((parentObj =
+                void 0 !== reference && -1 === childContext.indexOf(":")
+                  ? reference + ":" + childContext
+                  : void 0),
+              (parentObj = reviveModel(
+                response,
+                value,
+                childContext,
+                value[childContext],
+                parentObj,
+                null
+              )),
+              void 0 !== parentObj
+                ? (value[childContext] = parentObj)
+                : delete value[childContext]));
   return value;
+}
+function bumpArrayCount(arrayContext, slots, response) {
+  if (
+    (arrayContext.count += slots) > response._arraySizeLimit &&
+    arrayContext.fork
+  )
+    throw Error(
+      "Maximum array nesting exceeded. Large nested arrays can be dangerous. Try adding intermediate objects."
+    );
 }
 var initializingHandler = null;
 function initializeModelChunk(chunk) {
@@ -2298,13 +2331,15 @@ function initializeModelChunk(chunk) {
   chunk.value = null;
   chunk.reason = null;
   try {
-    var rawModel = JSON.parse(resolvedModel),
-      value = reviveModel(
+    var rawModel = JSON.parse(resolvedModel);
+    resolvedModel = { count: 0, fork: !1 };
+    var value = reviveModel(
         response,
         { "": rawModel },
         "",
         rawModel,
-        _chunk$reason
+        _chunk$reason,
+        resolvedModel
       ),
       resolveListeners = chunk.value;
     if (null !== resolveListeners)
@@ -2316,19 +2351,20 @@ function initializeModelChunk(chunk) {
         var listener = resolveListeners[rawModel];
         "function" === typeof listener
           ? listener(value)
-          : fulfillReference(response, listener, value);
+          : fulfillReference(response, listener, value, resolvedModel);
       }
     if (null !== initializingHandler) {
       if (initializingHandler.errored) throw initializingHandler.reason;
       if (0 < initializingHandler.deps) {
         initializingHandler.value = value;
+        initializingHandler.reason = resolvedModel;
         initializingHandler.chunk = chunk;
         return;
       }
     }
     chunk.status = "fulfilled";
     chunk.value = value;
-    chunk.reason = null;
+    chunk.reason = resolvedModel;
   } catch (error) {
     (chunk.status = "rejected"), (chunk.reason = error);
   } finally {
@@ -2341,7 +2377,8 @@ function reportGlobalError(response, error) {
       ? triggerErrorOnChunk(response, chunk, error)
       : "fulfilled" === chunk.status &&
         null !== chunk.reason &&
-        chunk.reason.error(error);
+        ((chunk = chunk.reason),
+        "function" === typeof chunk.error && chunk.error(error));
   });
 }
 function getChunk(response, id) {
@@ -2356,40 +2393,67 @@ function getChunk(response, id) {
     chunks.set(id, chunk));
   return chunk;
 }
-function fulfillReference(response, reference, value) {
+function fulfillReference(response, reference, value, arrayRoot) {
   var handler = reference.handler,
     parentObject = reference.parentObject,
     key = reference.key,
     map = reference.map,
     path = reference.path;
   try {
-    for (var i = 1; i < path.length; i++) {
+    for (
+      var localLength = 0,
+        rootArrayContexts = response._rootArrayContexts,
+        i = 1;
+      i < path.length;
+      i++
+    ) {
       var name = path[i];
       if (
         "object" !== typeof value ||
-        !hasOwnProperty.call(value, name) ||
-        value instanceof Promise
+        null === value ||
+        (getPrototypeOf(value) !== ObjectPrototype &&
+          getPrototypeOf(value) !== ArrayPrototype) ||
+        !hasOwnProperty.call(value, name)
       )
         throw Error("Invalid reference.");
       value = value[name];
+      if (isArrayImpl(value))
+        (localLength = 0),
+          (arrayRoot = rootArrayContexts.get(value) || arrayRoot);
+      else if (((arrayRoot = null), "string" === typeof value))
+        localLength = value.length;
+      else if ("bigint" === typeof value) {
+        var n = Math.abs(Number(value));
+        localLength = 0 === n ? 1 : Math.floor(Math.log10(n)) + 1;
+      } else localLength = ArrayBuffer.isView(value) ? value.byteLength : 0;
     }
-    var mappedValue = map(response, value, parentObject, key);
-    parentObject[key] = mappedValue;
-    "" === key && null === handler.value && (handler.value = mappedValue);
+    var resolvedValue = map(response, value, parentObject, key);
+    var referenceArrayRoot = reference.arrayRoot;
+    null !== referenceArrayRoot &&
+      (null !== arrayRoot
+        ? (arrayRoot.fork && (referenceArrayRoot.fork = !0),
+          bumpArrayCount(referenceArrayRoot, arrayRoot.count, response))
+        : 0 < localLength &&
+          bumpArrayCount(referenceArrayRoot, localLength, response));
   } catch (error) {
-    rejectReference(response, reference.handler, error);
+    rejectReference(response, handler, error);
     return;
   }
+  resolveReference(response, handler, parentObject, key, resolvedValue);
+}
+function resolveReference(response, handler, parentObject, key, resolvedValue) {
+  "__proto__" !== key && (parentObject[key] = resolvedValue);
+  "" === key && null === handler.value && (handler.value = resolvedValue);
   handler.deps--;
   0 === handler.deps &&
-    ((reference = handler.chunk),
-    null !== reference &&
-      "blocked" === reference.status &&
-      ((value = reference.value),
-      (reference.status = "fulfilled"),
-      (reference.value = handler.value),
-      (reference.reason = handler.reason),
-      null !== value && wakeChunk(response, value, handler.value)));
+    ((parentObject = handler.chunk),
+    null !== parentObject &&
+      "blocked" === parentObject.status &&
+      ((key = parentObject.value),
+      (parentObject.status = "fulfilled"),
+      (parentObject.value = handler.value),
+      (parentObject.reason = handler.reason),
+      null !== key && wakeChunk(response, key, handler.value, parentObject)));
 }
 function rejectReference(response, handler, error) {
   handler.errored ||
@@ -2401,60 +2465,97 @@ function rejectReference(response, handler, error) {
       "blocked" === handler.status &&
       triggerErrorOnChunk(response, handler, error));
 }
-function getOutlinedModel(response, reference, parentObject, key, map) {
+function getOutlinedModel(
+  response,
+  reference,
+  parentObject,
+  key,
+  referenceArrayRoot,
+  map
+) {
   reference = reference.split(":");
-  var id = parseInt(reference[0], 16);
-  id = getChunk(response, id);
-  switch (id.status) {
+  var id = parseInt(reference[0], 16),
+    chunk = getChunk(response, id);
+  switch (chunk.status) {
     case "resolved_model":
-      initializeModelChunk(id);
+      initializeModelChunk(chunk);
   }
-  switch (id.status) {
+  switch (chunk.status) {
     case "fulfilled":
-      id = id.value;
-      for (var i = 1; i < reference.length; i++) {
-        var name = reference[i];
+      id = chunk.value;
+      chunk = chunk.reason;
+      for (
+        var localLength = 0,
+          rootArrayContexts = response._rootArrayContexts,
+          i = 1;
+        i < reference.length;
+        i++
+      ) {
+        localLength = reference[i];
         if (
           "object" !== typeof id ||
-          !hasOwnProperty.call(id, name) ||
-          id instanceof Promise
+          null === id ||
+          (getPrototypeOf(id) !== ObjectPrototype &&
+            getPrototypeOf(id) !== ArrayPrototype) ||
+          !hasOwnProperty.call(id, localLength)
         )
           throw Error("Invalid reference.");
-        id = id[name];
+        id = id[localLength];
+        isArrayImpl(id)
+          ? ((localLength = 0), (chunk = rootArrayContexts.get(id) || chunk))
+          : ((chunk = null),
+            "string" === typeof id
+              ? (localLength = id.length)
+              : "bigint" === typeof id
+                ? ((localLength = Math.abs(Number(id))),
+                  (localLength =
+                    0 === localLength
+                      ? 1
+                      : Math.floor(Math.log10(localLength)) + 1))
+                : (localLength = ArrayBuffer.isView(id) ? id.byteLength : 0));
       }
-      return map(response, id, parentObject, key);
-    case "pending":
+      parentObject = map(response, id, parentObject, key);
+      null !== referenceArrayRoot &&
+        (null !== chunk
+          ? (chunk.fork && (referenceArrayRoot.fork = !0),
+            bumpArrayCount(referenceArrayRoot, chunk.count, response))
+          : 0 < localLength &&
+            bumpArrayCount(referenceArrayRoot, localLength, response));
+      return parentObject;
     case "blocked":
       return (
         initializingHandler
           ? ((response = initializingHandler), response.deps++)
           : (response = initializingHandler =
               { chunk: null, value: null, reason: null, deps: 1, errored: !1 }),
-        (parentObject = {
+        (referenceArrayRoot = {
           handler: response,
           parentObject: parentObject,
           key: key,
           map: map,
-          path: reference
+          path: reference,
+          arrayRoot: referenceArrayRoot
         }),
-        null === id.value
-          ? (id.value = [parentObject])
-          : id.value.push(parentObject),
-        null === id.reason
-          ? (id.reason = [parentObject])
-          : id.reason.push(parentObject),
+        null === chunk.value
+          ? (chunk.value = [referenceArrayRoot])
+          : chunk.value.push(referenceArrayRoot),
+        null === chunk.reason
+          ? (chunk.reason = [referenceArrayRoot])
+          : chunk.reason.push(referenceArrayRoot),
         null
       );
+    case "pending":
+      throw Error("Invalid forward reference.");
     default:
       return (
         initializingHandler
           ? ((initializingHandler.errored = !0),
             (initializingHandler.value = null),
-            (initializingHandler.reason = id.reason))
+            (initializingHandler.reason = chunk.reason))
           : (initializingHandler = {
               chunk: null,
               value: null,
-              reason: id.reason,
+              reason: chunk.reason,
               deps: 0,
               errored: !0
             }),
@@ -2463,13 +2564,25 @@ function getOutlinedModel(response, reference, parentObject, key, map) {
   }
 }
 function createMap(response, model) {
-  return new Map(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Map.");
+  response = new Map(model);
+  model.$$consumed = !0;
+  return response;
 }
 function createSet(response, model) {
-  return new Set(model);
+  if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Set.");
+  response = new Set(model);
+  model.$$consumed = !0;
+  return response;
 }
 function extractIterator(response, model) {
-  return model[Symbol.iterator]();
+  if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
+  if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
+  response = model[Symbol.iterator]();
+  model.$$consumed = !0;
+  return response;
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2480,13 +2593,34 @@ function parseTypedArray(
   constructor,
   bytesPerElement,
   parentObject,
-  parentKey
+  parentKey,
+  referenceArrayRoot
 ) {
+  function reject(error) {
+    if (!handler.errored) {
+      handler.errored = !0;
+      handler.value = null;
+      handler.reason = error;
+      var chunk = handler.chunk;
+      null !== chunk &&
+        "blocked" === chunk.status &&
+        triggerErrorOnChunk(response, chunk, error);
+    }
+  }
   reference = parseInt(reference.slice(2), 16);
-  bytesPerElement = response._prefix + reference;
-  if (response._chunks.has(reference))
+  var key = response._prefix + reference;
+  bytesPerElement = response._chunks;
+  if (bytesPerElement.has(reference))
     throw Error("Already initialized typed array.");
-  reference = response._formData.get(bytesPerElement).arrayBuffer();
+  bytesPerElement.set(
+    reference,
+    new ReactPromise(
+      "rejected",
+      null,
+      Error("Already initialized typed array.")
+    )
+  );
+  reference = response._formData.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2498,37 +2632,32 @@ function parseTypedArray(
       deps: 1,
       errored: !1
     };
-  reference.then(
-    function (buffer) {
-      buffer = constructor === ArrayBuffer ? buffer : new constructor(buffer);
-      parentObject[parentKey] = buffer;
-      "" === parentKey && null === handler.value && (handler.value = buffer);
-      handler.deps--;
-      if (
-        0 === handler.deps &&
-        ((buffer = handler.chunk),
-        null !== buffer && "blocked" === buffer.status)
-      ) {
-        var resolveListeners = buffer.value;
-        buffer.status = "fulfilled";
-        buffer.value = handler.value;
-        buffer.reason = null;
-        null !== resolveListeners &&
-          wakeChunk(response, resolveListeners, handler.value);
-      }
-    },
-    function (error) {
-      if (!handler.errored) {
-        handler.errored = !0;
-        handler.value = null;
-        handler.reason = error;
-        var chunk = handler.chunk;
-        null !== chunk &&
-          "blocked" === chunk.status &&
-          triggerErrorOnChunk(response, chunk, error);
-      }
+  reference.then(function (buffer) {
+    try {
+      null !== referenceArrayRoot &&
+        bumpArrayCount(referenceArrayRoot, buffer.byteLength, response);
+      var resolvedValue =
+        constructor === ArrayBuffer ? buffer : new constructor(buffer);
+      "__proto__" !== key && (parentObject[parentKey] = resolvedValue);
+      "" === parentKey &&
+        null === handler.value &&
+        (handler.value = resolvedValue);
+    } catch (x) {
+      reject(x);
+      return;
     }
-  );
+    handler.deps--;
+    0 === handler.deps &&
+      ((buffer = handler.chunk),
+      null !== buffer &&
+        "blocked" === buffer.status &&
+        ((resolvedValue = buffer.value),
+        (buffer.status = "fulfilled"),
+        (buffer.value = handler.value),
+        (buffer.reason = null),
+        null !== resolvedValue &&
+          wakeChunk(response, resolvedValue, handler.value, buffer)));
+  }, reject);
   return null;
 }
 function resolveStream(response, id, stream, controller) {
@@ -2544,86 +2673,78 @@ function resolveStream(response, id, stream, controller) {
           : controller.enqueueModel(chunks));
 }
 function parseReadableStream(response, reference, type) {
+  function enqueue(value) {
+    "bytes" !== type || ArrayBuffer.isView(value)
+      ? controller.enqueue(value)
+      : flightController.error(Error("Invalid data for bytes stream."));
+  }
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
     throw Error("Already initialized stream.");
   var controller = null,
-    closed = !1;
-  type = new ReadableStream({
-    type: type,
-    start: function (c) {
-      controller = c;
-    }
-  });
-  var previousBlockedChunk = null;
-  resolveStream(response, reference, type, {
-    enqueueModel: function (json) {
-      if (null === previousBlockedChunk) {
-        var chunk = createResolvedModelChunk(response, json, -1);
-        initializeModelChunk(chunk);
-        "fulfilled" === chunk.status
-          ? controller.enqueue(chunk.value)
-          : (chunk.then(
-              function (v) {
-                return controller.enqueue(v);
-              },
-              function (e) {
-                return controller.error(e);
-              }
-            ),
-            (previousBlockedChunk = chunk));
-      } else {
-        chunk = previousBlockedChunk;
-        var chunk$31 = new ReactPromise("pending", null, null);
-        chunk$31.then(
-          function (v) {
-            return controller.enqueue(v);
-          },
-          function (e) {
-            return controller.error(e);
-          }
-        );
-        previousBlockedChunk = chunk$31;
-        chunk.then(function () {
-          previousBlockedChunk === chunk$31 && (previousBlockedChunk = null);
-          resolveModelChunk(response, chunk$31, json, -1);
-        });
+    closed = !1,
+    stream = new ReadableStream({
+      type: type,
+      start: function (c) {
+        controller = c;
       }
-    },
-    close: function () {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk)) controller.close();
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.close();
+    }),
+    previousBlockedChunk = null,
+    flightController = {
+      enqueueModel: function (json) {
+        if (null === previousBlockedChunk) {
+          var chunk = createResolvedModelChunk(response, json, -1);
+          initializeModelChunk(chunk);
+          "fulfilled" === chunk.status
+            ? enqueue(chunk.value)
+            : (chunk.then(enqueue, flightController.error),
+              (previousBlockedChunk = chunk));
+        } else {
+          chunk = previousBlockedChunk;
+          var chunk$32 = new ReactPromise("pending", null, null);
+          chunk$32.then(enqueue, flightController.error);
+          previousBlockedChunk = chunk$32;
+          chunk.then(function () {
+            previousBlockedChunk === chunk$32 && (previousBlockedChunk = null);
+            resolveModelChunk(response, chunk$32, json, -1);
           });
         }
-    },
-    error: function (error) {
-      if (!closed)
-        if (((closed = !0), null === previousBlockedChunk))
-          controller.error(error);
-        else {
-          var blockedChunk = previousBlockedChunk;
-          previousBlockedChunk = null;
-          blockedChunk.then(function () {
-            return controller.error(error);
-          });
-        }
-    }
-  });
-  return type;
+      },
+      close: function () {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.close();
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.close();
+            });
+          }
+      },
+      error: function (error) {
+        if (!closed)
+          if (((closed = !0), null === previousBlockedChunk))
+            controller.error(error);
+          else {
+            var blockedChunk = previousBlockedChunk;
+            previousBlockedChunk = null;
+            blockedChunk.then(function () {
+              return controller.error(error);
+            });
+          }
+      }
+    };
+  resolveStream(response, reference, stream, flightController);
+  return stream;
 }
-function asyncIterator() {
+function FlightIterator(next) {
+  this.next = next;
+}
+FlightIterator.prototype = {};
+FlightIterator.prototype[ASYNC_ITERATOR] = function () {
   return this;
-}
-function createIterator(next) {
-  next = { next: next };
-  next[ASYNC_ITERATOR] = asyncIterator;
-  return next;
-}
+};
 function parseAsyncIterable(response, reference, iterator) {
   reference = parseInt(reference.slice(2), 16);
   if (response._chunks.has(reference))
@@ -2635,7 +2756,7 @@ function parseAsyncIterable(response, reference, iterator) {
   $jscomp$compprop5 =
     (($jscomp$compprop5[ASYNC_ITERATOR] = function () {
       var nextReadIndex = 0;
-      return createIterator(function (arg) {
+      return new FlightIterator(function (arg) {
         if (void 0 !== arg)
           throw Error(
             "Values cannot be passed to next() of AsyncIterables passed to Client Components."
@@ -2715,17 +2836,28 @@ function parseAsyncIterable(response, reference, iterator) {
   });
   return iterator;
 }
-function parseModelString(response, obj, key, value, reference) {
+function parseModelString(response, obj, key, value, reference, arrayRoot) {
   if ("$" === value[0]) {
     switch (value[1]) {
       case "$":
-        return value.slice(1);
+        return (
+          null !== arrayRoot &&
+            bumpArrayCount(arrayRoot, value.length - 1, response),
+          value.slice(1)
+        );
       case "@":
         return (obj = parseInt(value.slice(2), 16)), getChunk(response, obj);
       case "h":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, loadServerReference$1)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(
+            response,
+            arrayRoot,
+            obj,
+            key,
+            null,
+            loadServerReference$1
+          )
         );
       case "T":
         if (void 0 === reference || void 0 === response._temporaryReferences)
@@ -2738,27 +2870,37 @@ function parseModelString(response, obj, key, value, reference) {
         );
       case "Q":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createMap)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createMap)
         );
       case "W":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, createSet)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
         obj = value.slice(2);
-        var formPrefix = response._prefix + obj + "_",
-          data = new FormData();
-        response._formData.forEach(function (entry, entryKey) {
-          entryKey.startsWith(formPrefix) &&
-            data.append(entryKey.slice(formPrefix.length), entry);
-        });
-        return data;
+        obj = response._prefix + obj + "_";
+        key = new FormData();
+        response = response._formData;
+        arrayRoot = Array.from(response.keys());
+        for (value = 0; value < arrayRoot.length; value++)
+          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            for (
+              var entries = response.getAll(reference),
+                newKey = reference.slice(obj.length),
+                j = 0;
+              j < entries.length;
+              j++
+            )
+              key.append(newKey, entries[j]);
+            response.delete(reference);
+          }
+        return key;
       case "i":
         return (
-          (value = value.slice(2)),
-          getOutlinedModel(response, value, obj, key, extractIterator)
+          (arrayRoot = value.slice(2)),
+          getOutlinedModel(response, arrayRoot, obj, key, null, extractIterator)
         );
       case "I":
         return Infinity;
@@ -2771,35 +2913,147 @@ function parseModelString(response, obj, key, value, reference) {
       case "D":
         return new Date(Date.parse(value.slice(2)));
       case "n":
-        return BigInt(value.slice(2));
+        obj = value.slice(2);
+        if (300 < obj.length)
+          throw Error(
+            "BigInt is too large. Received " +
+              obj.length +
+              " digits but the limit is 300."
+          );
+        null !== arrayRoot && bumpArrayCount(arrayRoot, obj.length, response);
+        return BigInt(obj);
     }
     switch (value[1]) {
       case "A":
-        return parseTypedArray(response, value, ArrayBuffer, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          ArrayBuffer,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "O":
-        return parseTypedArray(response, value, Int8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "o":
-        return parseTypedArray(response, value, Uint8Array, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8Array,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "U":
-        return parseTypedArray(response, value, Uint8ClampedArray, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint8ClampedArray,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "S":
-        return parseTypedArray(response, value, Int16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "s":
-        return parseTypedArray(response, value, Uint16Array, 2, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint16Array,
+          2,
+          obj,
+          key,
+          arrayRoot
+        );
       case "L":
-        return parseTypedArray(response, value, Int32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Int32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "l":
-        return parseTypedArray(response, value, Uint32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Uint32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "G":
-        return parseTypedArray(response, value, Float32Array, 4, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float32Array,
+          4,
+          obj,
+          key,
+          arrayRoot
+        );
       case "g":
-        return parseTypedArray(response, value, Float64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          Float64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "M":
-        return parseTypedArray(response, value, BigInt64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigInt64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "m":
-        return parseTypedArray(response, value, BigUint64Array, 8, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          BigUint64Array,
+          8,
+          obj,
+          key,
+          arrayRoot
+        );
       case "V":
-        return parseTypedArray(response, value, DataView, 1, obj, key);
+        return parseTypedArray(
+          response,
+          value,
+          DataView,
+          1,
+          obj,
+          key,
+          arrayRoot
+        );
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
@@ -2817,8 +3071,9 @@ function parseModelString(response, obj, key, value, reference) {
         return parseAsyncIterable(response, value, !0);
     }
     value = value.slice(1);
-    return getOutlinedModel(response, value, obj, key, createModel);
+    return getOutlinedModel(response, value, obj, key, arrayRoot, createModel);
   }
+  null !== arrayRoot && bumpArrayCount(arrayRoot, value.length, response);
   return value;
 }
 function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
@@ -2826,13 +3081,17 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
       3 < arguments.length && void 0 !== arguments[3]
         ? arguments[3]
         : new FormData(),
+    arraySizeLimit =
+      4 < arguments.length && void 0 !== arguments[4] ? arguments[4] : 1e6,
     chunks = new Map();
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
     _formData: backingFormData,
     _chunks: chunks,
-    _temporaryReferences: temporaryReferences
+    _temporaryReferences: temporaryReferences,
+    _rootArrayContexts: new WeakMap(),
+    _arraySizeLimit: arraySizeLimit
   };
 }
 function resolveField(response, key, value) {
@@ -2848,13 +3107,22 @@ function resolveField(response, key, value) {
 function close(response) {
   reportGlobalError(response, Error("Connection closed."));
 }
-function loadServerReference(bundlerConfig, id, bound) {
+function loadServerReference(bundlerConfig, metaData) {
+  var id = metaData.id;
+  if ("string" !== typeof id) return null;
   var serverReference = resolveServerReference(bundlerConfig, id);
   bundlerConfig = preloadModule(serverReference);
-  return bound
-    ? Promise.all([bound, bundlerConfig]).then(function (_ref) {
+  metaData = metaData.bound;
+  return null !== metaData
+    ? Promise.all([metaData, bundlerConfig]).then(function (_ref) {
         _ref = _ref[0];
         var fn = requireModule(serverReference);
+        if (1e3 < _ref.length)
+          throw Error(
+            "Server Function has too many bound arguments. Received " +
+              _ref.length +
+              " but the limit is 1000."
+          );
         return fn.bind.apply(fn, [null].concat(_ref));
       })
     : bundlerConfig
@@ -2863,8 +3131,19 @@ function loadServerReference(bundlerConfig, id, bound) {
         })
       : Promise.resolve(requireModule(serverReference));
 }
-function decodeBoundActionMetaData(body, serverManifest, formFieldPrefix) {
-  body = createResponse(serverManifest, formFieldPrefix, void 0, body);
+function decodeBoundActionMetaData(
+  body,
+  serverManifest,
+  formFieldPrefix,
+  arraySizeLimit
+) {
+  body = createResponse(
+    serverManifest,
+    formFieldPrefix,
+    void 0,
+    body,
+    arraySizeLimit
+  );
   close(body);
   body = getChunk(body, 0);
   body.then(function () {});
@@ -2891,16 +3170,24 @@ exports.createTemporaryReferenceSet = function () {
 };
 exports.decodeAction = function (body, serverManifest) {
   var formData = new FormData(),
-    action = null;
+    action = null,
+    seenActions = new Set();
   body.forEach(function (value, key) {
     key.startsWith("$ACTION_")
       ? key.startsWith("$ACTION_REF_")
-        ? ((value = "$ACTION_" + key.slice(12) + ":"),
+        ? seenActions.has(key) ||
+          (seenActions.add(key),
+          (value = "$ACTION_" + key.slice(12) + ":"),
           (value = decodeBoundActionMetaData(body, serverManifest, value)),
-          (action = loadServerReference(serverManifest, value.id, value.bound)))
+          (action = loadServerReference(serverManifest, value)))
         : key.startsWith("$ACTION_ID_") &&
-          ((value = key.slice(11)),
-          (action = loadServerReference(serverManifest, value, null)))
+          !seenActions.has(key) &&
+          (seenActions.add(key),
+          (value = key.slice(11)),
+          (action = loadServerReference(serverManifest, {
+            id: value,
+            bound: null
+          })))
       : formData.append(key, value);
   });
   return null === action
@@ -2936,7 +3223,8 @@ exports.decodeReply = function (body, webpackMap, options) {
     webpackMap,
     "",
     options ? options.temporaryReferences : void 0,
-    body
+    body,
+    options ? options.arraySizeLimit : void 0
   );
   webpackMap = getChunk(body, 0);
   close(body);
@@ -2946,7 +3234,9 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
   var response = createResponse(
       webpackMap,
       "",
-      options ? options.temporaryReferences : void 0
+      options ? options.temporaryReferences : void 0,
+      void 0,
+      options ? options.arraySizeLimit : void 0
     ),
     pendingFiles = 0,
     queuedFields = [];
@@ -2970,13 +3260,13 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
       );
     else {
       pendingFiles++;
-      var JSCompiler_object_inline_chunks_233 = [];
+      var JSCompiler_object_inline_chunks_229 = [];
       value.on("data", function (chunk) {
-        JSCompiler_object_inline_chunks_233.push(chunk);
+        JSCompiler_object_inline_chunks_229.push(chunk);
       });
       value.on("end", function () {
         try {
-          var blob = new Blob(JSCompiler_object_inline_chunks_233, {
+          var blob = new Blob(JSCompiler_object_inline_chunks_229, {
             type: mimeType
           });
           response._formData.append(name, blob, filename);

--- a/src/react-server-dom-webpack/package.json
+++ b/src/react-server-dom-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-server-dom-webpack",
   "description": "React Server Components bindings for DOM using Webpack. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly.",
-  "version": "19.0.3",
+  "version": "19.0.4",
   "keywords": [
     "react"
   ],
@@ -99,8 +99,8 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^19.0.3",
-    "react-dom": "^19.0.3",
+    "react": "^19.0.4",
+    "react-dom": "^19.0.4",
     "webpack": "^5.59.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- update package metadata to react-on-rails-rsc 19.0.5-rc.5
- refresh vendored react-server-dom-webpack runtime to React 19.0.4
- align peer dependencies to React 19.0.4
- keep blocked FOUC/CSS wrapper patch out of this candidate and preserve bound server action decoding for React thenables

## Verification
- yarn build
- yarn jest tests/webpack-plugin-runtime-detection.test.ts tests/react-flight-webpack-plugin-css-order.test.ts tests/react-flight-webpack-plugin-client-reference-chunks.test.ts tests/rspack-compat/webpack-loader.rspack.test.ts
- yarn test
- yarn pack --filename /tmp/react-on-rails-rsc-19.0.5-rc.5.tgz
- tarball inspection: root 19.0.5-rc.5, vendored react-server-dom-webpack 19.0.4, reconcilerVersion 19.0.4, no 19.0.3 runtime, no blocked CSS wrapper/global manifest strings
- npm publish /tmp/react-on-rails-rsc-19.0.5-rc.5.tgz --tag rc --dry-run
- autoreview --mode local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Updates security-sensitive RSC wire format and deserialization logic across all vendored runtimes; incorrect integration could affect server actions, streaming payloads, or client reference loading despite being a dependency bump release.
> 
> **Overview**
> Releases **19.0.5-rc.5** and bumps **react** / **react-dom** peer dependencies to **^19.0.4**, with changelog noting the prior RC still shipped a **19.0.3** RSC runtime tied to **CVE-2025-55183**, **CVE-2025-55184**, and **CVE-2025-67779**.
> 
> The bulk of the diff refreshes the vendored **react-server-dom-webpack** bundles to **React 19.0.4** (reported **reconcilerVersion** / devtools version strings, and browser devtools **rendererPackageName** set to **react-on-rails-rsc**). Flight client/server code gains **__proto__** guards on serialize and hydrate paths, safer outlined-reference walking (**hasOwnProperty** / invalid reference errors), deduplicated server-function references, and stricter decode limits (nested arrays, BigInt digits, bound server-action args, one-time Map/Set/Iterator init). Server decode/action handling also deduplicates **$ACTION_** entries and threads optional **arraySizeLimit** through **decodeReply** / bound action metadata.
> 
> **react-server-dom-webpack-plugin** now skips webpack **runtime** chunk **.js** files when building client chunk metadata (non-server builds), so manifests do not treat the runtime bundle as a loadable app chunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fe8392ff519cd320f2fb540ce6de87bfd6aa3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package version to 19.0.5-rc.5
  * Updated React peer dependencies to version 19.0.4

* **Security**
  * Patched critical security vulnerabilities in the React runtime bundle (CVE-2025-55183, CVE-2025-55184, CVE-2025-67779)
  * Enhanced prototype pollution protections in serialization and deserialization
  * Strengthened reference validation with improved array nesting limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->