### PR TITLE
Add release publishing workflow

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -1,0 +1,114 @@
+# Update Changelog
+
+You are helping update `CHANGELOG.md` for `react-on-rails-rsc`.
+
+## Arguments
+
+This command accepts an optional argument: `$ARGUMENTS`
+
+- No argument (`/update-changelog`): add user-visible entries to an
+  `[Unreleased]` section or to the current draft release section.
+- Explicit version (`/update-changelog 19.0.5-rc.6`): add entries and stamp or
+  update that exact version section.
+
+This repository does not currently have a rake changelog task. Edit
+`CHANGELOG.md` directly.
+
+## Important Repo Conventions
+
+- Package name: `react-on-rails-rsc`
+- Tags do not use a `v` prefix. Use `19.0.5-rc.6`, not `v19.0.5-rc.6`.
+- Version headers use this format:
+
+  ```markdown
+  ## [19.0.5-rc.6] - 2026-06-04
+  ```
+
+- Compare links also use unprefixed tags:
+
+  ```markdown
+  [19.0.5-rc.6]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.5...19.0.5-rc.6
+  ```
+
+## What To Include
+
+Only add user-visible changes:
+
+- New public exports or package capabilities
+- Bug fixes
+- Behavior changes in RSC rendering, manifests, webpack/rspack plugins, loaders,
+  or package publishing
+- Security fixes
+- Compatibility changes affecting downstream `react_on_rails` or
+  `react-on-rails-pro`
+
+Do not add entries for formatting, lint-only changes, test-only changes, or
+internal refactors unless they directly explain a user-visible fix.
+
+## Section Order
+
+Use these headings, omitting empty sections:
+
+1. `### Added`
+2. `### Changed`
+3. `### Fixed`
+4. `### Security`
+5. `### Removed`
+
+Keep wording concise and focused on observable behavior.
+
+## Process
+
+1. Fetch the latest main branch before comparing:
+
+   ```bash
+   git fetch origin main
+   ```
+
+2. Inspect recent tags and the current changelog:
+
+   ```bash
+   git tag --sort=-v:refname | head -20
+   sed -n '1,220p' CHANGELOG.md
+   ```
+
+3. Find merged PRs or commits since the previous released tag:
+
+   ```bash
+   git log --oneline <previous-tag>..origin/main
+   ```
+
+4. Add or update the version section in `CHANGELOG.md`.
+
+5. Update the compare links at the bottom:
+
+   - `[new-version]` compares `<previous-tag>...<new-version>`
+   - Older links remain below it
+
+6. Verify formatting:
+
+   ```bash
+   sed -n '1,240p' CHANGELOG.md
+   ```
+
+7. For release readiness, run:
+
+   ```bash
+   yarn release:dry-run
+   ```
+
+## rc.6 Example
+
+```markdown
+## [19.0.5-rc.6] - 2026-06-04
+
+### Added
+- Added regression coverage for manifest CSS serialization on rendered client
+  references and component-shaped client-reference export metadata.
+
+### Fixed
+- Fixed rendered client references with manifest CSS to emit request-scoped
+  Flight stylesheet hints while preserving `react.client.reference` metadata.
+
+[19.0.5-rc.6]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.5...19.0.5-rc.6
+```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This package provides internal tooling for React Server Components integration:
 - Webpack loader for bundling server components
 - Client/server utilities for RSC rendering
 
+## Releasing
+
+Release this package from `main` using the changelog-driven workflow in
+[`docs/releasing.md`](docs/releasing.md). Run `yarn release:dry-run` before
+`yarn release`.
+
 ## Support
 
 For questions about React Server Components:

