### PR TITLE
Add release artifact verification gate

### DIFF
--- a/.github/workflows/artifact-checks.yml
+++ b/.github/workflows/artifact-checks.yml
@@ -14,11 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      # Pinned immutable actions/checkout release SHA verified via git ls-remote.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        # Pinned immutable actions/setup-node release SHA verified via git ls-remote.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20.x'
+          cache: yarn
       - name: Install packages using yarn
         run: yarn --frozen-lockfile
       - name: Verify package artifacts

--- a/.github/workflows/artifact-checks.yml
+++ b/.github/workflows/artifact-checks.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           node-version: '20.x'
       - name: Install packages using yarn
-        run: yarn
+        run: yarn --frozen-lockfile
       - name: Verify package artifacts
         run: yarn verify:artifacts

--- a/.github/workflows/artifact-checks.yml
+++ b/.github/workflows/artifact-checks.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   verify-artifacts:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js

--- a/.github/workflows/artifact-checks.yml
+++ b/.github/workflows/artifact-checks.yml
@@ -1,0 +1,24 @@
+name: Verify package artifacts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install packages using yarn
+        run: yarn
+      - name: Verify package artifacts
+        run: yarn verify:artifacts

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:rsc": "NODE_CONDITIONS=react-server jest tests/*.rsc.test.*",
     "test:non-rsc": "jest tests --testPathIgnorePatterns=\".*\\.rsc\\.test\\..*\"",
     "build": "rm -rf dist tsconfig.tsbuildinfo && yarn run tsc",
+    "verify:artifacts": "bash scripts/verify-release.sh",
     "prepublishOnly": "yarn run build",
     "release": "bash scripts/release.sh",
     "release:dry-run": "bash scripts/release.sh --dry-run",
@@ -86,6 +87,7 @@
     "prepare": "yarn run build-if-needed"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "0.18.3",
     "@rspack/core": "^1.0.0",
     "@tsconfig/node14": "^14.1.2",
     "@types/jest": "^30.0.0",
@@ -94,6 +96,7 @@
     "css-loader": "^7.1.4",
     "jest": "^29.7.0",
     "mini-css-extract-plugin": "^2.10.2",
+    "publint": "0.3.21",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "ts-jest": "^29.4.5",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -290,15 +290,14 @@ preflight_checks() {
 
 run_tests() {
   if [[ "$SKIP_TESTS" == true ]]; then
-    log_warn "Skipping tests, build, and npm pack checks (--skip-tests)."
+    log_warn "Skipping tests and artifact verification (--skip-tests)."
     return
   fi
 
   echo ""
-  log_info "Running tests, build, and npm pack dry run..."
+  log_info "Running tests and artifact verification..."
   yarn test
-  yarn run build
-  npm pack --dry-run
+  yarn run verify:artifacts
 
   if ! git diff --quiet || ! git diff --cached --quiet; then
     log_error "Tests/build changed tracked files. Commit or revert those changes before releasing."
@@ -306,7 +305,7 @@ run_tests() {
     exit 1
   fi
 
-  log_info "Tests, build, and npm pack dry run passed."
+  log_info "Tests and artifact verification passed."
 }
 
 show_summary_and_confirm() {

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-${npm_config_cache:-${TMPDIR:-/tmp}/react-on-rails-rsc-npm-cache}}"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ror-rsc-artifacts.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+log() {
+  printf '\n[verify-release] %s\n' "$*"
+}
+
+log "Building distributable files"
+yarn run build
+
+log "Packing npm artifact"
+PACK_JSON="$TMP_DIR/npm-pack.json"
+npm pack --json --ignore-scripts --pack-destination "$TMP_DIR" > "$PACK_JSON"
+TARBALL="$(
+  node - "$PACK_JSON" "$TMP_DIR" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const [packJsonPath, packDestination] = process.argv.slice(2);
+const packOutput = JSON.parse(fs.readFileSync(packJsonPath, 'utf8'));
+
+if (!Array.isArray(packOutput) || packOutput.length !== 1 || !packOutput[0].filename) {
+  throw new Error(`Unexpected npm pack output: ${JSON.stringify(packOutput)}`);
+}
+
+console.log(path.resolve(packDestination, packOutput[0].filename));
+NODE
+)"
+test -f "$TARBALL"
+echo "  - Tarball: $TARBALL"
+
+log "Installing packed artifact into a temporary project"
+CONSUMER_DIR="$TMP_DIR/consumer"
+mkdir -p "$CONSUMER_DIR"
+(
+  cd "$CONSUMER_DIR"
+  yarn init -y >/dev/null
+  yarn add --ignore-scripts --silent "$TARBALL"
+)
+
+PACKAGE_DIR="$CONSUMER_DIR/node_modules/react-on-rails-rsc"
+
+cat > "$TMP_DIR/verify-package-targets.cjs" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const packageDir = process.argv[2];
+const packageJsonPath = path.join(packageDir, 'package.json');
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const packageRoot = fs.realpathSync(packageDir);
+
+if (!pkg.exports || typeof pkg.exports !== 'object') {
+  throw new Error('package.json must define an exports map');
+}
+
+const targets = [];
+
+function collectTargets(value, exportPath, conditionPath = []) {
+  if (typeof value === 'string') {
+    targets.push({ exportPath, conditionPath, target: value });
+    return;
+  }
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    for (const [condition, nestedValue] of Object.entries(value)) {
+      collectTargets(nestedValue, exportPath, conditionPath.concat(condition));
+    }
+    return;
+  }
+
+  throw new Error(`Unsupported exports value for ${exportPath}: ${JSON.stringify(value)}`);
+}
+
+for (const [exportPath, value] of Object.entries(pkg.exports)) {
+  collectTargets(value, exportPath);
+}
+
+for (const { exportPath, conditionPath, target } of targets) {
+  if (!target.startsWith('./')) {
+    continue;
+  }
+
+  if (target.includes('*')) {
+    throw new Error(`Wildcard export targets are not supported by this verifier: ${exportPath} -> ${target}`);
+  }
+
+  const resolvedTarget = path.resolve(packageDir, target);
+  if (!fs.existsSync(resolvedTarget)) {
+    const conditionLabel = conditionPath.length ? conditionPath.join('.') : '<root>';
+    throw new Error(`Missing export target: ${exportPath} (${conditionLabel}) -> ${target}`);
+  }
+
+  const realTarget = fs.realpathSync(resolvedTarget);
+  if (!realTarget.startsWith(packageRoot + path.sep) && realTarget !== fs.realpathSync(packageJsonPath)) {
+    throw new Error(`Export target escapes package root: ${exportPath} -> ${target}`);
+  }
+}
+
+const runtimeEntrypoints = Object.keys(pkg.exports).filter((exportPath) => exportPath !== './package.json');
+if (runtimeEntrypoints.length !== 11) {
+  throw new Error(`Expected 11 runtime export paths, found ${runtimeEntrypoints.length}: ${runtimeEntrypoints.join(', ')}`);
+}
+
+console.log(`  - Verified ${targets.length} export target files across ${runtimeEntrypoints.length} runtime paths plus package.json`);
+NODE
+
+cat > "$TMP_DIR/resolve-exports.cjs" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const packageDir = process.argv[2];
+const conditionLabel = process.argv[3] || 'default';
+const pkg = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+const packageName = pkg.name;
+
+for (const exportPath of Object.keys(pkg.exports)) {
+  const specifier = exportPath === '.' ? packageName : `${packageName}/${exportPath.slice(2)}`;
+  const resolved = require.resolve(specifier, { paths: [path.dirname(packageDir)] });
+  console.log(`  - ${conditionLabel} require.resolve ${specifier} -> ${path.relative(packageDir, resolved)}`);
+}
+NODE
+
+IMPORT_RESOLVE_PROBE="$CONSUMER_DIR/import-resolve-exports.mjs"
+cat > "$IMPORT_RESOLVE_PROBE" <<'NODE'
+import fs from 'node:fs';
+import path from 'node:path';
+
+const packageDir = process.argv[2];
+const conditionLabel = process.argv[3] || 'default';
+const pkg = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+const packageName = pkg.name;
+
+for (const exportPath of Object.keys(pkg.exports)) {
+  const specifier = exportPath === '.' ? packageName : `${packageName}/${exportPath.slice(2)}`;
+  const resolved = import.meta.resolve(specifier);
+  console.log(`  - ${conditionLabel} import.meta.resolve ${specifier} -> ${path.relative(packageDir, new URL(resolved).pathname)}`);
+}
+NODE
+
+log "Verifying package exports and resolver conditions"
+node "$TMP_DIR/verify-package-targets.cjs" "$PACKAGE_DIR"
+node "$TMP_DIR/resolve-exports.cjs" "$PACKAGE_DIR" default
+node --conditions=react-server "$TMP_DIR/resolve-exports.cjs" "$PACKAGE_DIR" react-server
+node "$IMPORT_RESOLVE_PROBE" "$PACKAGE_DIR" default
+node --conditions=react-server "$IMPORT_RESOLVE_PROBE" "$PACKAGE_DIR" react-server
+
+cat > "$TMP_DIR/verify-runtime-version.cjs" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const packageDir = process.argv[2];
+const rootPackage = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+const runtimePackagePath = path.join(packageDir, 'dist/react-server-dom-webpack/package.json');
+const runtimePackage = JSON.parse(fs.readFileSync(runtimePackagePath, 'utf8'));
+const runtimeVersion = runtimePackage.version;
+const expectedPeerRange = `^${runtimeVersion}`;
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label} expected ${expected}, got ${actual}`);
+  }
+}
+
+assertEqual(rootPackage.peerDependencies?.react, expectedPeerRange, 'root peerDependencies.react');
+assertEqual(rootPackage.peerDependencies?.['react-dom'], expectedPeerRange, 'root peerDependencies.react-dom');
+assertEqual(runtimePackage.peerDependencies?.react, expectedPeerRange, 'runtime peerDependencies.react');
+assertEqual(runtimePackage.peerDependencies?.['react-dom'], expectedPeerRange, 'runtime peerDependencies.react-dom');
+
+const runtimeDevelopmentBundle = fs.readFileSync(
+  path.join(
+    packageDir,
+    'dist/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js'
+  ),
+  'utf8'
+);
+
+for (const marker of [`version: "${runtimeVersion}"`, `reconcilerVersion: "${runtimeVersion}"`]) {
+  if (!runtimeDevelopmentBundle.includes(marker)) {
+    throw new Error(`Packaged runtime bundle does not contain ${marker}`);
+  }
+}
+
+console.log(`  - Runtime version ${runtimeVersion} matches peer policy ${expectedPeerRange}`);
+NODE
+
+log "Verifying embedded React runtime version policy"
+node "$TMP_DIR/verify-runtime-version.cjs" "$PACKAGE_DIR"
+
+log "Running publint"
+yarn publint run "$TARBALL"
+
+log "Running Are The Types Wrong"
+yarn attw "$TARBALL" \
+  --profile node16 \
+  --ignore-rules cjs-only-exports-default \
+  --format table \
+  --no-emoji \
+  --no-color
+
+log "Artifact verification passed"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -28,7 +28,26 @@ const fs = require('fs');
 const path = require('path');
 
 const [packJsonPath, packDestination] = process.argv.slice(2);
-const packOutput = JSON.parse(fs.readFileSync(packJsonPath, 'utf8'));
+const rawPackOutput = fs.readFileSync(packJsonPath, 'utf8');
+const packOutputLines = rawPackOutput.split(/\r?\n/);
+let packOutput;
+
+for (const [lineIndex, line] of packOutputLines.entries()) {
+  if (!line.trimStart().startsWith('[')) {
+    continue;
+  }
+
+  try {
+    packOutput = JSON.parse(packOutputLines.slice(lineIndex).join('\n'));
+    break;
+  } catch {
+    // npm can print lifecycle output before --json output; keep searching.
+  }
+}
+
+if (!packOutput) {
+  throw new Error(`Unable to parse npm pack JSON output: ${rawPackOutput}`);
+}
 
 if (!Array.isArray(packOutput) || packOutput.length !== 1 || !packOutput[0].filename) {
   throw new Error(`Unexpected npm pack output: ${JSON.stringify(packOutput)}`);

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -126,9 +126,32 @@ for (const { exportPath, conditionPath, target } of targets) {
   }
 }
 
-const runtimeEntrypoints = Object.keys(pkg.exports).filter((exportPath) => exportPath !== './package.json');
-if (runtimeEntrypoints.length !== 11) {
-  throw new Error(`Expected 11 runtime export paths, found ${runtimeEntrypoints.length}: ${runtimeEntrypoints.join(', ')}`);
+const expectedRuntimeEntrypoints = [
+  '.',
+  './client',
+  './client.browser',
+  './client.node',
+  './RSCReferenceDiscoveryPlugin',
+  './RspackLoader',
+  './RspackPlugin',
+  './server',
+  './server.node',
+  './WebpackLoader',
+  './WebpackPlugin',
+].sort();
+const runtimeEntrypoints = Object.keys(pkg.exports)
+  .filter((exportPath) => exportPath !== './package.json')
+  .sort();
+
+if (JSON.stringify(runtimeEntrypoints) !== JSON.stringify(expectedRuntimeEntrypoints)) {
+  throw new Error(
+    [
+      'Runtime export paths changed.',
+      `Expected: ${expectedRuntimeEntrypoints.join(', ')}`,
+      `Actual:   ${runtimeEntrypoints.join(', ')}`,
+      'Update the artifact verifier snapshot when the package export surface intentionally changes.',
+    ].join('\n')
+  );
 }
 
 console.log(`  - Verified ${targets.length} export target files across ${runtimeEntrypoints.length} runtime paths plus package.json`);
@@ -217,9 +240,11 @@ log "Verifying embedded React runtime version policy"
 node "$TMP_DIR/verify-runtime-version.cjs" "$PACKAGE_DIR"
 
 log "Running publint"
-yarn publint run "$TARBALL"
+yarn publint "$TARBALL"
 
 log "Running Are The Types Wrong"
+# Keep the Node 16 profile to catch legacy Node resolver regressions; this
+# package still supports consumers on older bundler/runtime stacks.
 yarn attw "$TARBALL" \
   --profile node16 \
   --ignore-rules cjs-only-exports-default \

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -94,7 +94,18 @@ function collectTargets(value, exportPath, conditionPath = []) {
     return;
   }
 
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
+  if (value === null) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectTargets(item, exportPath, conditionPath);
+    }
+    return;
+  }
+
+  if (typeof value === 'object') {
     for (const [condition, nestedValue] of Object.entries(value)) {
       collectTargets(nestedValue, exportPath, conditionPath.concat(condition));
     }
@@ -206,9 +217,21 @@ const fs = require('fs');
 const path = require('path');
 
 const packageDir = process.argv[2];
-const rootPackage = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
 const runtimePackagePath = path.join(packageDir, 'dist/react-server-dom-webpack/package.json');
-const runtimePackage = JSON.parse(fs.readFileSync(runtimePackagePath, 'utf8'));
+
+function readFileSafe(filePath, context) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `verify-runtime-version: cannot read ${filePath} (${context}); has the vendored runtime layout changed?\n` +
+      `  ${error.message}`
+    );
+  }
+}
+
+const rootPackage = JSON.parse(readFileSafe(path.join(packageDir, 'package.json'), 'root package.json'));
+const runtimePackage = JSON.parse(readFileSafe(runtimePackagePath, 'runtime package.json'));
 const runtimeVersion = runtimePackage.version;
 const expectedPeerRange = `^${runtimeVersion}`;
 
@@ -223,12 +246,12 @@ assertEqual(rootPackage.peerDependencies?.['react-dom'], expectedPeerRange, 'roo
 assertEqual(runtimePackage.peerDependencies?.react, expectedPeerRange, 'runtime peerDependencies.react');
 assertEqual(runtimePackage.peerDependencies?.['react-dom'], expectedPeerRange, 'runtime peerDependencies.react-dom');
 
-const runtimeDevelopmentBundle = fs.readFileSync(
+const runtimeDevelopmentBundle = readFileSafe(
   path.join(
     packageDir,
     'dist/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js'
   ),
-  'utf8'
+  'development bundle'
 );
 
 for (const marker of [`version: "${runtimeVersion}"`, `reconcilerVersion: "${runtimeVersion}"`]) {

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -19,12 +19,18 @@ log() {
   printf '\n[verify-release] %s\n' "$*"
 }
 
+NODE_MAJOR="$(node -p "Number(process.versions.node.split('.')[0])")"
+if (( NODE_MAJOR < 20 )); then
+  printf 'verify-release requires Node.js 20 or newer for import.meta.resolve export checks. Found %s.\n' "$(node -p "process.versions.node")" >&2
+  exit 1
+fi
+
 log "Building distributable files"
 yarn run build
 
 log "Packing npm artifact"
 PACK_JSON="$TMP_DIR/npm-pack.json"
-npm pack --json --ignore-scripts --pack-destination "$TMP_DIR" > "$PACK_JSON"
+npm pack --json --pack-destination "$TMP_DIR" > "$PACK_JSON"
 TARBALL="$(
   node - "$PACK_JSON" "$TMP_DIR" <<'NODE'
 const fs = require('fs');
@@ -267,12 +273,12 @@ log "Verifying embedded React runtime version policy"
 node "$TMP_DIR/verify-runtime-version.cjs" "$PACKAGE_DIR"
 
 log "Running publint"
-yarn publint "$TARBALL"
+yarn run publint "$TARBALL"
 
 log "Running Are The Types Wrong"
 # Keep the Node 16 profile to catch legacy Node resolver regressions; this
 # package still supports consumers on older bundler/runtime stacks.
-yarn attw "$TARBALL" \
+yarn run attw "$TARBALL" \
   --profile node16 \
   --ignore-rules cjs-only-exports-default \
   --format table \

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -6,9 +6,12 @@ cd "$ROOT_DIR"
 
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-${npm_config_cache:-${TMPDIR:-/tmp}/react-on-rails-rsc-npm-cache}}"
 
+TMP_DIR=""
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ror-rsc-artifacts.XXXXXX")"
 cleanup() {
-  rm -rf "$TMP_DIR"
+  if [[ -n "${TMP_DIR:-}" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -111,7 +114,8 @@ for (const { exportPath, conditionPath, target } of targets) {
   }
 
   if (target.includes('*')) {
-    throw new Error(`Wildcard export targets are not supported by this verifier: ${exportPath} -> ${target}`);
+    console.warn(`  - Skipping wildcard export target: ${exportPath} -> ${target}`);
+    continue;
   }
 
   const resolvedTarget = path.resolve(packageDir, target);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@andrewbranch/untar.js@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz#ba9494f85eb83017c5c855763969caf1d0adea00"
+  integrity sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==
+
+"@arethetypeswrong/cli@0.18.3":
+  version "0.18.3"
+  resolved "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.3.tgz#c63921709886a0772d3ea75673c61c5b39a5bdfe"
+  integrity sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ==
+  dependencies:
+    "@arethetypeswrong/core" "0.18.3"
+    chalk "^4.1.2"
+    cli-table3 "^0.6.3"
+    commander "^10.0.1"
+    marked "^9.1.2"
+    marked-terminal "^7.1.0"
+    semver "^7.5.4"
+
+"@arethetypeswrong/core@0.18.3":
+  version "0.18.3"
+  resolved "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.3.tgz#9dbf9ae33f4a9ea975533ad3200d98d591bbfbcb"
+  integrity sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==
+  dependencies:
+    "@andrewbranch/untar.js" "^1.0.3"
+    "@loaderkit/resolve" "^1.0.2"
+    cjs-module-lexer "^1.2.3"
+    fflate "^0.8.3"
+    lru-cache "^11.0.1"
+    semver "^7.5.4"
+    typescript "5.6.1-rc"
+    validate-npm-package-name "^5.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -269,6 +301,16 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@braidai/lang@^1.0.0":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz#65bc2bc1db6d00e153b95ac7006f4573e289e9be"
+  integrity sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==
+
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
 "@emnapi/core@^1.5.0":
   version "1.9.2"
@@ -614,6 +656,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@loaderkit/resolve@^1.0.2":
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz#8d45341e688faecc25b3ae919c0f45d94c4e26c9"
+  integrity sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==
+  dependencies:
+    "@braidai/lang" "^1.0.0"
+
 "@module-federation/error-codes@0.22.0":
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/@module-federation/error-codes/-/error-codes-0.22.0.tgz#31ccc990dc240d73912ba7bd001f7e35ac751992"
@@ -665,6 +714,11 @@
     "@emnapi/core" "^1.5.0"
     "@emnapi/runtime" "^1.5.0"
     "@tybys/wasm-util" "^0.10.1"
+
+"@publint/pack@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/@publint/pack/-/pack-0.1.4.tgz#866a82a1a8ab52329ae08baec6f3969ed99a30bf"
+  integrity sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==
 
 "@rspack/binding-darwin-arm64@1.7.11":
   version "1.7.11"
@@ -757,6 +811,11 @@
   version "0.34.41"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.41.tgz#aa51a6c1946df2c5a11494a2cdb9318e026db16c"
   integrity sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==
+
+"@sindresorhus/is@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
 "@sinonjs/commons@^3.0.0":
   version "3.0.1"
@@ -1094,10 +1153,22 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
@@ -1110,6 +1181,11 @@ ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
 anymatch@^3.0.3:
   version "3.1.3"
@@ -1266,6 +1342,11 @@ chalk@^4.0.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.4.1:
+  version "5.6.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -1286,10 +1367,40 @@ ci-info@^4.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.3.1.tgz#355ad571920810b5623e11d40232f443f16f1daa"
   integrity sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==
 
-cjs-module-lexer@^1.0.0:
+cjs-module-lexer@^1.0.0, cjs-module-lexer@^1.2.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
   integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
+
+cli-highlight@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"
+  integrity sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==
+  dependencies:
+    chalk "^4.0.0"
+    highlight.js "^10.7.1"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
+    yargs "^16.0.0"
+
+cli-table3@^0.6.3, cli-table3@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
+  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -1321,6 +1432,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -1425,6 +1541,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emojilib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz#ac518a8bb0d5f76dda57289ccb2fdf9d39ae721e"
+  integrity sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==
+
 enhanced-resolve@^5.17.1:
   version "5.18.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz#728ab082f8b7b6836de51f1637aab5d3b9568faf"
@@ -1432,6 +1553,11 @@ enhanced-resolve@^5.17.1:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -1555,6 +1681,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz#bc27d8eb30343d4d512abb03480202ce65d825fc"
+  integrity sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -1650,6 +1781,11 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+highlight.js@^10.7.1:
+  version "10.7.3"
+  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -2275,6 +2411,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
+lru-cache@^11.0.1:
+  version "11.5.1"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz#f3daa3540847b9737ebc02499ddb36765e54db4a"
+  integrity sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -2300,6 +2441,24 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+marked-terminal@^7.1.0:
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz#7a86236565f3dd530f465ffce9c3f8b62ef270e8"
+  integrity sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    ansi-regex "^6.1.0"
+    chalk "^5.4.1"
+    cli-highlight "^2.1.11"
+    cli-table3 "^0.6.5"
+    node-emoji "^2.2.0"
+    supports-hyperlinks "^3.1.0"
+
+marked@^9.1.2:
+  version "9.1.6"
+  resolved "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz#5d2a3f8180abfbc5d62e3258a38a1c19c0381695"
+  integrity sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -2351,10 +2510,24 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nanoid@^3.3.12:
   version "3.3.12"
@@ -2370,6 +2543,16 @@ neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+node-emoji@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz#1d000e3c76e462577895be1b436f4aa2d6760eb0"
+  integrity sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==
+  dependencies:
+    "@sindresorhus/is" "^4.6.0"
+    char-regex "^1.0.2"
+    emojilib "^2.4.0"
+    skin-tone "^2.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -2392,6 +2575,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-assign@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 once@^1.3.0:
   version "1.4.0"
@@ -2433,6 +2621,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-manager-detector@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
+
 parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -2442,6 +2635,23 @@ parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -2566,6 +2776,16 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+publint@0.3.21:
+  version "0.3.21"
+  resolved "https://registry.npmjs.org/publint/-/publint-0.3.21.tgz#91e1425f638e2128343d5543f77551915d57409a"
+  integrity sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==
+  dependencies:
+    "@publint/pack" "^0.1.4"
+    package-manager-detector "^1.6.0"
+    picocolors "^1.1.1"
+    sade "^1.8.1"
+
 pure-rand@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
@@ -2630,6 +2850,13 @@ resolve@^1.20.0:
     is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+sade@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
 
 safe-buffer@^5.1.0:
   version "5.2.1"
@@ -2704,6 +2931,13 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+skin-tone@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz#4e3933ab45c0d4f4f781745d64b9f4c208e41237"
+  integrity sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==
+  dependencies:
+    unicode-emoji-modifier-base "^1.0.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -2787,7 +3021,7 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2800,6 +3034,14 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
+
+supports-hyperlinks@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz#b8e485b179681dea496a1e7abdf8985bd3145461"
+  integrity sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -2845,6 +3087,20 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -2893,6 +3149,11 @@ type-fest@^4.41.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
+typescript@5.6.1-rc:
+  version "5.6.1-rc"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz#d5e4d7d8170174fed607b74cc32aba3d77018e02"
+  integrity sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==
+
 typescript@^5.4.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
@@ -2907,6 +3168,11 @@ undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+unicode-emoji-modifier-base@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz#dbbd5b54ba30f287e2a8d5a249da6c0cef369459"
+  integrity sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==
 
 update-browserslist-db@^1.1.1:
   version "1.1.2"
@@ -2929,6 +3195,11 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
+
+validate-npm-package-name@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
+  integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
 walker@^1.0.8:
   version "1.0.8"
@@ -3023,10 +3294,28 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.3.1:
   version "17.7.2"


### PR DESCRIPTION
Fixes #61

## Summary
- Adds `yarn verify:artifacts` with a release artifact ladder: build, `npm pack`, temp-project install, export target checks, default/react-server resolver checks, runtime version policy check, publint, and Are The Types Wrong.
- Wires `scripts/release.sh` so release test verification runs the artifact ladder.
- Adds a GitHub Actions artifact check on pull requests and pushes to `main`.

## Tests
- `yarn install --frozen-lockfile`
- `yarn verify:artifacts`
- Mutation check: broken export target failed with `Missing export target`, then reverted
- `yarn build`
- `yarn test`
- `actionlint .github/workflows/artifact-checks.yml .github/workflows/claude-code-review.yml .github/workflows/claude.yml .github/workflows/unit-tests.yml`
- `bash -n scripts/verify-release.sh scripts/release.sh`
- `yarn release:dry-run` exited before verification because `19.0.5-rc.7` is already tagged/published

Coordinator rerun:
- `bash -n scripts/verify-release.sh scripts/release.sh`
- `actionlint .github/workflows/artifact-checks.yml`
- `yarn verify:artifacts`

## Codex Decision Log
- Pinned `publint` and `@arethetypeswrong/cli` as devDependencies for reproducible local/CI checks.
- Kept publint non-strict because strict mode reports existing package-shape warnings outside this issue's release-gate scope.
- Ran ATTW with Node 16 profile and ignored the existing `cjs-only-exports-default` rule so the new gate catches regressions without forcing unrelated API changes.
- Did not edit `unit-tests.yml`.

## Review / Simplify Evidence
- `codex review --uncommitted` was attempted but exceeded closeout time and was terminated; its sandbox could not complete the temp install during `yarn verify:artifacts`.
- `claude` CLI is installed, but no additional Claude/simplify pass was run after coordinator requested stop/status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI/release tooling and devDependencies only; no runtime library behavior or auth/data paths are modified.
> 
> **Overview**
> Adds a **release artifact verification ladder** via `yarn verify:artifacts` (`scripts/verify-release.sh`): build, `npm pack`, install the tarball in a temp project, validate export targets and resolver behavior (default + `react-server`), embedded runtime/React peer version policy, **publint**, and **Are The Types Wrong** (Node 16 profile).
> 
> **Release** and **CI** now run this gate: `scripts/release.sh` replaces separate build/`npm pack --dry-run` with `yarn verify:artifacts`, and a new **Verify package artifacts** workflow on PRs and `main` runs the same check. Dev deps **publint** and **@arethetypeswrong/cli** are pinned for reproducible local/CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb757e3d0082f3e4bd14daf8bac666514adc0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Merge Criteria
- Full `gh pr checks 77` list is green, including `Verify package artifacts`.
- All review threads are resolved or explicitly triaged non-blocking.
- Branch is mergeable into `main` with no conflicts.
- Workflow Change Audit evidence is present for `.github/workflows/artifact-checks.yml`.
- Local artifact ladder evidence includes `yarn verify:artifacts`; mutation-check evidence is documented.
- Preferred to land before #83 and #84 so later CI/release work can rely on `verify:artifacts`.
