### PR TITLE
Add compatibility matrix and canary signal

### DIFF
--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -83,11 +83,11 @@ jobs:
         run: node scripts/prepare-compatibility-install.cjs
       - name: Build package artifacts
         env:
-          NODE_OPTIONS: ${{ matrix.node-options }}
+          NODE_OPTIONS: ${{ matrix.node-options || '' }}
         run: yarn build
       - name: Run unit and integration tests
         env:
-          NODE_OPTIONS: ${{ matrix.node-options }}
+          NODE_OPTIONS: ${{ matrix.node-options || '' }}
         run: yarn test
       - name: Record matrix result
         if: always()
@@ -95,7 +95,7 @@ jobs:
           {
             echo "### Test command"
             echo
-            echo "- Command: \`yarn test\`"
+            echo "- Command: \`yarn build && yarn test\`"
             echo "- Result: \`${{ job.status }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -122,6 +122,8 @@ jobs:
           COMPAT_REACT_SERVER_DOM_WEBPACK: canary
           COMPAT_WEBPACK: '^5.0.0'
           COMPAT_RSPACK: 1.x
+          # COMPAT_TYPES_REACT / COMPAT_TYPES_REACT_DOM intentionally omitted:
+          # canary @types packages are not reliably published; stable types remain.
         run: node scripts/prepare-compatibility-install.cjs
       - name: Build package artifacts
         run: yarn build

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -1,0 +1,128 @@
+name: Compatibility matrix
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '23 10 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compatibility-matrix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    if: github.event_name != 'schedule'
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: React 19.0.4 / webpack 5.59.0 + rspack 1.x / Node 20
+            node-version: '20.x'
+            react-version: '19.0.4'
+            react-dom-version: '19.0.4'
+            types-react-version: '19.0.4'
+            types-react-dom-version: '19.0.4'
+            webpack-version: '5.59.0'
+            rspack-version: '1.x'
+            node-options: --openssl-legacy-provider
+          - label: React 19.0.4 / webpack latest 5.x + rspack 1.x / Node 22
+            node-version: '22.x'
+            react-version: '19.0.4'
+            react-dom-version: '19.0.4'
+            types-react-version: '19.0.4'
+            types-react-dom-version: '19.0.4'
+            webpack-version: '^5.0.0'
+            rspack-version: '1.x'
+          - label: React 19.2.x / webpack 5.59.0 + rspack 1.x / Node 22
+            node-version: '22.x'
+            react-version: '~19.2.0'
+            react-dom-version: '~19.2.0'
+            types-react-version: '~19.2.0'
+            types-react-dom-version: '~19.2.0'
+            webpack-version: '5.59.0'
+            rspack-version: '1.x'
+            node-options: --openssl-legacy-provider
+          - label: React 19.2.x / webpack latest 5.x + rspack 1.x / Node 20
+            node-version: '20.x'
+            react-version: '~19.2.0'
+            react-dom-version: '~19.2.0'
+            types-react-version: '~19.2.0'
+            types-react-dom-version: '~19.2.0'
+            webpack-version: '^5.0.0'
+            rspack-version: '1.x'
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install matrix packages without changing yarn.lock
+        env:
+          COMPAT_LABEL: ${{ matrix.label }}
+          COMPAT_REACT: ${{ matrix.react-version }}
+          COMPAT_REACT_DOM: ${{ matrix.react-dom-version }}
+          COMPAT_TYPES_REACT: ${{ matrix.types-react-version }}
+          COMPAT_TYPES_REACT_DOM: ${{ matrix.types-react-dom-version }}
+          COMPAT_WEBPACK: ${{ matrix.webpack-version }}
+          COMPAT_RSPACK: ${{ matrix.rspack-version }}
+        run: node scripts/prepare-compatibility-install.cjs
+      - name: Build package artifacts
+        run: yarn build
+      - name: Run unit and integration tests
+        env:
+          NODE_OPTIONS: ${{ matrix.node-options }}
+        run: yarn test
+      - name: Record matrix result
+        if: always()
+        run: |
+          {
+            echo "### Test command"
+            echo
+            echo "- Command: \`yarn test\`"
+            echo "- Result: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  canary:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: React canary signal
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+      - name: Install canary packages without changing yarn.lock
+        env:
+          COMPAT_LABEL: React canary / webpack latest 5.x / rspack latest 1.x / Node 22
+          COMPAT_REACT: canary
+          COMPAT_REACT_DOM: canary
+          COMPAT_REACT_SERVER_DOM_WEBPACK: canary
+          COMPAT_WEBPACK: ^5.0.0
+          COMPAT_RSPACK: 1.x
+        run: node scripts/prepare-compatibility-install.cjs
+      - name: Build package artifacts
+        run: yarn build
+      - name: Run canary unit and integration tests
+        run: yarn test
+      - name: Record canary result
+        if: always()
+        run: |
+          {
+            echo "### Canary signal"
+            echo
+            echo "- Command: \`yarn test\`"
+            echo "- Result: \`${{ job.status }}\`"
+            echo "- This scheduled canary is signal-only; failures do not block required compatibility checks."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -21,6 +21,7 @@ jobs:
     if: github.event_name != 'schedule'
     name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -61,10 +62,10 @@ jobs:
             rspack-version: '1.x'
 
     steps:
-      # Pinned immutable actions/checkout release SHA verified via git ls-remote.
+      # Pinned immutable actions/checkout@v5 release SHA verified via git ls-remote.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        # Pinned immutable actions/setup-node release SHA verified via git ls-remote.
+        # Pinned immutable actions/setup-node@v4 release SHA verified via git ls-remote.
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
@@ -81,6 +82,8 @@ jobs:
           COMPAT_RSPACK: ${{ matrix.rspack-version }}
         run: node scripts/prepare-compatibility-install.cjs
       - name: Build package artifacts
+        env:
+          NODE_OPTIONS: ${{ matrix.node-options }}
         run: yarn build
       - name: Run unit and integration tests
         env:
@@ -100,12 +103,13 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: React canary signal
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     continue-on-error: true
     steps:
-      # Pinned immutable actions/checkout release SHA verified via git ls-remote.
+      # Pinned immutable actions/checkout@v5 release SHA verified via git ls-remote.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        # Pinned immutable actions/setup-node release SHA verified via git ls-remote.
+        # Pinned immutable actions/setup-node@v4 release SHA verified via git ls-remote.
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22.x'

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -116,7 +116,7 @@ jobs:
           COMPAT_REACT: canary
           COMPAT_REACT_DOM: canary
           COMPAT_REACT_SERVER_DOM_WEBPACK: canary
-          COMPAT_WEBPACK: ^5.0.0
+          COMPAT_WEBPACK: '^5.0.0'
           COMPAT_RSPACK: 1.x
         run: node scripts/prepare-compatibility-install.cjs
       - name: Build package artifacts

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -61,10 +61,10 @@ jobs:
             rspack-version: '1.x'
 
     steps:
-      # actions/checkout@v5
+      # Pinned immutable actions/checkout release SHA verified via git ls-remote.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        # actions/setup-node@v4
+        # Pinned immutable actions/setup-node release SHA verified via git ls-remote.
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
@@ -74,6 +74,7 @@ jobs:
           COMPAT_LABEL: ${{ matrix.label }}
           COMPAT_REACT: ${{ matrix.react-version }}
           COMPAT_REACT_DOM: ${{ matrix.react-dom-version }}
+          COMPAT_REACT_SERVER_DOM_WEBPACK: ${{ matrix.react-version }}
           COMPAT_TYPES_REACT: ${{ matrix.types-react-version }}
           COMPAT_TYPES_REACT_DOM: ${{ matrix.types-react-dom-version }}
           COMPAT_WEBPACK: ${{ matrix.webpack-version }}
@@ -101,10 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      # actions/checkout@v5
+      # Pinned immutable actions/checkout release SHA verified via git ls-remote.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        # actions/setup-node@v4
+        # Pinned immutable actions/setup-node release SHA verified via git ls-remote.
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22.x'

--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -61,11 +61,14 @@ jobs:
             rspack-version: '1.x'
 
     steps:
-      - uses: actions/checkout@v5
+      # actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        # actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Install matrix packages without changing yarn.lock
         env:
           COMPAT_LABEL: ${{ matrix.label }}
@@ -98,11 +101,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      # actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        # actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22.x'
+          cache: yarn
       - name: Install canary packages without changing yarn.lock
         env:
           COMPAT_LABEL: React canary / webpack latest 5.x / rspack latest 1.x / Node 22

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Release this package from `main` using the changelog-driven workflow in
 [`docs/releasing.md`](docs/releasing.md). Run `yarn release:dry-run` before
 `yarn release`.
 
+## Compatibility Policy
+
+The package peer dependencies are the current source of truth for supported
+React and webpack ranges. CI also runs a focused compatibility matrix covering
+React 19.0.4 and 19.2.x, Node.js 20 and 22, webpack 5.59.0 and latest 5.x, and
+rspack latest 1.x. A weekly React canary job is signal-only and is allowed to
+fail while upstream canary APIs move.
+
+A formal versioning policy is tracked in
+[#70](https://github.com/shakacode/react_on_rails_rsc/issues/70); no merged
+`docs/versioning.md` exists in this branch yet.
+
 ## Support
 
 For questions about React Server Components:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ rspack latest 1.x. A weekly React canary job is signal-only and is allowed to
 fail while upstream canary APIs move.
 
 A formal versioning policy is tracked in
-[#70](https://github.com/shakacode/react_on_rails_rsc/issues/70); no merged
-`docs/versioning.md` exists in this branch yet.
+[#70](https://github.com/shakacode/react_on_rails_rsc/issues/70).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The package peer dependencies are the current source of truth for supported
 React and webpack ranges. CI also runs a focused compatibility matrix covering
 React 19.0.4 and 19.2.x, Node.js 20 and 22, webpack 5.59.0 and latest 5.x, and
 rspack latest 1.x. A weekly React canary job is signal-only and is allowed to
-fail while upstream canary APIs move.
+fail while upstream canary APIs move; review its GitHub Actions summary for
+early warnings.
 
 A formal versioning policy is tracked in
 [#70](https://github.com/shakacode/react_on_rails_rsc/issues/70).

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -50,7 +50,7 @@ try {
 
     fs.writeFileSync(packageJsonPath, `${JSON.stringify(nextPackageJson, null, 2)}\n`);
 
-    run('yarn', ['install', '--pure-lockfile', '--non-interactive', '--ignore-scripts'], {
+    run('yarn', ['install', '--pure-lockfile', '--non-interactive'], {
       ...env,
       YARN_CACHE_FOLDER:
         env.YARN_CACHE_FOLDER ||
@@ -136,9 +136,9 @@ function validateRequestedSpecs(specs) {
 }
 
 function assertReactSpec(packageName, spec) {
-  if (isCanarySpec(spec) || spec === '~19.2.0') return;
+  if (isCanarySpec(spec)) return;
 
-  const version = parseVersion(spec);
+  const version = parseVersion(stripSimpleRangePrefix(spec));
   if (version.major !== 19 || (version.minor === 0 && version.patch < 4)) {
     throw new Error(`${packageName}@${spec} is outside the supported React compatibility matrix`);
   }
@@ -147,7 +147,7 @@ function assertReactSpec(packageName, spec) {
 function assertWebpackSpec(spec) {
   if (spec === '^5.0.0') return;
 
-  const version = parseVersion(spec);
+  const version = parseVersion(stripSimpleRangePrefix(spec));
   if (version.major !== 5 || compareVersions(version, { major: 5, minor: 59, patch: 0 }) < 0) {
     throw new Error(`webpack@${spec} is below the supported peer minimum 5.59.0`);
   }
@@ -156,7 +156,7 @@ function assertWebpackSpec(spec) {
 function assertRspackSpec(spec) {
   if (spec === '^1.0.0' || spec === '^1' || spec === '1.x') return;
 
-  const version = parseVersion(spec);
+  const version = parseVersion(stripSimpleRangePrefix(spec));
   if (version.major !== 1) {
     throw new Error(`@rspack/core@${spec} is outside the supported rspack 1.x compatibility matrix`);
   }
@@ -186,6 +186,10 @@ function isCanarySpec(spec) {
   return spec === 'canary' || spec.includes('-canary');
 }
 
+function stripSimpleRangePrefix(spec) {
+  return spec.replace(/^[~^]/, '');
+}
+
 function parseVersion(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
   if (!match) {
@@ -204,21 +208,16 @@ function compareVersions(a, b) {
 }
 
 function assertGitPathClean(relativePath) {
-  const targetPath = path.join(rootDir, relativePath);
-  if (!fs.existsSync(targetPath)) {
-    return;
-  }
-
-  const result = spawnSync('git', ['diff', '--quiet', '--', relativePath], {
+  const result = spawnSync('git', ['status', '--porcelain', '--', relativePath], {
     cwd: rootDir,
-    stdio: 'inherit',
+    stdio: 'pipe',
   });
 
   if (result.error) {
     throw result.error;
   }
 
-  if (result.status !== 0) {
+  if ((result.stdout || '').toString().trim() !== '') {
     throw new Error(`${relativePath} changed during compatibility install`);
   }
 }
@@ -242,7 +241,7 @@ function writeSummary(runLabel, requestedSpecs, installedVersions) {
       '| --- | --- | --- |',
       ...rows,
       '',
-      '- Install mode: `yarn install --pure-lockfile --non-interactive --ignore-scripts`',
+      '- Install mode: `yarn install --pure-lockfile --non-interactive`',
       '- `package.json` was restored after install.',
       '- `git diff -- yarn.lock` remained clean after matrix prep.',
       '',

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -94,11 +94,10 @@ function compactObject(object) {
   );
 }
 
-function run(command, args, childEnv) {
+function run(command, args) {
   console.log(`[compat] Running ${command} ${args.join(' ')}`);
   const result = spawnSync(command, args, {
     cwd: rootDir,
-    env: childEnv,
     stdio: 'inherit',
   });
 
@@ -165,7 +164,7 @@ function assertWebpackSpec(spec) {
 }
 
 function assertRspackSpec(spec) {
-  if (spec === '^1.0.0' || spec === '^1' || spec === '1.x') return;
+  if (spec === '^1' || spec === '1.x') return;
 
   const version = parseVersion(stripSimpleRangePrefix(spec));
   if (version.major !== 1) {

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -61,6 +61,13 @@ try {
   fs.writeFileSync(packageJsonPath, originalPackageJson);
 }
 
+if (skipInstall) {
+  assertGitPathClean('package.json');
+  assertGitPathClean('yarn.lock');
+  console.log(`[compat] ${label}: requested specs validated; skipping install and installed-version checks`);
+  process.exit(0);
+}
+
 const installed = Object.fromEntries(
   Object.entries(packageSpecs).map(([packageName, spec]) => [
     packageName,
@@ -121,7 +128,11 @@ function readInstalledVersion(packageName, spec) {
 
 function validateRequestedSpecs(specs) {
   for (const [packageName, spec] of Object.entries(specs)) {
-    if (packageName === 'react' || packageName === 'react-dom') {
+    if (
+      packageName === 'react' ||
+      packageName === 'react-dom' ||
+      packageName === 'react-server-dom-webpack'
+    ) {
       assertReactSpec(packageName, spec);
     }
 
@@ -164,9 +175,14 @@ function assertRspackSpec(spec) {
 
 function matchesSpec(actualVersion, spec) {
   if (isCanarySpec(spec)) return actualVersion.includes('canary');
-  if (spec === '^5.0.0') return parseVersion(actualVersion).major === 5;
-  if (spec === '^1.0.0' || spec === '^1' || spec === '1.x') {
+  if (spec === '1.x') {
     return parseVersion(actualVersion).major === 1;
+  }
+
+  if (spec.startsWith('^')) {
+    const expected = parseVersion(stripSimpleRangePrefix(spec));
+    const actual = parseVersion(actualVersion);
+    return actual.major === expected.major && compareVersions(actual, expected) >= 0;
   }
 
   if (spec.startsWith('~')) {

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const packageJsonPath = path.join(rootDir, 'package.json');
+
+const originalPackageJson = fs.readFileSync(packageJsonPath, 'utf8');
+const packageJson = JSON.parse(originalPackageJson);
+
+const env = process.env;
+const label = env.COMPAT_LABEL || 'compatibility matrix leg';
+const skipInstall = env.COMPAT_SKIP_INSTALL === '1';
+
+const packageSpecs = compactObject({
+  react: env.COMPAT_REACT,
+  'react-dom': env.COMPAT_REACT_DOM || env.COMPAT_REACT,
+  'react-server-dom-webpack': env.COMPAT_REACT_SERVER_DOM_WEBPACK,
+  webpack: env.COMPAT_WEBPACK,
+  '@rspack/core': env.COMPAT_RSPACK,
+  '@types/react': env.COMPAT_TYPES_REACT,
+  '@types/react-dom': env.COMPAT_TYPES_REACT_DOM,
+});
+
+if (Object.keys(packageSpecs).length === 0) {
+  throw new Error('No compatibility package overrides were provided.');
+}
+
+validateRequestedSpecs(packageSpecs);
+
+try {
+  if (skipInstall) {
+    console.log(`[compat] ${label}: skipping yarn install because COMPAT_SKIP_INSTALL=1`);
+  } else {
+    const nextPackageJson = {
+      ...packageJson,
+      devDependencies: {
+        ...packageJson.devDependencies,
+        ...packageSpecs,
+      },
+      resolutions: {
+        ...(packageJson.resolutions || {}),
+        ...packageSpecs,
+      },
+    };
+
+    fs.writeFileSync(packageJsonPath, `${JSON.stringify(nextPackageJson, null, 2)}\n`);
+
+    run('yarn', ['install', '--pure-lockfile', '--non-interactive', '--ignore-scripts'], {
+      ...env,
+      YARN_CACHE_FOLDER:
+        env.YARN_CACHE_FOLDER ||
+        path.join(env.RUNNER_TEMP || os.tmpdir(), 'react-on-rails-rsc-yarn-compat-cache'),
+    });
+  }
+} finally {
+  fs.writeFileSync(packageJsonPath, originalPackageJson);
+}
+
+const installed = Object.fromEntries(
+  Object.entries(packageSpecs).map(([packageName, spec]) => [
+    packageName,
+    readInstalledVersion(packageName, spec),
+  ])
+);
+
+for (const [packageName, spec] of Object.entries(packageSpecs)) {
+  const actualVersion = installed[packageName];
+  if (!matchesSpec(actualVersion, spec)) {
+    throw new Error(
+      `${packageName} installed ${actualVersion}, which does not satisfy requested compatibility spec ${spec}`
+    );
+  }
+}
+
+assertGitPathClean('package.json');
+assertGitPathClean('yarn.lock');
+writeSummary(label, packageSpecs, installed);
+
+console.log(`[compat] ${label}: installed requested compatibility packages`);
+for (const [packageName, version] of Object.entries(installed)) {
+  console.log(`[compat]   ${packageName}@${version}`);
+}
+console.log('[compat] package.json restored and yarn.lock remained clean');
+
+function compactObject(object) {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => typeof value === 'string' && value.trim() !== '')
+  );
+}
+
+function run(command, args, childEnv) {
+  console.log(`[compat] Running ${command} ${args.join(' ')}`);
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    env: childEnv,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with status ${result.status}`);
+  }
+}
+
+function readInstalledVersion(packageName, spec) {
+  const packageJsonFile = path.join(rootDir, 'node_modules', ...packageName.split('/'), 'package.json');
+  if (!fs.existsSync(packageJsonFile)) {
+    throw new Error(`${packageName}@${spec} was not installed at ${packageJsonFile}`);
+  }
+
+  return JSON.parse(fs.readFileSync(packageJsonFile, 'utf8')).version;
+}
+
+function validateRequestedSpecs(specs) {
+  for (const [packageName, spec] of Object.entries(specs)) {
+    if (packageName === 'react' || packageName === 'react-dom') {
+      assertReactSpec(packageName, spec);
+    }
+
+    if (packageName === 'webpack') {
+      assertWebpackSpec(spec);
+    }
+
+    if (packageName === '@rspack/core') {
+      assertRspackSpec(spec);
+    }
+  }
+}
+
+function assertReactSpec(packageName, spec) {
+  if (isCanarySpec(spec) || spec === '~19.2.0') return;
+
+  const version = parseVersion(spec);
+  if (version.major !== 19 || (version.minor === 0 && version.patch < 4)) {
+    throw new Error(`${packageName}@${spec} is outside the supported React compatibility matrix`);
+  }
+}
+
+function assertWebpackSpec(spec) {
+  if (spec === '^5.0.0') return;
+
+  const version = parseVersion(spec);
+  if (version.major !== 5 || compareVersions(version, { major: 5, minor: 59, patch: 0 }) < 0) {
+    throw new Error(`webpack@${spec} is below the supported peer minimum 5.59.0`);
+  }
+}
+
+function assertRspackSpec(spec) {
+  if (spec === '^1.0.0' || spec === '^1' || spec === '1.x') return;
+
+  const version = parseVersion(spec);
+  if (version.major !== 1) {
+    throw new Error(`@rspack/core@${spec} is outside the supported rspack 1.x compatibility matrix`);
+  }
+}
+
+function matchesSpec(actualVersion, spec) {
+  if (isCanarySpec(spec)) return actualVersion.includes('canary');
+  if (spec === '^5.0.0') return parseVersion(actualVersion).major === 5;
+  if (spec === '^1.0.0' || spec === '^1' || spec === '1.x') {
+    return parseVersion(actualVersion).major === 1;
+  }
+
+  if (spec.startsWith('~')) {
+    const expected = parseVersion(spec.slice(1));
+    const actual = parseVersion(actualVersion);
+    return (
+      actual.major === expected.major &&
+      actual.minor === expected.minor &&
+      compareVersions(actual, expected) >= 0
+    );
+  }
+
+  return actualVersion === spec;
+}
+
+function isCanarySpec(spec) {
+  return spec === 'canary' || spec.includes('-canary');
+}
+
+function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) {
+    throw new Error(`Unsupported version specifier: ${version}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareVersions(a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+function assertGitPathClean(relativePath) {
+  const targetPath = path.join(rootDir, relativePath);
+  if (!fs.existsSync(targetPath)) {
+    return;
+  }
+
+  const result = spawnSync('git', ['diff', '--quiet', '--', relativePath], {
+    cwd: rootDir,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${relativePath} changed during compatibility install`);
+  }
+}
+
+function writeSummary(runLabel, requestedSpecs, installedVersions) {
+  if (!env.GITHUB_STEP_SUMMARY) return;
+
+  const rows = Object.keys(requestedSpecs)
+    .sort()
+    .map(
+      (packageName) =>
+        `| \`${packageName}\` | \`${requestedSpecs[packageName]}\` | \`${installedVersions[packageName]}\` |`
+    );
+
+  fs.appendFileSync(
+    env.GITHUB_STEP_SUMMARY,
+    [
+      `## ${runLabel}`,
+      '',
+      '| Package | Requested | Installed |',
+      '| --- | --- | --- |',
+      ...rows,
+      '',
+      '- Install mode: `yarn install --pure-lockfile --non-interactive --ignore-scripts`',
+      '- `package.json` was restored after install.',
+      '- `git diff -- yarn.lock` remained clean after matrix prep.',
+      '',
+    ].join('\n')
+  );
+}

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -156,7 +156,7 @@ function assertReactSpec(packageName, spec) {
 }
 
 function assertWebpackSpec(spec) {
-  if (spec === '^5.0.0') return;
+  if (spec.startsWith('^')) return;
 
   const version = parseVersion(stripSimpleRangePrefix(spec));
   if (version.major !== 5 || compareVersions(version, { major: 5, minor: 59, patch: 0 }) < 0) {
@@ -182,7 +182,8 @@ function matchesSpec(actualVersion, spec) {
   if (spec.startsWith('^')) {
     const expected = parseVersion(stripSimpleRangePrefix(spec));
     const actual = parseVersion(actualVersion);
-    return actual.major === expected.major && compareVersions(actual, expected) >= 0;
+    const effective = spec === '^5.0.0' ? { major: 5, minor: 59, patch: 0 } : expected;
+    return actual.major === effective.major && compareVersions(actual, effective) >= 0;
   }
 
   if (spec.startsWith('~')) {
@@ -231,6 +232,10 @@ function assertGitPathClean(relativePath) {
 
   if (result.error) {
     throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`git status failed for ${relativePath} (exit ${result.status})`);
   }
 
   if ((result.stdout || '').toString().trim() !== '') {

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -155,8 +155,9 @@ function assertWebpackSpec(spec) {
     if (version.major !== 5) {
       throw new Error(`webpack@${spec} is outside the supported webpack 5.x compatibility matrix`);
     }
-    // Broad 5.x ranges ask yarn for latest webpack 5; installed-version checks
-    // below still enforce the package peer minimum.
+    // Broad 5.x caret ranges (for example, ^5.0.0) cannot be checked against
+    // the 5.59.0 peer minimum until yarn resolves a concrete version.
+    // matchesSpec() enforces the floor after installation.
     return;
   }
 

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -14,6 +14,7 @@ const packageJson = JSON.parse(originalPackageJson);
 const env = process.env;
 const label = env.COMPAT_LABEL || 'compatibility matrix leg';
 const skipInstall = env.COMPAT_SKIP_INSTALL === '1';
+const WEBPACK_PEER_MIN = { major: 5, minor: 59, patch: 0 };
 
 const packageSpecs = compactObject({
   react: env.COMPAT_REACT,
@@ -154,12 +155,16 @@ function assertWebpackSpec(spec) {
     if (version.major !== 5) {
       throw new Error(`webpack@${spec} is outside the supported webpack 5.x compatibility matrix`);
     }
+    // Broad 5.x ranges ask yarn for latest webpack 5; installed-version checks
+    // below still enforce the package peer minimum.
     return;
   }
 
   const version = parseVersion(stripSimpleRangePrefix(spec));
-  if (version.major !== 5 || compareVersions(version, { major: 5, minor: 59, patch: 0 }) < 0) {
-    throw new Error(`webpack@${spec} is below the supported peer minimum 5.59.0`);
+  if (version.major !== 5 || compareVersions(version, WEBPACK_PEER_MIN) < 0) {
+    throw new Error(
+      `webpack@${spec} is below the supported peer minimum ${formatVersion(WEBPACK_PEER_MIN)}`
+    );
   }
 }
 
@@ -174,14 +179,19 @@ function assertRspackSpec(spec) {
 
 function matchesSpec(packageName, actualVersion, spec) {
   if (isCanarySpec(spec)) return actualVersion.includes('canary');
-  if (spec === '1.x') {
+  if (spec === '^1' || spec === '1.x') {
     return parseVersion(actualVersion).major === 1;
   }
 
   if (spec.startsWith('^')) {
     const expected = parseVersion(stripSimpleRangePrefix(spec));
     const actual = parseVersion(actualVersion);
-    const effective = packageName === 'webpack' ? { major: 5, minor: 59, patch: 0 } : expected;
+    // Webpack's peer minimum is 5.59.0; enforce it even when the requested
+    // range is wider, such as ^5.0.0.
+    const effective =
+      packageName === 'webpack' && compareVersions(expected, WEBPACK_PEER_MIN) < 0
+        ? WEBPACK_PEER_MIN
+        : expected;
     return actual.major === effective.major && compareVersions(actual, effective) >= 0;
   }
 
@@ -221,6 +231,10 @@ function parseVersion(version) {
 
 function compareVersions(a, b) {
   return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
 }
 
 function assertGitPathClean(relativePath) {

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -3,7 +3,6 @@
 
 const { spawnSync } = require('child_process');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
 const rootDir = path.resolve(__dirname, '..');
@@ -50,12 +49,7 @@ try {
 
     fs.writeFileSync(packageJsonPath, `${JSON.stringify(nextPackageJson, null, 2)}\n`);
 
-    run('yarn', ['install', '--pure-lockfile', '--non-interactive'], {
-      ...env,
-      YARN_CACHE_FOLDER:
-        env.YARN_CACHE_FOLDER ||
-        path.join(env.RUNNER_TEMP || os.tmpdir(), 'react-on-rails-rsc-yarn-compat-cache'),
-    });
+    run('yarn', ['install', '--pure-lockfile', '--non-interactive']);
   }
 } finally {
   fs.writeFileSync(packageJsonPath, originalPackageJson);
@@ -77,7 +71,7 @@ const installed = Object.fromEntries(
 
 for (const [packageName, spec] of Object.entries(packageSpecs)) {
   const actualVersion = installed[packageName];
-  if (!matchesSpec(actualVersion, spec)) {
+  if (!matchesSpec(packageName, actualVersion, spec)) {
     throw new Error(
       `${packageName} installed ${actualVersion}, which does not satisfy requested compatibility spec ${spec}`
     );
@@ -156,7 +150,13 @@ function assertReactSpec(packageName, spec) {
 }
 
 function assertWebpackSpec(spec) {
-  if (spec.startsWith('^')) return;
+  if (spec.startsWith('^')) {
+    const version = parseVersion(stripSimpleRangePrefix(spec));
+    if (version.major !== 5) {
+      throw new Error(`webpack@${spec} is outside the supported webpack 5.x compatibility matrix`);
+    }
+    return;
+  }
 
   const version = parseVersion(stripSimpleRangePrefix(spec));
   if (version.major !== 5 || compareVersions(version, { major: 5, minor: 59, patch: 0 }) < 0) {
@@ -173,7 +173,7 @@ function assertRspackSpec(spec) {
   }
 }
 
-function matchesSpec(actualVersion, spec) {
+function matchesSpec(packageName, actualVersion, spec) {
   if (isCanarySpec(spec)) return actualVersion.includes('canary');
   if (spec === '1.x') {
     return parseVersion(actualVersion).major === 1;
@@ -182,7 +182,7 @@ function matchesSpec(actualVersion, spec) {
   if (spec.startsWith('^')) {
     const expected = parseVersion(stripSimpleRangePrefix(spec));
     const actual = parseVersion(actualVersion);
-    const effective = spec === '^5.0.0' ? { major: 5, minor: 59, patch: 0 } : expected;
+    const effective = packageName === 'webpack' ? { major: 5, minor: 59, patch: 0 } : expected;
     return actual.major === effective.major && compareVersions(actual, effective) >= 0;
   }
 

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -65,6 +65,9 @@ export class ClientReferenceDependency extends ModuleDependency {
     super(request);
   }
 
+  // webpack 5.59 typings model Dependency.type as a readonly property, while
+  // current webpack exposes the runtime surface as an accessor.
+  // @ts-ignore Keep the accessor shape for current webpack while supporting the peer minimum.
   override get type(): string {
     return 'client-reference';
   }

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -67,7 +67,8 @@ export class ClientReferenceDependency extends ModuleDependency {
 
   // webpack 5.59 typings model Dependency.type as a readonly property, while
   // current webpack exposes the runtime surface as an accessor.
-  // @ts-ignore Keep the accessor shape for current webpack while supporting the peer minimum.
+  // @ts-ignore: @ts-expect-error cannot be used here. The error only appears
+  // against 5.59 typings; current webpack typings accept the accessor override.
   override get type(): string {
     return 'client-reference';
   }


### PR DESCRIPTION
## Summary
- Adds a focused compatibility matrix for React 19.0.4/19.2.x, Node 20/22, webpack min/latest, and rspack 1.x.
- Adds a weekly/manual React canary signal job with `continue-on-error`.
- Installs matrix package versions with a temporary `package.json` overlay, `yarn install --pure-lockfile`, and explicit clean checks for `package.json` and `yarn.lock`.
- Documents the compatibility policy pointer in `README.md`.

Links #62.

## Validation
- `actionlint .github/workflows/compatibility-matrix.yml`
- `COMPAT_LABEL='local React 19.0.4 webpack 5.59.0 smoke' COMPAT_REACT=19.0.4 COMPAT_REACT_DOM=19.0.4 COMPAT_TYPES_REACT=19.0.4 COMPAT_TYPES_REACT_DOM=19.0.4 COMPAT_WEBPACK=5.59.0 COMPAT_RSPACK=1.x node scripts/prepare-compatibility-install.cjs`
- Seeded incompatibility: `COMPAT_LABEL='seeded invalid React 18 guard' COMPAT_REACT=18.3.1 COMPAT_SKIP_INSTALL=1 node scripts/prepare-compatibility-install.cjs` fails with `react@18.3.1 is outside the supported React compatibility matrix`.
- Seeded webpack min evidence: `yarn test` fails on webpack 5.59.0 without `NODE_OPTIONS=--openssl-legacy-provider` due `ERR_OSSL_EVP_UNSUPPORTED`; the min-webpack matrix legs set that option explicitly.
- `NODE_OPTIONS=--openssl-legacy-provider yarn test` against React 19.0.4 / webpack 5.59.0 passed.
- `yarn install --frozen-lockfile`
- `git diff --check`
- `yarn test`

## Release note
Workflow/dependency automation change; maintainer-gated per repo policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI and install automation plus a typings-only webpack plugin tweak; no runtime product behavior or auth/data paths change.
> 
> **Overview**
> Adds **CI coverage** for supported React, Node, webpack, and rspack combinations without committing lockfile changes, and documents that policy in the README.
> 
> A new **Compatibility matrix** workflow runs on PRs and `main` with four matrix legs (React 19.0.4 vs 19.2.x, Node 20 vs 22, webpack pinned at 5.59.0 vs latest 5.x, rspack 1.x). Each leg uses `scripts/prepare-compatibility-install.cjs` to temporarily overlay `devDependencies`/`resolutions`, run `yarn install --pure-lockfile`, restore `package.json`, assert `yarn.lock` stays clean, validate installed versions against the matrix guards, then `yarn build` and `yarn test`. Legs on webpack **5.59.0** set `NODE_OPTIONS=--openssl-legacy-provider` where OpenSSL legacy is required.
> 
> A separate **React canary** job runs weekly or via `workflow_dispatch` with `continue-on-error` so upstream canary breakage is signal-only.
> 
> `RSCWebpackPlugin` gets a small **`@ts-ignore` on `ClientReferenceDependency.type`** so TypeScript accepts both webpack 5.59 typings (readonly `type`) and newer webpack (accessor override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862be14c86fb34ef4b9d4a1f27953f6b3289533a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Merge Criteria
- Full `gh pr checks 83` list is green, including all compatibility matrix legs; scheduled canary is signal-only and may be skipped on PRs.
- All review threads are resolved or explicitly triaged non-blocking.
- Branch is mergeable into `main` with no conflicts.
- Workflow Change Audit evidence is present for `.github/workflows/compatibility-matrix.yml`.
- Seeded incompatibility evidence is documented: invalid React 18 and invalid webpack 4 guards fail locally as expected.
- Prefer landing after #77 so artifact verification and compatibility CI agree on release validation shape.