--- a/bin/release
+++ b/bin/release
@@ -1,17 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Usage: ./bin/release [options]
-# 
-# This script runs release-it with provided options to automate the release process.
-# Common options:
-#   major       - Bump major version (1.0.0)
-#   minor       - Bump minor version (0.1.0) 
-#   patch       - Bump patch version (0.0.1)
-#   --dry-run   - Don't make actual changes
-#
-# Examples:
-#   ./bin/release major     # Release major version
-#   ./bin/release 19.0.0    # Release version 19.0.0
-#   ./bin/release --dry-run # Test release process
-
-npx release-it "$@"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+exec "$ROOT_DIR/scripts/release.sh" "$@"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,118 @@
+# Releasing react-on-rails-rsc
+
+This project uses a changelog-driven release workflow. The target version is
+read from `CHANGELOG.md`; do not pass a version to the release script. Update
+the changelog first, merge that change to `main`, then run the release script.
+
+Tags in this repository do not use a `v` prefix. For example, the rc.6 tag is
+`19.0.5-rc.6`, not `v19.0.5-rc.6`.
+
+## Prerequisites
+
+For an actual release:
+
+1. `npm whoami` succeeds for an npm account that can publish `react-on-rails-rsc`.
+2. `gh auth status` succeeds for a GitHub account that can create releases.
+3. The working tree is clean and the current branch is `main`.
+4. `CHANGELOG.md` has a top release header for the version being published.
+
+## Release Process
+
+### 1. Update The Changelog
+
+Use the local Claude Code command:
+
+```text
+/update-changelog
+```
+
+For a release candidate or explicit version, update `CHANGELOG.md` so the first
+release header after the intro is the target version:
+
+```markdown
+## [19.0.5-rc.6] - 2026-06-04
+```
+
+The changelog compare links at the bottom should also use unprefixed tags:
+
+```markdown
+[19.0.5-rc.6]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.5...19.0.5-rc.6
+```
+
+Review and merge the changelog/version PR before publishing.
+
+### 2. Run A Dry Run
+
+From `main`:
+
+```bash
+yarn release:dry-run
+```
+
+The dry run verifies the release version, npm/GitHub auth where available,
+package publish state, tests, build, and `npm pack --dry-run`.
+
+### 3. Publish
+
+```bash
+yarn release
+```
+
+The script will:
+
+1. Read the target version from the first `## [X.Y.Z]` header in `CHANGELOG.md`.
+2. Verify that `package.json` is not ahead of the changelog version.
+3. Stop if the release tag already exists or the npm version is already published.
+4. Publish prereleases such as `19.0.5-rc.6` with the npm `next` dist-tag.
+5. Run `yarn test`, `yarn run build`, and `npm pack --dry-run`.
+6. Run `release-it` to commit any needed version bump, tag, and publish to npm.
+7. Create a GitHub release from the matching `CHANGELOG.md` section.
+
+### 4. Verify
+
+- npm: https://www.npmjs.com/package/react-on-rails-rsc
+- GitHub releases: https://github.com/shakacode/react_on_rails_rsc/releases
+
+For an rc release, confirm npm uses the `next` dist-tag:
+
+```bash
+npm view react-on-rails-rsc dist-tags --json
+```
+
+## Current rc.6 Follow-Up
+
+After `19.0.5-rc.6` is published, update the downstream
+`shakacode/react_on_rails` rollout PR to depend on `react-on-rails-rsc@19.0.5-rc.6`
+directly and remove the temporary `19.0.5-rc.5` patch package entry.
+
+## Troubleshooting
+
+**npm cache is unwritable:**
+
+The release script defaults npm cache to a temp directory. To override:
+
+```bash
+NPM_CONFIG_CACHE=/private/tmp/react-on-rails-rsc-npm-cache yarn release:dry-run
+```
+
+**Version already exists on npm or as a git tag:**
+
+Choose a new version, update `CHANGELOG.md` and `package.json`, then rerun the
+release.
+
+**npm publish failed after a tag was created:**
+
+Delete the local and remote tag, fix the issue, then rerun:
+
+```bash
+git tag -d 19.0.5-rc.6
+git push origin :19.0.5-rc.6
+```
+
+**GitHub release failed after npm publish:**
+
+Create it manually from the changelog notes:
+
+```bash
+gh release create 19.0.5-rc.6 --title "19.0.5-rc.6" --prerelease --notes "..."
+```

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "test:non-rsc": "jest tests --testPathIgnorePatterns=\".*\\.rsc\\.test\\..*\"",
     "build": "rm -rf dist tsconfig.tsbuildinfo && yarn run tsc",
     "prepublishOnly": "yarn run build",
