### PR TITLE
Prepare 19.0.5-rc.8 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [19.0.5-rc.8] - 2026-06-12
+
+### Fixed
+- Fixed Webpack client manifest generation to bind each client component to the chunk group created by its client-reference dependency, avoiding cross-reference chunk over-preloads while preserving entries for eager-imported client references. ([#54])
+
 ## [19.0.5-rc.7] - 2026-06-09
 
 ### Added
@@ -71,6 +76,7 @@ All notable changes to this package will be documented in this file.
 ### Changed
 - Released the first `19.0.5` release candidate.
 
+[19.0.5-rc.8]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.7...19.0.5-rc.8
 [19.0.5-rc.7]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.6...19.0.5-rc.7
 [19.0.5-rc.6]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.5...19.0.5-rc.6
 [19.0.5-rc.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.4...19.0.5-rc.5
@@ -80,3 +86,4 @@ All notable changes to this package will be documented in this file.
 [19.0.5-rc.1]: https://github.com/shakacode/react_on_rails_rsc/releases/tag/19.0.5-rc.1
 
 [#52]: https://github.com/shakacode/react_on_rails_rsc/pull/52
+[#54]: https://github.com/shakacode/react_on_rails_rsc/pull/54


### PR DESCRIPTION
Links #65

## Summary
- Stamps `CHANGELOG.md` for `19.0.5-rc.8`.
- Sets `package.json` to `19.0.5-rc.8` so the GitHub Actions release workflow version-agreement guard can pass after merge.
- Carries the user-visible rc.8 entries for #54 and #86.

## Classification Sweep (`19.0.5-rc.7..origin/main`)
| PR | Title | Result | Category | Reason |
| --- | --- | --- | --- | --- |
| #54 | Build client manifest from client-reference dependency chunk groups | entry-needed | product code | Changes Webpack client manifest chunk mapping and emitted preload behavior. |
| #74 | Add agent batch/review skill suite ported from react_on_rails | no-entry | internal | Agent workflow docs/skills only. |
| #80 | Docs: Option 5 stock npm runtime go/no-go decision (#55 spike) | no-entry | internal | Documentation/research only. |
| #85 | Add packed-tarball E2E pipeline suite | no-entry | internal | Test/release validation harness only. |
| #87 | Extract and own the webpack RSC plugin as TypeScript source | no-entry | internal | Refactor/source ownership with intended public behavior parity. |
| #88 | Make PR skill workflows discoverable | no-entry | internal | Agent workflow discoverability only. |
| #76 | Harden dependency and Claude automation | no-entry | release-process | Dependabot/review automation and release-it pinning only. |
| #86 | Apply React 19.0.7 RSC reply-decode DoS fixes | entry-needed | product code | Security/runtime update users receive in the package. |
| #77 | Add release artifact verification gate | no-entry | release-process | Release verification tooling and CI only. |
| #95 | Allow artifact verifier to accept covering root peer ranges | no-entry | release-process | Artifact verifier fix only. |
| #75 | Document release dist-tag policy and artifact parity checks | no-entry | release-process | Release docs only. |
| #78 | Add Flight client error path coverage | no-entry | internal | Tests/error-path coverage only. |
| #79 | Document runtime versioning policy and live backlog pointers | no-entry | internal | Documentation only. |
| #83 | Add compatibility matrix and canary signal | no-entry | release-process | CI compatibility signal only. |
| #82 | Add Claude agent setup and workflow skill stubs | no-entry | internal | Agent setup/workflow scaffolding only. |
| #84 | Release from GitHub Actions with trusted publishing | no-entry | release-process | Release automation only. |

No `UNKNOWN` rows.

## Validation
- `yarn install --frozen-lockfile`
- `yarn verify:artifacts` packed and validated `react-on-rails-rsc-19.0.5-rc.8.tgz`.
- `yarn build`
- `yarn test`
- `git diff --check`
- `yarn release:dry-run` read `CHANGELOG.md` and `package.json` as `19.0.5-rc.8`, confirmed prerelease `next`, then exited before mutation because the worker branch is not `main`.

## Current Release State
- npm dist-tags: `latest=19.0.4`, `next=19.0.5-rc.7`, stale `rc=19.0.5-rc.5`.
- npm versions: `19.0.5-rc.8` absent.
- Git tag `19.0.5-rc.8`: absent on origin.
- GitHub release `19.0.5-rc.8`: absent.

## Maintainer-Run Checklist
After this PR is merged to `main`, dispatch the protected Actions release workflow; do not run these from an agent worker branch:

```bash
git checkout main
git pull --ff-only origin main
yarn release:dry-run

gh workflow run release.yml \
  --ref main \
  -f version=19.0.5-rc.8 \
  -f confirm_publish=publish

npm view react-on-rails-rsc dist-tags versions --json
git ls-remote --tags origin 'refs/tags/19.0.5-rc.8' 'refs/tags/19.0.5-rc.8^{}'
gh release view 19.0.5-rc.8 --json tagName,name,isPrerelease,publishedAt,url
```

Final promotion stays gated until rc.8 downstream verification/soak passes and a final `19.0.5` changelog/package PR lands.

## Merge Criteria
- Full `gh pr checks 81` list is green; skipped advisory jobs are acceptable.
- All review threads are resolved or explicitly triaged non-blocking.
- Branch is mergeable into `main` with no conflicts.
- Merge only when maintainers are ready for 19.0.5-rc.8 release motion; actual npm publish, tag push, and GitHub release creation remain maintainer-only through the protected release workflow.
