### PR TITLE
Filter runtime-chunk and hot-update CSS from client manifest

### DIFF
--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
@@ -370,7 +370,12 @@ class ReactFlightWebpackPlugin {
                 try {
                   for (_iterator.s(); !(_step = _iterator.n()).done; ) {
                     const file = _step.value;
-                    if (file.endsWith(".css") && null !== cssPrefix) {
+                    if (
+                      file.endsWith(".css") &&
+                      !file.endsWith(".hot-update.css") &&
+                      null !== cssPrefix &&
+                      (_this.isServer || !runtimeChunkFiles.has(file))
+                    ) {
                       const cssUrl = cssPrefix + file;
                       -1 === cssFiles.indexOf(cssUrl) && cssFiles.push(cssUrl);
                     } else if (

--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -10,18 +10,31 @@ type ClientReference = {
   type?: string;
 };
 
+type ChunkDef = {
+  id: string;
+  files: string[];
+};
+
 const emitManifestMetadata = ({
   files,
   publicPath = '/assets/',
+  isServer = false,
+  chunks: chunkDefs,
+  entrypoints: entrypointDefs,
 }: {
-  files: string[];
+  files?: string[];
   publicPath?: string;
+  isServer?: boolean;
+  chunks?: ChunkDef[];
+  entrypoints?: Array<{ runtimeChunk: ChunkDef }>;
 }) => {
   const clientFile = '/app/components/ClientComponent.js';
   // The plugin matches this specific runtime resource to inject client-reference dependency blocks.
-  const runtimeFile = require.resolve('../src/react-server-dom-webpack/client.browser.js');
+  const runtimeFile = require.resolve(
+    isServer ? '../src/react-server-dom-webpack/client.node.js' : '../src/react-server-dom-webpack/client.browser.js',
+  );
   const plugin = new ReactFlightWebpackPlugin({
-    isServer: false,
+    isServer,
     clientReferences: [clientFile],
   });
 
@@ -111,13 +124,23 @@ const emitManifestMetadata = ({
   };
   const emittedAssets = new Map<string, { source(): string | Buffer }>();
   const processAssetCallbacks: Array<() => void> = [];
-  const chunk = {
-    id: 'client-chunk',
-    files: new Set(files),
-  };
+  const resolvedChunks = (chunkDefs ?? [{ id: 'client-chunk', files: files ?? [] }]).map((c) => ({
+    id: c.id,
+    files: new Set(c.files),
+  }));
   const module = {
     resource: clientFile,
   };
+  const entrypoints = new Map<string, { getRuntimeChunk: () => (typeof resolvedChunks)[0] | null }>();
+  if (entrypointDefs) {
+    for (let i = 0; i < entrypointDefs.length; i++) {
+      const runtimeChunkObj = resolvedChunks.find((c) => c.id === entrypointDefs[i]!.runtimeChunk.id) ?? {
+        id: entrypointDefs[i]!.runtimeChunk.id,
+        files: new Set(entrypointDefs[i]!.runtimeChunk.files),
+      };
+      entrypoints.set(`entry-${i}`, { getRuntimeChunk: () => runtimeChunkObj });
+    }
+  }
   const compilation = {
     dependencyFactories: new Map(),
     dependencyTemplates: new Map(),
@@ -125,11 +148,11 @@ const emitManifestMetadata = ({
     outputOptions: {
       publicPath,
     },
-    entrypoints: new Map(),
+    entrypoints,
     chunkGroups: [
       {
         getBlocks: () => clientReferenceBlocks,
-        chunks: [chunk],
+        chunks: resolvedChunks,
       },
     ],
     chunkGraph: {
@@ -158,7 +181,9 @@ const emitManifestMetadata = ({
   expect(processAssetCallbacks).toHaveLength(1);
   processAssetCallbacks[0]!();
 
-  const manifestAsset = emittedAssets.get('react-client-manifest.json');
+  const manifestAsset = emittedAssets.get(
+    isServer ? 'react-server-client-manifest.json' : 'react-client-manifest.json',
+  );
   expect(manifestAsset).toBeDefined();
   const manifestSource = manifestAsset!.source().toString();
   const manifest = JSON.parse(manifestSource);
@@ -250,6 +275,64 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
       id: './ClientComponent.js',
       chunks: ['client-chunk', 'client.js'],
       css: [],
+      name: '*',
+    });
+  });
+
+  it('does not record CSS files from runtime chunks in the client manifest', () => {
+    const runtimeChunk = { id: 'runtime', files: ['runtime.js', 'runtime.css'] };
+    const clientChunk = { id: 'client-chunk', files: ['client.js', 'client.css'] };
+    const metadata = emitManifestMetadata({
+      chunks: [runtimeChunk, clientChunk],
+      entrypoints: [{ runtimeChunk }],
+    });
+
+    expect(metadata).toEqual({
+      id: './ClientComponent.js',
+      chunks: ['client-chunk', 'client.js'],
+      css: ['/assets/client.css'],
+      name: '*',
+    });
+  });
+
+  it('still records all CSS files from a non-runtime chunk', () => {
+    const metadata = emitManifestMetadata({
+      chunks: [{ id: 'client-chunk', files: ['a.css', 'b.css', 'client.js'] }],
+    });
+
+    expect(metadata).toEqual({
+      id: './ClientComponent.js',
+      chunks: ['client-chunk', 'client.js'],
+      css: ['/assets/a.css', '/assets/b.css'],
+      name: '*',
+    });
+  });
+
+  it('still records runtime-owned CSS on the server manifest', () => {
+    const runtimeChunk = { id: 'runtime', files: ['runtime.js', 'runtime.css'] };
+    const metadata = emitManifestMetadata({
+      isServer: true,
+      chunks: [runtimeChunk],
+      entrypoints: [{ runtimeChunk }],
+    });
+
+    expect(metadata).toEqual({
+      id: './ClientComponent.js',
+      chunks: ['runtime', 'runtime.js'],
+      css: ['/assets/runtime.css'],
+      name: '*',
+    });
+  });
+
+  it('does not record hot-update CSS files', () => {
+    const metadata = emitManifestMetadata({
+      chunks: [{ id: 'client-chunk', files: ['client.hot-update.css', 'client.css', 'client.js'] }],
+    });
+
+    expect(metadata).toEqual({
+      id: './ClientComponent.js',
+      chunks: ['client-chunk', 'client.js'],
+      css: ['/assets/client.css'],
       name: '*',
     });
   });


### PR DESCRIPTION
## Summary

- Add runtime-chunk CSS filter to the CSS collection branch of the manifest builder, matching the existing JS branch behavior
- Skip `*.hot-update.css` files from manifest CSS entries (matching the existing `.hot-update.js`/`.hot-update.mjs` filters on the JS side)
- Server manifest (`isServer`) bypasses the runtime-chunk filter since it needs full CSS coverage for SSR

Fixes the asymmetry where the JS branch already filtered `runtimeChunkFiles` but the CSS branch did not, causing runtime-chunk CSS to leak into every client component's manifest entry.

## What changed

**`src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js`**
- CSS collection now checks `!runtimeChunkFiles.has(file)` (client only) and `!file.endsWith(".hot-update.css")`

**`tests/react-flight-webpack-plugin-css-order.test.ts`**
- Extended `emitManifestMetadata` helper to support multi-chunk layouts with `chunks`, `entrypoints`, and `isServer` parameters
- Added 4 new test cases:
  - Runtime-chunk CSS excluded from client manifest
  - Non-runtime chunk CSS still fully recorded
  - Server manifest retains runtime-chunk CSS
  - Hot-update CSS files excluded

## Impact on marketplace demo

Measured with Playwright (cache disabled): **zero download difference**. The demo has only 1 shared CSS file (2.2 KB `markdown-libs.css`), no runtime-chunk CSS, and CSS is loaded via HTML `<link>` tags — none of the conditions that trigger the bug. The fix is a correctness improvement for projects with runtime-chunk CSS and active Flight `$S` hints.

## Test plan

- [x] All 11 CSS order tests pass (4 new)
- [x] Full test suite: 131/131 tests pass (3 pre-existing suite-level RSC env failures unchanged)
- [x] `yarn build` succeeds
- [x] Marketplace demo verified: identical manifest + identical browser downloads

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS asset filtering in webpack processing to properly distinguish between server and client builds, excluding runtime chunk CSS from client manifests and hot-update CSS files.

* **Tests**
  * Expanded test coverage for CSS asset handling across different build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->