+    "release": "bash scripts/release.sh",
+    "release:dry-run": "bash scripts/release.sh --dry-run",
     "build-if-needed": "test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/RSCReferenceDiscoveryPlugin.js -a -f dist/RSCReferenceDiscoveryPlugin.d.ts -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js || (yarn run build && test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/RSCReferenceDiscoveryPlugin.js -a -f dist/RSCReferenceDiscoveryPlugin.d.ts -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js)",
     "prepack": "yarn run build-if-needed",
     "prepare": "yarn run build-if-needed"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+DRY_RUN=false
+SKIP_TESTS=false
+ALLOW_SAME_VERSION_RELEASE=false
+VERSION_STATUS="unknown"
+NPM_AUTHENTICATED=false
+GITHUB_RELEASE_ARGS=()
+
+# Keep npm usable in sandboxed shells where the default user cache can be
+# unwritable. User-provided cache settings still win.
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-${npm_config_cache:-${TMPDIR:-/tmp}/react-on-rails-rsc-npm-cache}}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release.sh [options]
+
+Changelog-driven release script for react-on-rails-rsc.
+Reads the target version from CHANGELOG.md and publishes to npm.
+
+Options:
+  --dry-run       Run release-it in dry-run mode (no publish, no tag, no push)
+  --skip-tests    Skip test, build, and npm pack checks (not recommended)
+  -h, --help      Show this help message
+
+The release version is always read from CHANGELOG.md. Update CHANGELOG.md
+first, merge that change to main, then run this script from main.
+EOF
+}
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+confirm() {
+  local prompt="$1"
+  echo -en "${BOLD}${prompt} [y/N] ${NC}"
+  read -r answer </dev/tty
+  case "$answer" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --skip-tests) SKIP_TESTS=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+parse_version_from_changelog() {
+  local header
+  header=$(grep -m1 -E '^## \[[0-9]' CHANGELOG.md || true)
+
+  if [[ -z "$header" ]]; then
+    log_error "No release header found in CHANGELOG.md (expected: ## [X.Y.Z] - YYYY-MM-DD)."
+    exit 1
+  fi
+
+  RELEASE_VERSION=$(echo "$header" | sed -E 's/^## \[([^]]+)\].*/\1/')
+  RELEASE_DATE=$(echo "$header" | sed -E 's/.*\] - ([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')
+
+  if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    log_error "CHANGELOG.md release version is not valid semver: ${RELEASE_VERSION}"
+    exit 1
+  fi
+
+  log_info "CHANGELOG version: ${RELEASE_VERSION} (${RELEASE_DATE})"
+}
+
+parse_current_version() {
+  CURRENT_VERSION=$(node -p "require('./package.json').version")
+  PACKAGE_NAME=$(node -p "require('./package.json').name")
+  log_info "package.json version: ${CURRENT_VERSION}"
+  log_info "package name: ${PACKAGE_NAME}"
+}
+
+compare_versions() {
+  node - "$1" "$2" <<'EOF'
+const [currentVersion, releaseVersion] = process.argv.slice(2);
+
+function parse(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split(".") : null,
+  };
+}
+
+function comparePrerelease(a, b) {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+
+  const maxLength = Math.max(a.length, b.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const left = a[index];
+    const right = b[index];
+
+    if (left === undefined) return -1;
+    if (right === undefined) return 1;
+    if (left === right) continue;
+
+    const leftIsNumber = /^\d+$/.test(left);
+    const rightIsNumber = /^\d+$/.test(right);
+
+    if (leftIsNumber && rightIsNumber) {
+      return Number(left) < Number(right) ? -1 : 1;
+    }
+
+    if (leftIsNumber !== rightIsNumber) {
+      return leftIsNumber ? -1 : 1;
+    }
+
+    return left < right ? -1 : 1;
+  }
+
+  return 0;
+}
+
+const current = parse(currentVersion);
+const release = parse(releaseVersion);
+
+if (!current || !release) {
+  console.error(`Invalid semver comparison: ${currentVersion} vs ${releaseVersion}`);
+  process.exit(2);
+}
+
+for (const key of ["major", "minor", "patch"]) {
+  if (current[key] < release[key]) {
+    console.log(-1);
+    process.exit(0);
+  }
+
+  if (current[key] > release[key]) {
+    console.log(1);
+    process.exit(0);
+  }
+}
+
+console.log(comparePrerelease(current.prerelease, release.prerelease));
+EOF
+}
+
+version_tag_exists() {
+  if git rev-parse "$RELEASE_VERSION" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1
+}
+
+version_published_to_npm() {
+  local output
+
+  if output=$(npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json 2>&1); then
+    return 0
+  fi
+
+  if echo "$output" | grep -q 'E404'; then
+    return 1
+  fi
+
+  if echo "$output" | grep -qE 'E401|E403|ENEEDAUTH'; then
+    log_warn "npm auth blocked publish-state lookup; retrying anonymously against the public registry."
+
+    if output=$(NPM_CONFIG_USERCONFIG=/dev/null npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json 2>&1); then
+      return 0
+    fi
+
+    if echo "$output" | grep -q 'E404'; then
+      return 1
+    fi
+  fi
+
+  log_error "Unable to verify npm publish state for ${PACKAGE_NAME}@${RELEASE_VERSION}."
+  echo "$output" >&2
+  exit 1
+}
+
+check_version_state() {
+  local comparison
+  if ! comparison=$(compare_versions "$CURRENT_VERSION" "$RELEASE_VERSION"); then
+    log_error "Unable to compare package.json version ${CURRENT_VERSION} with CHANGELOG.md version ${RELEASE_VERSION}."
+    exit 1
+  fi
+
+  case "$comparison" in
+    0)
+      VERSION_STATUS="already-updated"
+
+      if version_tag_exists || version_published_to_npm; then
+        log_info "No release needed: ${RELEASE_VERSION} is already tagged or published."
+        exit 0
+      fi
+
+      ALLOW_SAME_VERSION_RELEASE=true
+      log_info "Version confirmed: package.json already matches CHANGELOG.md at ${RELEASE_VERSION}."
+      ;;
+    -1)
+      VERSION_STATUS="needs-bump"
+
+      if version_tag_exists || version_published_to_npm; then
+        log_error "Release version ${RELEASE_VERSION} already exists as a tag or published npm version."
+        exit 1
+      fi
+
+      log_info "Version confirmed: release-it will update package.json from ${CURRENT_VERSION} to ${RELEASE_VERSION}."
+      ;;
+    1)
+      VERSION_STATUS="ahead-of-changelog"
+      log_error "package.json version ${CURRENT_VERSION} is ahead of CHANGELOG.md version ${RELEASE_VERSION}."
+      log_error "Update CHANGELOG.md to the intended release version or reset package.json before releasing."
+      exit 1
+      ;;
+    *)
+      log_error "Unexpected version comparison result: ${comparison}"
+      exit 1
+      ;;
+  esac
+}
+
+detect_npm_tag() {
+  if [[ "$RELEASE_VERSION" == *-* ]]; then
+    NPM_TAG="next"
+    GITHUB_RELEASE_ARGS+=(--prerelease)
+    log_info "Prerelease detected: npm dist-tag next, GitHub prerelease."
+  else
+    NPM_TAG="latest"
+  fi
+}
+
+preflight_checks() {
+  echo ""
+  log_info "Running pre-flight checks..."
+
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    log_error "Git working tree must be clean. Commit or stash changes first."
+    exit 1
+  fi
+  echo "  - Clean working tree"
+
+  local branch
+  branch=$(git branch --show-current)
+  if [[ "$branch" != "main" ]]; then
+    log_error "Releases must be run from main (current: ${branch})."
+    exit 1
+  fi
+  echo "  - On main branch"
+
+  echo "  - Tag ${RELEASE_VERSION} does not exist"
+
+  local npm_user=""
+  if npm_user=$(npm whoami 2>/dev/null); then
+    NPM_AUTHENTICATED=true
+    echo "  - Logged in to npm as: ${npm_user}"
+  elif [[ "$DRY_RUN" == true ]]; then
+    log_warn "npm auth unavailable; continuing because this is a dry run."
+  else
+    log_error "Not logged in to npm. Run 'npm login' first."
+    exit 1
+  fi
+
+  if gh auth status >/dev/null 2>&1; then
+    echo "  - GitHub CLI authenticated"
+  elif [[ "$DRY_RUN" == true ]]; then
+    log_warn "GitHub CLI auth unavailable; continuing because this is a dry run."
+  else
+    log_error "Not authenticated with GitHub CLI. Run 'gh auth login' first."
+    exit 1
+  fi
+}
+
+run_tests() {
+  if [[ "$SKIP_TESTS" == true ]]; then
+    log_warn "Skipping tests, build, and npm pack checks (--skip-tests)."
+    return
+  fi
+
+  echo ""
+  log_info "Running tests, build, and npm pack dry run..."
+  yarn test
+  yarn run build
+  npm pack --dry-run
+
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    log_error "Tests/build changed tracked files. Commit or revert those changes before releasing."
+    git status --short
+    exit 1
+  fi
+
+  log_info "Tests, build, and npm pack dry run passed."
+}
+
+show_summary_and_confirm() {
+  echo ""
+  echo "============================================================"
+  echo -e "  ${BOLD}Release Summary${NC}"
+  echo "============================================================"
+  echo "  Current version:  ${CURRENT_VERSION}"
+  echo "  Release version:  ${RELEASE_VERSION}"
+  echo "  Version status:   ${VERSION_STATUS}"
+  echo "  npm dist-tag:     ${NPM_TAG}"
+  echo "  Same version:     ${ALLOW_SAME_VERSION_RELEASE}"
+  echo "  Dry run:          ${DRY_RUN}"
+  echo "============================================================"
+  echo ""
+
+  if [[ "$DRY_RUN" == true ]]; then
+    log_info "DRY RUN: no changes will be made."
+  else
+    confirm "Proceed with release ${RELEASE_VERSION}?"
+  fi
+}
+
+do_release() {
+  echo ""
+  log_info "Running release-it..."
+
+  local -a args=(
+    "${RELEASE_VERSION}"
+    "--npm.publish"
+    "--npm.tag=${NPM_TAG}"
+    "--no-github.release"
+    "--git.tagName=\${version}"
+    "--git.commitMessage=Release \${version}"
+    "--git.tagAnnotation=Release \${version}"
+  )
+
+  if [[ "$ALLOW_SAME_VERSION_RELEASE" == true ]]; then
+    args+=("--npm.skipChecks" "--npm.ignoreVersion" "--npm.allowSameVersion")
+  elif [[ "$DRY_RUN" == true && "$NPM_AUTHENTICATED" != true ]]; then
+    args+=("--npm.skipChecks")
+  fi
+
+  if [[ "$DRY_RUN" == true ]]; then
+    args+=("--dry-run" "--verbose" "--ci")
+  fi
+
+  echo "  npx release-it ${args[*]}"
+  npx release-it "${args[@]}"
+}
+
+extract_changelog_section() {
+  awk '
+    /^## \['"${RELEASE_VERSION}"'\]/ { found=1; next }
+    /^## \[/ { if (found) exit }
+    found && /^\[.+\]:/ { next }
+    found { print }
+  ' CHANGELOG.md | awk 'NF{p=1} p' | awk '{ lines[NR]=$0 } END { for (i=NR; i>0; i--) if (lines[i]!="") { last=i; break } for (i=1; i<=last; i++) print lines[i] }'
+}
+
+create_github_release() {
+  if [[ "$DRY_RUN" == true ]]; then
+    log_info "DRY RUN: would create GitHub release ${RELEASE_VERSION}"
+    echo "  Release notes preview:"
+    extract_changelog_section | head -20
+    return
+  fi
+
+  echo ""
+  log_info "Creating GitHub release..."
+
+  local notes
+  notes=$(extract_changelog_section)
+
+  if [[ -z "$notes" ]]; then
+    log_warn "No changelog section found for ${RELEASE_VERSION}. Creating release without notes."
+    gh release create "$RELEASE_VERSION" --title "$RELEASE_VERSION" --notes "" "${GITHUB_RELEASE_ARGS[@]}"
+  else
+    gh release create "$RELEASE_VERSION" --title "$RELEASE_VERSION" --notes "$notes" "${GITHUB_RELEASE_ARGS[@]}"
+  fi
+
+  log_info "GitHub release created: ${RELEASE_VERSION}"
+}
+
+main() {
+  echo ""
+  echo -e "${BOLD}react-on-rails-rsc release${NC}"
+  echo ""
+
+  parse_version_from_changelog
+  parse_current_version
+  check_version_state
+  detect_npm_tag
+  preflight_checks
+  run_tests
+  show_summary_and_confirm
+  do_release
+  create_github_release
+
+  echo ""
+  echo "============================================================"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo -e "  ${GREEN}${BOLD}DRY RUN COMPLETE${NC}"
+  else
+    echo -e "  ${GREEN}${BOLD}RELEASE COMPLETE: ${RELEASE_VERSION}${NC}"
+    echo ""
+    echo "  npm: https://www.npmjs.com/package/react-on-rails-rsc"
+    echo "  GitHub: https://github.com/shakacode/react_on_rails_rsc/releases/tag/${RELEASE_VERSION}"
+  fi
+  echo "============================================================"
+  echo ""
+}
+
+main


### PR DESCRIPTION
## Summary
- add a changelog-driven release script adapted from pack-config-diff for react-on-rails-rsc
- add release docs and a local /update-changelog command tailored to this repo's unprefixed tag convention
- wire yarn release and yarn release:dry-run through the new script

## Verification
- bash -n scripts/release.sh
- shellcheck scripts/release.sh
- git diff --check origin/main...HEAD
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"
- yarn release:dry-run --help
- yarn test
- yarn run build
- NPM_CONFIG_CACHE=/private/tmp/react-on-rails-rsc-npm-cache npm pack --dry-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how npm packages are published and tagged; mistakes could ship wrong versions or duplicate releases, though guards and dry-run reduce exposure.
> 
> **Overview**
> Introduces a **changelog-driven** npm/GitHub release path for `react-on-rails-rsc`, replacing ad-hoc `release-it` usage from `bin/release`.
> 
> A new `scripts/release.sh` reads the target version from the top `CHANGELOG.md` header, compares it to `package.json`, blocks duplicate tags/npm versions, runs tests/build/`npm pack --dry-run`, then drives `release-it` (unprefixed git tags, `next` for prereleases) and creates a GitHub release from the matching changelog section. `package.json` adds `yarn release` and `yarn release:dry-run`; `bin/release` delegates to the script.
> 
> **Docs and tooling:** `docs/releasing.md` and README **Releasing** describe the workflow; `.claude/commands/update-changelog.md` documents how to maintain `CHANGELOG.md` (unprefixed tags, compare links, `yarn release:dry-run`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e59f32398e69de1ef26c904f62a8ffe7a936ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->