### PR TITLE
Add packed-tarball E2E pipeline suite: webpack+rspack → Flight → SSR HTML → hydration

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,18 @@
+name: Run E2E pipeline tests
+on: [pull_request]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install packages using yarn
+        run: yarn
+      # Packs the npm tarball, installs it into a disposable consumer
+      # project, and runs the webpack+rspack -> Flight -> SSR -> hydration
+      # pipeline suite (scripts/e2e/run.sh).
+      - run: yarn test:e2e

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "test": "yarn test:rsc && yarn test:non-rsc",
     "test:rsc": "NODE_CONDITIONS=react-server jest tests/*.rsc.test.*",
     "test:non-rsc": "jest tests --testPathIgnorePatterns=\".*\\.rsc\\.test\\..*\"",
+    "test:e2e": "bash scripts/e2e/run.sh",
     "build": "rm -rf dist tsconfig.tsbuildinfo && yarn run tsc",
     "prepublishOnly": "yarn run build",
     "release": "bash scripts/release.sh",

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -44,8 +44,9 @@ else
   yarn build
 
   echo "==> Packing tarball into $WORK_DIR"
-  npm pack --pack-destination "$WORK_DIR" >/dev/null
-  TARBALL="$(ls "$WORK_DIR"/react-on-rails-rsc-*.tgz | head -1)"
+  # npm pack prints the tarball filename as the last stdout line.
+  TARBALL="$WORK_DIR/$(npm pack --pack-destination "$WORK_DIR" | tail -1)"
+  test -f "$TARBALL"
   echo "    $TARBALL"
 
   echo "==> Creating consumer project at $PROJECT_DIR"

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# E2E pipeline harness: packed tarball -> consumer install -> webpack+rspack
+# builds -> Flight render -> SSR HTML -> jsdom hydration.
+#
+# Callable locally (`yarn test:e2e`), from CI (.github/workflows/e2e-tests.yml),
+# and from agent skills.
+#
+# Conventions (shared pack plumbing — keep in sync with issue #61):
+#   RSC_E2E_WORK_DIR     Base working dir. Default: mktemp -d ror-rsc-e2e.XXXXXX
+#   RSC_E2E_PROJECT_DIR  Consumer project dir (exported to the jest suite).
+#                        Default: $RSC_E2E_WORK_DIR/project
+#   RSC_E2E_BUNDLER      webpack | rspack | both. Default: both
+#   RSC_E2E_KEEP         1 = keep the work dir after the run (debugging)
+#   RSC_E2E_REUSE        1 = reuse an already-installed project (skips
+#                        build + pack + npm install; fixture/scripts are
+#                        re-copied so local edits still apply)
+#   Tarball:             $RSC_E2E_WORK_DIR/react-on-rails-rsc-<version>.tgz
+#                        (npm pack default naming)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+WORK_DIR="${RSC_E2E_WORK_DIR:-}"
+if [[ -z "$WORK_DIR" ]]; then
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ror-rsc-e2e.XXXXXX")"
+fi
+mkdir -p "$WORK_DIR"
+PROJECT_DIR="${RSC_E2E_PROJECT_DIR:-$WORK_DIR/project}"
+
+cleanup() {
+  if [[ "${RSC_E2E_KEEP:-0}" != "1" ]]; then
+    rm -rf "$WORK_DIR"
+  else
+    echo "RSC_E2E_KEEP=1 — keeping work dir: $WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "${RSC_E2E_REUSE:-0}" == "1" && -d "$PROJECT_DIR/node_modules/react-on-rails-rsc" ]]; then
+  echo "==> Reusing installed consumer project at $PROJECT_DIR"
+else
+  echo "==> Building dist/"
+  yarn build
+
+  echo "==> Packing tarball into $WORK_DIR"
+  npm pack --pack-destination "$WORK_DIR" >/dev/null
+  TARBALL="$(ls "$WORK_DIR"/react-on-rails-rsc-*.tgz | head -1)"
+  echo "    $TARBALL"
+
+  echo "==> Creating consumer project at $PROJECT_DIR"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  cat >"$PROJECT_DIR/package.json" <<EOF
+{
+  "name": "ror-rsc-e2e-consumer",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "react-on-rails-rsc": "file:$TARBALL",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "webpack": "^5.98.0",
+    "@rspack/core": "^1.0.0",
+    "css-loader": "^7.1.4",
+    "mini-css-extract-plugin": "^2.10.2",
+    "jsdom": "^26.0.0"
+  }
+}
+EOF
+
+  echo "==> Installing consumer project (npm install of the packed tarball)"
+  (cd "$PROJECT_DIR" && npm install --no-audit --no-fund --loglevel=error)
+fi
+
+echo "==> Copying fixture app + pipeline scripts"
+rm -rf "$PROJECT_DIR/src" "$PROJECT_DIR/scripts" "$PROJECT_DIR/build"
+cp -R "$ROOT/tests/e2e/fixture/src" "$PROJECT_DIR/src"
+cp -R "$ROOT/tests/e2e/fixture/scripts" "$PROJECT_DIR/scripts"
+
+echo "==> Running E2E suite (bundler: ${RSC_E2E_BUNDLER:-both})"
+export RSC_E2E_PROJECT_DIR="$PROJECT_DIR"
+export RSC_E2E_BUNDLER="${RSC_E2E_BUNDLER:-both}"
+yarn jest --config tests/e2e/jest.config.js --runInBand

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -52,6 +52,12 @@ else
   echo "==> Creating consumer project at $PROJECT_DIR"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
+  # Pin the consumer's bundler/react deps to the exact versions the repo's
+  # yarn.lock resolved so the CI job cannot drift when a compatible-range
+  # release of webpack/rspack/react ships (the suite asserts exact chunk
+  # names and current bundler behavior). jsdom is not a repo dependency and
+  # is pinned explicitly.
+  exact_version() { node -p "require('$1/package.json').version"; }
   cat >"$PROJECT_DIR/package.json" <<EOF
 {
   "name": "ror-rsc-e2e-consumer",
@@ -59,13 +65,13 @@ else
   "version": "0.0.0",
   "dependencies": {
     "react-on-rails-rsc": "file:$TARBALL",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
-    "webpack": "^5.98.0",
-    "@rspack/core": "^1.0.0",
-    "css-loader": "^7.1.4",
-    "mini-css-extract-plugin": "^2.10.2",
-    "jsdom": "^26.0.0"
+    "react": "$(exact_version react)",
+    "react-dom": "$(exact_version react-dom)",
+    "webpack": "$(exact_version webpack)",
+    "@rspack/core": "$(exact_version @rspack/core)",
+    "css-loader": "$(exact_version css-loader)",
+    "mini-css-extract-plugin": "$(exact_version mini-css-extract-plugin)",
+    "jsdom": "26.1.0"
   }
 }
 EOF

--- a/tests/e2e/fixture/scripts/build.js
+++ b/tests/e2e/fixture/scripts/build.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Builds the fixture app from the INSTALLED react-on-rails-rsc tarball.
+ *
+ * Usage: node scripts/build.js <webpack|rspack> <client|ssr>
+ *
+ * Resolves the bundler, the RSC plugin, and the Flight runtime entirely
+ * from this consumer project's node_modules so the packed dist/ output and
+ * the package exports map are what gets exercised — not the repo's src/.
+ *
+ * Output: build/<bundler>/<target>/ inside the project.
+ * Stdout: JSON { ok, assets, warnings } or { ok: false, errors }.
+ */
+
+'use strict';
+
+const path = require('path');
+
+const bundlerName = process.argv[2];
+const target = process.argv[3];
+if (!['webpack', 'rspack'].includes(bundlerName) || !['client', 'ssr'].includes(target)) {
+  process.stderr.write('Usage: node scripts/build.js <webpack|rspack> <client|ssr>\n');
+  process.exit(2);
+}
+
+const projectRoot = path.resolve(__dirname, '..');
+const outputPath = path.join(projectRoot, 'build', bundlerName, target);
+const isServer = target === 'ssr';
+
+let runBundler;
+let RSCPlugin;
+let CssExtractPlugin;
+if (bundlerName === 'webpack') {
+  runBundler = require('webpack');
+  RSCPlugin = require('react-on-rails-rsc/WebpackPlugin').RSCWebpackPlugin;
+  CssExtractPlugin = require('mini-css-extract-plugin');
+} else {
+  const { rspack } = require('@rspack/core');
+  runBundler = rspack;
+  RSCPlugin = require('react-on-rails-rsc/RspackPlugin').RSCRspackPlugin;
+  CssExtractPlugin = rspack.CssExtractRspackPlugin;
+}
+
+/**
+ * Seeds fake `.hot-update.css` / `.hot-update.js` files onto a client
+ * chunk so the manifest's hot-update exclusion is exercised by a real
+ * build instead of being vacuously true (one-shot builds never produce
+ * hot updates on their own). webpack-only: rspack's JS API does not allow
+ * mutating `chunk.files`.
+ */
+class SeedHotUpdateAssetsPlugin {
+  apply(compiler) {
+    const { Compilation, sources } = compiler.webpack;
+    compiler.hooks.thisCompilation.tap('SeedHotUpdateAssetsPlugin', (compilation) => {
+      compilation.hooks.processAssets.tap(
+        { name: 'SeedHotUpdateAssetsPlugin', stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL },
+        () => {
+          for (const chunk of compilation.chunks) {
+            if (typeof chunk.name === 'string' && chunk.name.includes('Counter')) {
+              for (const ext of ['css', 'js']) {
+                const file = `seeded.fake.hot-update.${ext}`;
+                compilation.emitAsset(file, new sources.RawSource('/* seeded hot update */'));
+                chunk.files.add(file);
+              }
+            }
+          }
+        },
+      );
+    });
+  }
+}
+
+const plugins = [
+  new RSCPlugin({
+    isServer,
+    chunkName: 'client-[request]',
+    clientReferences: [
+      {
+        directory: path.join(projectRoot, 'src', 'components'),
+        recursive: true,
+        include: /\.js$/,
+      },
+    ],
+  }),
+];
+if (!isServer) {
+  plugins.push(
+    new CssExtractPlugin({ filename: '[name].css', chunkFilename: '[name].chunk.css' }),
+  );
+  if (bundlerName === 'webpack') {
+    plugins.push(new SeedHotUpdateAssetsPlugin());
+  }
+}
+
+const cssRule = isServer
+  ? // The SSR bundle only needs CSS imports to be loadable as modules; the
+    // stylesheet hints come from the CLIENT manifest.
+    { test: /\.css$/, type: 'asset/source' }
+  : { test: /\.css$/, use: [CssExtractPlugin.loader, 'css-loader'] };
+
+const config = {
+  mode: 'development',
+  context: projectRoot,
+  target: isServer ? 'node' : 'web',
+  entry: { main: isServer ? './src/ssr-entry.js' : './src/hydrate-entry.js' },
+  output: {
+    path: outputPath,
+    filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
+    publicPath: isServer ? '' : '/assets/',
+    ...(isServer ? { library: { type: 'commonjs2' } } : {}),
+  },
+  optimization: {
+    chunkIds: 'named',
+    moduleIds: 'named',
+    minimize: false,
+    ...(isServer
+      ? {}
+      : {
+          runtimeChunk: 'single',
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              sharedFormat: {
+                test: /shared[\\/]format\.js$/,
+                name: 'shared-format',
+                minChunks: 2,
+                enforce: true,
+              },
+            },
+          },
+        }),
+  },
+  module: { rules: [cssRule] },
+  devtool: false,
+  plugins,
+};
+
+runBundler(config, (err, stats) => {
+  if (err) {
+    process.stdout.write(JSON.stringify({ ok: false, errors: [String((err && err.stack) || err)] }));
+    process.exit(1);
+  }
+  if (!stats) {
+    process.stdout.write(JSON.stringify({ ok: false, errors: ['no stats returned'] }));
+    process.exit(1);
+  }
+  const info = stats.toJson({ errors: true, warnings: true, assets: true });
+  if (stats.hasErrors()) {
+    process.stdout.write(
+      JSON.stringify({
+        ok: false,
+        errors: (info.errors || []).map((e) => [e.moduleName, e.message].filter(Boolean).join('\n')),
+        warnings: (info.warnings || []).map((w) => w.message),
+      }),
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    JSON.stringify({
+      ok: true,
+      warnings: (info.warnings || []).map((w) => w.message),
+      assets: (info.assets || []).map((a) => a.name),
+    }),
+  );
+});

--- a/tests/e2e/fixture/scripts/hydrate.js
+++ b/tests/e2e/fixture/scripts/hydrate.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Client hydration in jsdom.
+ *
+ * Usage: node scripts/hydrate.js <webpack|rspack>
+ *
+ * Serves the client build over a local HTTP server (publicPath /assets/),
+ * loads a page whose body contains the SSR HTML, executes the real client
+ * bundle (webpack/rspack runtime + async chunk loading via script tags),
+ * hydrates with the captured Flight payload, and clicks the counter.
+ *
+ * Reports JSON with console errors/warnings, recoverable hydration errors,
+ * stylesheet <link>s the Flight runtime preinits into <head>, the devtools
+ * renderer registrations (embedded runtime version check), and the counter
+ * text before/after the click.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const { JSDOM, VirtualConsole } = require('jsdom');
+const { MessageChannel, MessagePort } = require('worker_threads');
+
+const bundlerName = process.argv[2];
+const projectRoot = path.resolve(__dirname, '..');
+const buildDir = path.join(projectRoot, 'build', bundlerName);
+const clientDir = path.join(buildDir, 'client');
+
+const ssrHtml = fs.readFileSync(path.join(buildDir, 'ssr.html'), 'utf8');
+const payload = fs.readFileSync(path.join(buildDir, 'flight-payload.rsc'), 'utf8');
+
+const CONTENT_TYPES = {
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+};
+
+const pageHtml = [
+  '<!doctype html><html><head><meta charset="utf-8"></head><body>',
+  `<div id="root">${ssrHtml}</div>`,
+  '<script src="/assets/runtime.js"></script>',
+  '<script src="/assets/main.js"></script>',
+  '</body></html>',
+].join('');
+
+const fail = (message) => {
+  process.stdout.write(JSON.stringify({ ok: false, error: message }));
+  process.exit(1);
+};
+
+const consoleMessages = [];
+const devtoolsRenderers = [];
+
+const run = async (origin) => {
+  const virtualConsole = new VirtualConsole();
+  for (const level of ['error', 'warn']) {
+    virtualConsole.on(level, (...args) => {
+      consoleMessages.push({ level, message: args.map(String).join(' ') });
+    });
+  }
+  virtualConsole.on('jsdomError', (error) => {
+    consoleMessages.push({ level: 'jsdomError', message: String(error) });
+  });
+
+  const dom = await JSDOM.fromURL(`${origin}/`, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    pretendToBeVisual: true,
+    virtualConsole,
+    beforeParse(window) {
+      // The development Flight/browser runtimes register themselves with
+      // the devtools hook — capture the embedded version strings.
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+        isDisabled: false,
+        supportsFlight: true,
+        supportsFiber: true,
+        renderers: new Map(),
+        inject(internals) {
+          devtoolsRenderers.push({
+            version: internals.version,
+            rendererPackageName: internals.rendererPackageName,
+          });
+          return devtoolsRenderers.length;
+        },
+        checkDCE() {},
+        onCommitFiberRoot() {},
+        onCommitFiberUnmount() {},
+        onPostCommitFiberRoot() {},
+        onScheduleFiberRoot() {},
+        setStrictMode() {},
+      };
+      // Node globals jsdom does not implement but React/Flight need.
+      window.MessageChannel = MessageChannel;
+      window.MessagePort = MessagePort;
+      window.TextEncoder = TextEncoder;
+      window.TextDecoder = TextDecoder;
+      window.ReadableStream = ReadableStream;
+      if (!window.queueMicrotask) window.queueMicrotask = queueMicrotask;
+    },
+  });
+
+  const { window } = dom;
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('page load timed out')), 30_000);
+    window.addEventListener('load', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+
+  if (!window.__E2E__) {
+    throw new Error('client bundle did not expose window.__E2E__ — entry not executed');
+  }
+
+  const { document } = window;
+  const container = document.getElementById('root');
+  await window.__E2E__.hydrate(payload, container);
+
+  const counterValue = () => {
+    const el = document.querySelector('[data-testid="counter-value"]');
+    return el ? el.textContent : null;
+  };
+  const valueBeforeClick = counterValue();
+
+  const button = document.querySelector('[data-testid="counter-button"]');
+  if (!button) throw new Error('counter button not found after hydration');
+  button.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+  // Allow React to flush the update.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const valueAfterClick = counterValue();
+
+  const stylesheetLinks = [...document.querySelectorAll('link[rel="stylesheet"]')].map((link) =>
+    link.getAttribute('href'),
+  );
+  const nestedLabel = document.querySelector('[data-testid="nested-label"]');
+  const serverMessage = document.querySelector('[data-testid="server-message"]');
+
+  window.close();
+
+  return {
+    ok: true,
+    valueBeforeClick,
+    valueAfterClick,
+    nestedLabelText: nestedLabel ? nestedLabel.textContent : null,
+    serverMessageText: serverMessage ? serverMessage.textContent : null,
+    stylesheetLinks,
+    devtoolsRenderers,
+    recoverableErrors: window.__E2E__ ? window.__E2E__.recoverableErrors : null,
+    consoleMessages,
+  };
+};
+
+const server = http.createServer((req, res) => {
+  const urlPath = (req.url || '/').split('?')[0];
+  if (urlPath === '/') {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(pageHtml);
+    return;
+  }
+  if (urlPath.startsWith('/assets/')) {
+    const rel = urlPath.slice('/assets/'.length);
+    const file = path.join(clientDir, rel);
+    // Keep file access inside the client build dir.
+    if (file.startsWith(clientDir + path.sep) && fs.existsSync(file)) {
+      res.writeHead(200, {
+        'content-type': CONTENT_TYPES[path.extname(file)] || 'application/octet-stream',
+      });
+      res.end(fs.readFileSync(file));
+      return;
+    }
+  }
+  res.writeHead(404);
+  res.end('not found');
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address();
+  run(`http://127.0.0.1:${port}`)
+    .then((result) => {
+      process.stdout.write(JSON.stringify(result));
+      server.close();
+      // jsdom timers/resources can keep the loop alive; the result is out.
+      process.exit(0);
+    })
+    .catch((error) => {
+      server.close();
+      fail(String((error && error.stack) || error));
+    });
+});

--- a/tests/e2e/fixture/scripts/render-flight.js
+++ b/tests/e2e/fixture/scripts/render-flight.js
@@ -20,7 +20,9 @@ const { pathToFileURL } = require('url');
 const { PassThrough } = require('stream');
 
 const bundlerName = process.argv[2];
-const projectRoot = path.resolve(__dirname, '..');
+// The bundlers resolve symlinks (e.g. /tmp → /private/tmp on macOS), so the
+// manifest keys use real paths; the registered reference IDs must match.
+const projectRoot = fs.realpathSync(path.resolve(__dirname, '..'));
 const buildDir = path.join(projectRoot, 'build', bundlerName);
 
 // The public wrapper (exports-map entry)…
@@ -53,9 +55,10 @@ const model = createApp({
   ThemeSection: clientReference('ThemeSection.js'),
 });
 
+const errors = [];
 const stream = renderToPipeableStream(model, clientManifest, {
   onError(error) {
-    process.stderr.write(`flight onError: ${String((error && error.stack) || error)}\n`);
+    errors.push(String((error && error.stack) || error));
   },
 });
 
@@ -66,6 +69,9 @@ sink.on('data', (chunk) => {
 });
 sink.on('end', () => {
   fs.writeFileSync(path.join(buildDir, 'flight-payload.rsc'), payload);
-  process.stdout.write(JSON.stringify({ ok: true, payloadLength: payload.length }));
+  process.stdout.write(
+    JSON.stringify({ ok: errors.length === 0, errors, payloadLength: payload.length }),
+  );
+  process.exitCode = errors.length === 0 ? 0 : 1;
 });
 stream.pipe(sink);

--- a/tests/e2e/fixture/scripts/render-flight.js
+++ b/tests/e2e/fixture/scripts/render-flight.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Flight render — MUST run under `--conditions=react-server` (the harness
+ * launches it in a child process; the condition cannot be applied to an
+ * already-running test process).
+ *
+ * Usage: node --conditions=react-server scripts/render-flight.js <webpack|rspack>
+ *
+ * Renders the fixture's server-component tree with the GENERATED client
+ * manifest through the installed package's `server.node` export (this
+ * exercises the exports map under the react-server condition) and writes
+ * the Flight payload to build/<bundler>/flight-payload.rsc.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+const { PassThrough } = require('stream');
+
+const bundlerName = process.argv[2];
+const projectRoot = path.resolve(__dirname, '..');
+const buildDir = path.join(projectRoot, 'build', bundlerName);
+
+// The public wrapper (exports-map entry)…
+const { renderToPipeableStream } = require('react-on-rails-rsc/server.node');
+// …and registerClientReference from the SAME runtime module instance the
+// wrapper uses internally (dist/react-server-dom-webpack/server.node.js);
+// resolving the same file path hits the same require-cache entry.
+const pkgDir = path.dirname(require.resolve('react-on-rails-rsc/package.json'));
+const { registerClientReference } = require(
+  path.join(pkgDir, 'dist', 'react-server-dom-webpack', 'server.node.js'),
+);
+
+const createApp = require('../src/server/App.js');
+
+const clientManifest = JSON.parse(
+  fs.readFileSync(path.join(buildDir, 'client', 'react-client-manifest.json'), 'utf8'),
+);
+
+const clientReference = (file) =>
+  registerClientReference(
+    () => {
+      throw new Error(`client reference ${file} must not execute on the RSC server`);
+    },
+    pathToFileURL(path.join(projectRoot, 'src', 'components', file)).href,
+    'default',
+  );
+
+const model = createApp({
+  Counter: clientReference('Counter.js'),
+  ThemeSection: clientReference('ThemeSection.js'),
+});
+
+const stream = renderToPipeableStream(model, clientManifest, {
+  onError(error) {
+    process.stderr.write(`flight onError: ${String((error && error.stack) || error)}\n`);
+  },
+});
+
+const sink = new PassThrough();
+let payload = '';
+sink.on('data', (chunk) => {
+  payload += chunk;
+});
+sink.on('end', () => {
+  fs.writeFileSync(path.join(buildDir, 'flight-payload.rsc'), payload);
+  process.stdout.write(JSON.stringify({ ok: true, payloadLength: payload.length }));
+});
+stream.pipe(sink);

--- a/tests/e2e/fixture/scripts/render-ssr.js
+++ b/tests/e2e/fixture/scripts/render-ssr.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * SSR render — runs WITHOUT the react-server condition (normal SSR env).
+ *
+ * Usage: node scripts/render-ssr.js <webpack|rspack>
+ *
+ * Loads the SSR bundle (commonjs2 library), decodes the captured Flight
+ * payload with `createFromNodeStream` + the generated client/server
+ * manifests (real chunk loading inside the bundle's own runtime), then
+ * renders the decoded tree to HTML with the react-dom/server instance
+ * bundled alongside the Flight client. Writes build/<bundler>/ssr.html.
+ *
+ * The react-dom render is started BEFORE the payload stream flows so the
+ * Flight client's stylesheet hints are dispatched while the render request
+ * is active.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { PassThrough, Readable } = require('stream');
+
+const bundlerName = process.argv[2];
+const projectRoot = path.resolve(__dirname, '..');
+const buildDir = path.join(projectRoot, 'build', bundlerName);
+
+const ssrBundle = require(path.join(buildDir, 'ssr', 'main.js'));
+const { buildClientRenderer, React, ReactDOMServer } = ssrBundle;
+
+const clientManifest = JSON.parse(
+  fs.readFileSync(path.join(buildDir, 'client', 'react-client-manifest.json'), 'utf8'),
+);
+const serverManifest = JSON.parse(
+  fs.readFileSync(path.join(buildDir, 'ssr', 'react-server-client-manifest.json'), 'utf8'),
+);
+const payload = fs.readFileSync(path.join(buildDir, 'flight-payload.rsc'), 'utf8');
+
+const { createFromNodeStream } = buildClientRenderer(clientManifest, serverManifest);
+const treePromise = createFromNodeStream(Readable.from([Buffer.from(payload, 'utf8')]));
+
+const Root = () => React.use(treePromise);
+
+const errors = [];
+const finish = (ok, html) => {
+  if (html !== undefined) fs.writeFileSync(path.join(buildDir, 'ssr.html'), html);
+  process.stdout.write(JSON.stringify({ ok, errors, htmlLength: html ? html.length : 0 }));
+  process.exit(ok ? 0 : 1);
+};
+
+const stream = ReactDOMServer.renderToPipeableStream(React.createElement(Root), {
+  onError(error) {
+    errors.push(String((error && error.stack) || error));
+  },
+  onShellError(error) {
+    errors.push(`shell: ${String((error && error.stack) || error)}`);
+    finish(false);
+  },
+  onAllReady() {
+    const sink = new PassThrough();
+    let html = '';
+    sink.on('data', (chunk) => {
+      html += chunk;
+    });
+    sink.on('end', () => finish(errors.length === 0, html));
+    stream.pipe(sink);
+  },
+});

--- a/tests/e2e/fixture/src/components/Counter.css
+++ b/tests/e2e/fixture/src/components/Counter.css
@@ -1,0 +1,3 @@
+.counter {
+  color: rgb(20, 80, 20);
+}

--- a/tests/e2e/fixture/src/components/Counter.js
+++ b/tests/e2e/fixture/src/components/Counter.js
@@ -1,0 +1,22 @@
+'use client';
+
+import * as React from 'react';
+import { formatCount } from './shared/format';
+import './Counter.css';
+
+export default function Counter({ label, initial }) {
+  const [count, setCount] = React.useState(initial);
+  return React.createElement(
+    'div',
+    { className: 'counter', 'data-testid': 'counter' },
+    React.createElement(
+      'button',
+      {
+        'data-testid': 'counter-button',
+        onClick: () => setCount((current) => current + 1),
+      },
+      'increment',
+    ),
+    React.createElement('span', { 'data-testid': 'counter-value' }, formatCount(label, count)),
+  );
+}

--- a/tests/e2e/fixture/src/components/NestedLabel.css
+++ b/tests/e2e/fixture/src/components/NestedLabel.css
@@ -1,0 +1,3 @@
+.nested-label {
+  font-style: italic;
+}

--- a/tests/e2e/fixture/src/components/NestedLabel.js
+++ b/tests/e2e/fixture/src/components/NestedLabel.js
@@ -1,0 +1,13 @@
+'use client';
+
+import * as React from 'react';
+import { formatCount } from './shared/format';
+import './NestedLabel.css';
+
+export default function NestedLabel({ theme }) {
+  return React.createElement(
+    'em',
+    { className: 'nested-label', 'data-testid': 'nested-label' },
+    formatCount('theme', theme),
+  );
+}

--- a/tests/e2e/fixture/src/components/ThemeSection.css
+++ b/tests/e2e/fixture/src/components/ThemeSection.css
@@ -1,0 +1,3 @@
+.theme-section {
+  border-color: rgb(10, 10, 120);
+}

--- a/tests/e2e/fixture/src/components/ThemeSection.js
+++ b/tests/e2e/fixture/src/components/ThemeSection.js
@@ -1,0 +1,18 @@
+'use client';
+
+import * as React from 'react';
+import NestedLabel from './NestedLabel';
+import './ThemeSection.css';
+
+// A client component that renders ANOTHER client component — the nested
+// "use client" case. NestedLabel is itself discovered as a client
+// reference, so it appears in the manifest in its own right while also
+// being bundled into this component's chunk group.
+export default function ThemeSection({ theme }) {
+  return React.createElement(
+    'section',
+    { className: 'theme-section', 'data-testid': 'theme-section' },
+    React.createElement('h2', null, 'Theme'),
+    React.createElement(NestedLabel, { theme }),
+  );
+}

--- a/tests/e2e/fixture/src/components/shared/format.js
+++ b/tests/e2e/fixture/src/components/shared/format.js
@@ -1,0 +1,4 @@
+// Plain shared module (no directive). Imported by both Counter and
+// NestedLabel so the client build's splitChunks cacheGroup can force it
+// into a chunk shared by multiple client-reference chunk groups.
+export const formatCount = (label, value) => `${label}: ${value}`;

--- a/tests/e2e/fixture/src/hydrate-entry.js
+++ b/tests/e2e/fixture/src/hydrate-entry.js
@@ -1,0 +1,34 @@
+// Client-bundle entry. Pulls the Flight browser runtime into the bundle
+// (the plugin keys client-reference injection on that runtime module) and
+// exposes a hydrate function the jsdom harness calls with the captured
+// Flight payload.
+import * as React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { createFromReadableStream } from 'react-on-rails-rsc/client';
+import './index';
+
+const recoverableErrors = [];
+
+window.__E2E__ = {
+  recoverableErrors,
+  async hydrate(payloadText, container) {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payloadText));
+        controller.close();
+      },
+    });
+    const tree = await createFromReadableStream(stream);
+    return new Promise((resolve) => {
+      const Root = () => {
+        React.useEffect(() => resolve(root), []);
+        return tree;
+      };
+      const root = hydrateRoot(container, React.createElement(Root), {
+        onRecoverableError: (error) => {
+          recoverableErrors.push(String((error && error.stack) || error));
+        },
+      });
+    });
+  },
+};

--- a/tests/e2e/fixture/src/index.js
+++ b/tests/e2e/fixture/src/index.js
@@ -1,0 +1,4 @@
+// The entry app module intentionally imports no client component: client
+// references reach the bundle only through the plugin's injected async
+// blocks on the Flight client runtime (mirrors the split-shared fixture).
+export const app = 'rsc-e2e-fixture';

--- a/tests/e2e/fixture/src/server/App.js
+++ b/tests/e2e/fixture/src/server/App.js
@@ -1,0 +1,19 @@
+// Server-component tree for the fixture app, used by the Flight render
+// script under --conditions=react-server. The client components are
+// injected as registered client references — requiring them directly here
+// would execute client code on the server.
+'use strict';
+
+const React = require('react');
+const { serverMessage } = require('./serverOnly');
+
+module.exports = function createApp({ Counter, ThemeSection }) {
+  return React.createElement(
+    'div',
+    { id: 'app' },
+    React.createElement('h1', null, 'RSC E2E Fixture'),
+    React.createElement('p', { 'data-testid': 'server-message' }, serverMessage()),
+    React.createElement(Counter, { label: 'clicks', initial: 3 }),
+    React.createElement(ThemeSection, { theme: 'dark' }),
+  );
+};

--- a/tests/e2e/fixture/src/server/serverOnly.js
+++ b/tests/e2e/fixture/src/server/serverOnly.js
@@ -1,0 +1,6 @@
+// Server-only module: its output must appear in the Flight payload and the
+// SSR HTML, but the module itself must never be referenced by the client
+// manifest or client chunks.
+'use strict';
+
+exports.serverMessage = () => 'rendered-on-server-only';

--- a/tests/e2e/fixture/src/ssr-entry.js
+++ b/tests/e2e/fixture/src/ssr-entry.js
@@ -1,0 +1,10 @@
+// SSR-bundle entry, exposed via webpack/rspack `output.library` commonjs2.
+// Everything the SSR render script needs is re-exported from INSIDE the
+// bundle so the Flight node client, React, and react-dom/server share one
+// module graph (CSS hint dispatch and hooks both require a single React
+// and react-dom instance).
+import './index';
+
+export { buildClientRenderer } from 'react-on-rails-rsc/client';
+export * as React from 'react';
+export * as ReactDOMServer from 'react-dom/server';

--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -1,0 +1,20 @@
+// Dedicated jest config for the packed-tarball E2E suite.
+//
+// E2E files are named *.e2e.ts so the main jest config's testMatch
+// (`tests/**/*.test.*`) never picks them up — they only run through
+// `yarn test:e2e` (scripts/e2e/run.sh), which prepares the consumer
+// project and exports RSC_E2E_PROJECT_DIR.
+const { createDefaultPreset } = require('ts-jest');
+
+const tsJestTransformCfg = createDefaultPreset().transform;
+
+/** @type {import("jest").Config} **/
+module.exports = {
+  rootDir: '../..',
+  testEnvironment: 'node',
+  transform: {
+    ...tsJestTransformCfg,
+  },
+  testMatch: ['<rootDir>/tests/e2e/**/*.e2e.[jt]s'],
+  testTimeout: 300_000,
+};

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -357,7 +357,7 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
             `/assets/${base('NestedLabel.js')}.chunk.css`,
             `/assets/${base('ThemeSection.js')}.chunk.css`,
           ];
-      expect([...result.stylesheetLinks].sort()).toEqual(expectedLinks);
+      expect([...result.stylesheetLinks].sort()).toEqual([...expectedLinks].sort());
 
       // The runtime's embedded version string (captured from the devtools
       // hook registration) must match the intended fork version — catches

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -1,0 +1,436 @@
+/**
+ * Full-pipeline E2E: packed tarball → webpack+rspack builds → Flight render
+ * → SSR HTML → jsdom hydration.
+ *
+ * Runs against a disposable consumer project prepared by scripts/e2e/run.sh
+ * (`yarn test:e2e`): `npm pack` of this repo installed via npm into a temp
+ * project (RSC_E2E_PROJECT_DIR), so the suite exercises the published dist/
+ * files and the package exports map — not src/.
+ *
+ * Pipeline, per bundler leg (webpack and rspack share one fixture app in
+ * tests/e2e/fixture, two configs in scripts/build.js):
+ *
+ *   1. Build the client bundle (web target, splitChunks-shared module, CSS
+ *      via the extract plugin, split runtime chunk, seeded .hot-update
+ *      assets) and the SSR bundle (node target, commonjs2 library) with the
+ *      real installed plugins.
+ *   2. Assert EXACT per-component manifest chunk lists (post-#54
+ *      dependency-chunk-group semantics), CSS hints, runtime-chunk and
+ *      .hot-update exclusion.
+ *   3. Flight-render the fixture's server-component tree in a child node
+ *      process under --conditions=react-server (the condition cannot be
+ *      applied to this already-running jest process) and assert the wire
+ *      payload embeds the manifest chunk lists and CSS hints verbatim.
+ *   4. Decode the payload through the SSR bundle (createFromNodeStream +
+ *      react-dom/server inside one bundled module graph) and assert the
+ *      client-component boundaries appear fully rendered in the HTML.
+ *   5. Hydrate in jsdom against the real client bundle served over HTTP:
+ *      zero console errors/warnings, zero recoverable hydration errors,
+ *      client components interactive, stylesheet links present, and the
+ *      runtime's devtools-embedded version string matches the intended
+ *      React fork version (the rc.4 "runtime still reports 19.0.3" class
+ *      of incident).
+ *
+ * Known divergences of the rspack leg (current main behavior, asserted
+ * below so any change is caught):
+ *   - rspack manifest entries carry no `css` field, so the Flight payload
+ *     has no stylesheet hints (CSS still reaches the DOM through rspack's
+ *     own chunk-CSS runtime).
+ *   - the rspack plugin excludes generated client-reference chunks from
+ *     splitChunks, so the shared module is duplicated per chunk instead of
+ *     being split into a shared chunk.
+ *   - rspack chunk names embed the sanitized absolute module path.
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+
+const PROJECT_DIR = process.env.RSC_E2E_PROJECT_DIR ?? '';
+if (!PROJECT_DIR) {
+  throw new Error(
+    'RSC_E2E_PROJECT_DIR is not set. Run this suite through `yarn test:e2e` ' +
+      '(scripts/e2e/run.sh), which packs the tarball and prepares the consumer project.',
+  );
+}
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+// Node resolves module paths through symlinks (e.g. /tmp → /private/tmp on
+// macOS), so manifest keys use the real path.
+const PROJECT_REAL = fs.realpathSync(PROJECT_DIR);
+const INSTALLED_PKG = path.join(PROJECT_DIR, 'node_modules', 'react-on-rails-rsc');
+
+type Bundler = 'webpack' | 'rspack';
+const requested = process.env.RSC_E2E_BUNDLER ?? 'both';
+const BUNDLERS: Bundler[] =
+  requested === 'both' ? ['webpack', 'rspack'] : ([requested] as Bundler[]);
+if (!BUNDLERS.every((b) => b === 'webpack' || b === 'rspack')) {
+  throw new Error(`Invalid RSC_E2E_BUNDLER: ${requested} (use webpack | rspack | both)`);
+}
+
+interface ModuleMetadata {
+  id: string;
+  chunks: (string | number)[];
+  css?: string[];
+  name: string;
+}
+interface Manifest {
+  moduleLoading: { prefix: string; crossOrigin: string | null };
+  filePathToModuleMetadata: Record<string, ModuleMetadata>;
+}
+interface BuildResult {
+  ok: boolean;
+  assets: string[];
+  warnings: string[];
+}
+interface HydrateResult {
+  ok: boolean;
+  valueBeforeClick: string | null;
+  valueAfterClick: string | null;
+  nestedLabelText: string | null;
+  serverMessageText: string | null;
+  stylesheetLinks: string[];
+  devtoolsRenderers: { version: string; rendererPackageName: string }[];
+  recoverableErrors: string[];
+  consoleMessages: { level: string; message: string }[];
+}
+
+const runNode = <T>(args: string[]): T => {
+  let stdout: string;
+  try {
+    stdout = execFileSync(process.execPath, args, {
+      cwd: PROJECT_DIR,
+      encoding: 'utf8',
+      timeout: 240_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; message: string };
+    throw new Error(
+      `child process failed: node ${args.join(' ')}\n` +
+        `stdout: ${err.stdout ?? ''}\nstderr: ${err.stderr ?? ''}\n${err.message}`,
+    );
+  }
+  return JSON.parse(stdout) as T;
+};
+
+const readJson = <T>(...segments: string[]): T =>
+  JSON.parse(fs.readFileSync(path.join(...segments), 'utf8')) as T;
+
+const componentUrl = (file: string): string =>
+  pathToFileURL(path.join(PROJECT_REAL, 'src', 'components', file)).href;
+
+/** rspack expands `[request]` in the injected chunk name to the sanitized absolute path. */
+const rspackChunkBase = (file: string): string =>
+  `client-${path.join(PROJECT_REAL, 'src', 'components', file).replace(/[^a-zA-Z0-9]/g, '_')}`;
+
+const webpackChunkBase = (file: string): string => `client-${path.basename(file, '.js')}-js`;
+
+const chunkPair = (base: string): string[] => [base, `${base}.chunk.js`];
+
+/** Flight module-import rows look like `<row id>:I[id, chunks, name]`. */
+const importRows = (payload: string): [string, string[], string][] =>
+  [...payload.matchAll(/^[0-9a-f]+:I(\[.*\])$/gm)].map(
+    (m) => JSON.parse(m[1]!) as [string, string[], string],
+  );
+
+/** Flight stylesheet hint rows look like `<row id>:HS["<href>","rsc-css"]`. */
+const styleHintRows = (payload: string): [string, string][] =>
+  [...payload.matchAll(/^[0-9a-f]+:HS(\[.*\])$/gm)].map(
+    (m) => JSON.parse(m[1]!) as [string, string],
+  );
+
+jest.setTimeout(300_000);
+
+describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
+  const buildDir = path.join(PROJECT_DIR, 'build', bundler);
+  const isWebpack = bundler === 'webpack';
+  const base = isWebpack ? webpackChunkBase : rspackChunkBase;
+
+  // Exact post-#54 expectations: each client reference lists the chunks of
+  // its own dependency chunk group ([id, file, ...] pairs), minus initial
+  // and runtime chunks. NestedLabel is reachable through two groups (its
+  // own injected block and ThemeSection's chunk), so its entry is the
+  // union. Only webpack splits the shared module into its own chunk and
+  // records CSS chunk files.
+  const sharedPrefix = isWebpack ? chunkPair('shared-format') : [];
+  const expectedClientMetadata: Record<string, ModuleMetadata> = {
+    [componentUrl('Counter.js')]: {
+      id: './src/components/Counter.js',
+      chunks: [...sharedPrefix, ...chunkPair(base('Counter.js'))],
+      ...(isWebpack ? { css: [`/assets/${base('Counter.js')}.chunk.css`] } : {}),
+      name: '*',
+    },
+    [componentUrl('NestedLabel.js')]: {
+      id: './src/components/NestedLabel.js',
+      chunks: [
+        ...sharedPrefix,
+        ...chunkPair(base('NestedLabel.js')),
+        ...(isWebpack ? [] : chunkPair(base('ThemeSection.js'))),
+      ],
+      ...(isWebpack ? { css: [`/assets/${base('NestedLabel.js')}.chunk.css`] } : {}),
+      name: '*',
+    },
+    [componentUrl('ThemeSection.js')]: {
+      id: './src/components/ThemeSection.js',
+      chunks: [...sharedPrefix, ...chunkPair(base('ThemeSection.js'))],
+      ...(isWebpack ? { css: [`/assets/${base('ThemeSection.js')}.chunk.css`] } : {}),
+      name: '*',
+    },
+  };
+
+  const expectedSsrMetadata: Record<string, ModuleMetadata> = {
+    [componentUrl('Counter.js')]: {
+      id: './src/components/Counter.js',
+      chunks: chunkPair(base('Counter.js')),
+      ...(isWebpack ? { css: [] } : {}),
+      name: '*',
+    },
+    [componentUrl('NestedLabel.js')]: {
+      id: './src/components/NestedLabel.js',
+      chunks: [...chunkPair(base('NestedLabel.js')), ...chunkPair(base('ThemeSection.js'))],
+      ...(isWebpack ? { css: [] } : {}),
+      name: '*',
+    },
+    [componentUrl('ThemeSection.js')]: {
+      id: './src/components/ThemeSection.js',
+      chunks: chunkPair(base('ThemeSection.js')),
+      ...(isWebpack ? { css: [] } : {}),
+      name: '*',
+    },
+  };
+
+  let clientBuild: BuildResult;
+  let ssrBuild: BuildResult;
+  let clientManifest: Manifest;
+  let ssrManifest: Manifest;
+
+  beforeAll(() => {
+    clientBuild = runNode<BuildResult>(['scripts/build.js', bundler, 'client']);
+    ssrBuild = runNode<BuildResult>(['scripts/build.js', bundler, 'ssr']);
+    clientManifest = readJson<Manifest>(buildDir, 'client', 'react-client-manifest.json');
+    ssrManifest = readJson<Manifest>(buildDir, 'ssr', 'react-server-client-manifest.json');
+  });
+
+  it('builds both bundles without warnings', () => {
+    expect(clientBuild.ok).toBe(true);
+    expect(clientBuild.warnings).toEqual([]);
+    expect(ssrBuild.ok).toBe(true);
+    expect(ssrBuild.warnings).toEqual([]);
+  });
+
+  it('emits the exact per-component client manifest', () => {
+    expect(clientManifest.moduleLoading).toEqual({ prefix: '/assets/', crossOrigin: null });
+    expect(clientManifest.filePathToModuleMetadata).toEqual(expectedClientMetadata);
+  });
+
+  it('emits the exact per-component SSR (server) manifest', () => {
+    expect(ssrManifest.moduleLoading).toEqual({ prefix: '', crossOrigin: null });
+    expect(ssrManifest.filePathToModuleMetadata).toEqual(expectedSsrMetadata);
+  });
+
+  it('excludes the runtime chunk from every client manifest entry', () => {
+    // The client build splits the runtime out; it must never be listed for
+    // a client reference (the 19.0.5-rc runtime-chunk CSS leak incident).
+    expect(clientBuild.assets).toContain('runtime.js');
+    for (const metadata of Object.values(clientManifest.filePathToModuleMetadata)) {
+      const referenced = [...metadata.chunks.map(String), ...(metadata.css ?? [])];
+      expect(referenced.filter((entry) => entry.includes('runtime'))).toEqual([]);
+    }
+  });
+
+  it('excludes .hot-update assets from every client manifest entry', () => {
+    if (isWebpack) {
+      // The build seeds fake hot-update files onto the Counter chunk so
+      // this exclusion is exercised by a real chunk, not vacuously.
+      expect(clientBuild.assets).toContain('seeded.fake.hot-update.css');
+      expect(clientBuild.assets).toContain('seeded.fake.hot-update.js');
+    }
+    for (const metadata of Object.values(clientManifest.filePathToModuleMetadata)) {
+      const referenced = [...metadata.chunks.map(String), ...(metadata.css ?? [])];
+      expect(referenced.filter((entry) => entry.includes('.hot-update.'))).toEqual([]);
+    }
+  });
+
+  it('never lists server-only modules in the manifests', () => {
+    for (const manifest of [clientManifest, ssrManifest]) {
+      const keys = Object.keys(manifest.filePathToModuleMetadata);
+      expect(keys.filter((key) => key.includes('/server/'))).toEqual([]);
+    }
+  });
+
+  describe('Flight → SSR → hydration', () => {
+    let payload: string;
+
+    beforeAll(() => {
+      // Child process: the react-server condition must be set at process
+      // startup, so the Flight render cannot run inside jest itself.
+      runNode(['--conditions=react-server', 'scripts/render-flight.js', bundler]);
+      payload = fs.readFileSync(path.join(buildDir, 'flight-payload.rsc'), 'utf8');
+    });
+
+    it('embeds the manifest chunk lists verbatim in the Flight payload', () => {
+      const rows = importRows(payload);
+      // Only the two directly-referenced client components appear; the
+      // nested NestedLabel resolves inside ThemeSection's chunks.
+      expect(rows.map((row) => row[0]).sort()).toEqual([
+        './src/components/Counter.js',
+        './src/components/ThemeSection.js',
+      ]);
+      for (const file of ['Counter.js', 'ThemeSection.js']) {
+        const metadata = clientManifest.filePathToModuleMetadata[componentUrl(file)]!;
+        const row = rows.find((r) => r[0] === metadata.id);
+        expect(row).toBeDefined();
+        // The browser runtime feeds this list straight into
+        // __webpack_chunk_load__ — it must match the manifest verbatim.
+        expect(row![1]).toEqual(metadata.chunks.map(String));
+        expect(row![2]).toBe('default');
+      }
+      expect(payload).toContain('rendered-on-server-only');
+    });
+
+    it(
+      isWebpack
+        ? 'emits stylesheet hints for the referenced client components'
+        : 'emits no stylesheet hints (rspack manifest has no css metadata — current behavior)',
+      () => {
+        const hints = styleHintRows(payload);
+        if (isWebpack) {
+          expect(hints).toEqual([
+            [`/assets/${base('Counter.js')}.chunk.css`, 'rsc-css'],
+            [`/assets/${base('ThemeSection.js')}.chunk.css`, 'rsc-css'],
+          ]);
+        } else {
+          // Documents the rspack-leg gap: no `css` in the manifest means no
+          // Flight stylesheet hints. CSS still reaches the DOM through
+          // rspack's chunk-CSS runtime (asserted in the hydration test).
+          // If this starts failing, rspack gained CSS hints — tighten the
+          // expectations to match the webpack leg.
+          expect(hints).toEqual([]);
+        }
+      },
+    );
+
+    it('renders the payload to SSR HTML with executed client components', () => {
+      const result = runNode<{ ok: boolean; errors: string[] }>([
+        'scripts/render-ssr.js',
+        bundler,
+      ]);
+      expect(result.errors).toEqual([]);
+      expect(result.ok).toBe(true);
+
+      const html = fs.readFileSync(path.join(buildDir, 'ssr.html'), 'utf8');
+      // Server-component content…
+      expect(html).toContain('<h1>RSC E2E Fixture</h1>');
+      expect(html).toContain('rendered-on-server-only');
+      // …and the client-component boundaries, fully executed through the
+      // SSR bundle's real chunk loading (state, shared module, nesting).
+      expect(html).toContain('<div class="counter" data-testid="counter">');
+      expect(html).toContain('<span data-testid="counter-value">clicks: 3</span>');
+      expect(html).toContain('<section class="theme-section" data-testid="theme-section">');
+      expect(html).toContain('<em class="nested-label" data-testid="nested-label">theme: dark</em>');
+    });
+
+    it('hydrates in jsdom with zero errors and interactive client components', () => {
+      const result = runNode<HydrateResult>(['scripts/hydrate.js', bundler]);
+
+      expect(result.consoleMessages).toEqual([]);
+      expect(result.recoverableErrors).toEqual([]);
+      expect(result.ok).toBe(true);
+
+      // Hydrated from SSR markup, then interactive after a click.
+      expect(result.serverMessageText).toBe('rendered-on-server-only');
+      expect(result.nestedLabelText).toBe('theme: dark');
+      expect(result.valueBeforeClick).toBe('clicks: 3');
+      expect(result.valueAfterClick).toBe('clicks: 4');
+
+      // Stylesheets reach the document head: on webpack via the Flight
+      // CSS hints (preinit), on rspack via the chunk-CSS runtime.
+      const expectedLinks = isWebpack
+        ? [
+            `/assets/${base('Counter.js')}.chunk.css`,
+            `/assets/${base('ThemeSection.js')}.chunk.css`,
+          ]
+        : [
+            `/assets/${base('Counter.js')}.chunk.css`,
+            `/assets/${base('NestedLabel.js')}.chunk.css`,
+            `/assets/${base('ThemeSection.js')}.chunk.css`,
+          ];
+      expect([...result.stylesheetLinks].sort()).toEqual(expectedLinks);
+
+      // The runtime's embedded version string (captured from the devtools
+      // hook registration) must match the intended fork version — catches
+      // stale runtime builds like the rc.4 "still reports 19.0.3" incident.
+      const intendedVersion = readJson<{ version: string }>(
+        REPO_ROOT,
+        'src',
+        'react-server-dom-webpack',
+        'package.json',
+      ).version;
+      const flightRenderer = result.devtoolsRenderers.find(
+        (renderer) => renderer.rendererPackageName === 'react-on-rails-rsc',
+      );
+      expect(flightRenderer).toBeDefined();
+      expect(flightRenderer!.version).toBe(intendedVersion);
+
+      // And react-dom in the client bundle is the consumer-installed copy.
+      const reactDomVersion = readJson<{ version: string }>(
+        PROJECT_DIR,
+        'node_modules',
+        'react-dom',
+        'package.json',
+      ).version;
+      const domRenderer = result.devtoolsRenderers.find(
+        (renderer) => renderer.rendererPackageName === 'react-dom',
+      );
+      expect(domRenderer).toBeDefined();
+      expect(domRenderer!.version).toBe(reactDomVersion);
+    });
+  });
+});
+
+describe('installed tarball version integrity', () => {
+  it('ships the intended React fork version in the packed runtime', () => {
+    const intendedVersion = readJson<{ version: string }>(
+      REPO_ROOT,
+      'src',
+      'react-server-dom-webpack',
+      'package.json',
+    ).version;
+
+    // The runtime package.json inside the installed dist…
+    const installedRuntimeVersion = readJson<{ version: string }>(
+      INSTALLED_PKG,
+      'dist',
+      'react-server-dom-webpack',
+      'package.json',
+    ).version;
+    expect(installedRuntimeVersion).toBe(intendedVersion);
+
+    // …and every version string embedded in the installed runtime sources.
+    const cjsDir = path.join(INSTALLED_PKG, 'dist', 'react-server-dom-webpack', 'cjs');
+    const embedded: Record<string, string[]> = {};
+    for (const file of fs.readdirSync(cjsDir)) {
+      if (!file.endsWith('.js')) continue;
+      const source = fs.readFileSync(path.join(cjsDir, file), 'utf8');
+      const versions = [
+        ...source.matchAll(/\b(?:version|reconcilerVersion):\s*"([0-9][^"]*)"/g),
+      ].map((m) => m[1]!);
+      if (versions.length > 0) embedded[file] = versions;
+    }
+    // At least the development browser client embeds its version via the
+    // devtools registration — if this goes empty the assertion is vacuous.
+    expect(Object.keys(embedded).length).toBeGreaterThan(0);
+    for (const [file, versions] of Object.entries(embedded)) {
+      for (const version of versions) {
+        expect({ file, version }).toEqual({ file, version: intendedVersion });
+      }
+    }
+
+    // The installed package itself is the version this repo packs.
+    const repoVersion = readJson<{ version: string }>(REPO_ROOT, 'package.json').version;
+    const installedVersion = readJson<{ version: string }>(INSTALLED_PKG, 'package.json').version;
+    expect(installedVersion).toBe(repoVersion);
+  });
+});

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -118,6 +118,15 @@ const runNode = <T>(args: string[]): T => {
 const readJson = <T>(...segments: string[]): T =>
   JSON.parse(fs.readFileSync(path.join(...segments), 'utf8')) as T;
 
+// The intended React fork version — the runtime everywhere in the packed
+// dist must report exactly this (devtools registration + embedded strings).
+const INTENDED_FORK_VERSION = readJson<{ version: string }>(
+  REPO_ROOT,
+  'src',
+  'react-server-dom-webpack',
+  'package.json',
+).version;
+
 const componentUrl = (file: string): string =>
   pathToFileURL(path.join(PROJECT_REAL, 'src', 'components', file)).href;
 
@@ -362,17 +371,11 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
       // The runtime's embedded version string (captured from the devtools
       // hook registration) must match the intended fork version — catches
       // stale runtime builds like the rc.4 "still reports 19.0.3" incident.
-      const intendedVersion = readJson<{ version: string }>(
-        REPO_ROOT,
-        'src',
-        'react-server-dom-webpack',
-        'package.json',
-      ).version;
       const flightRenderer = result.devtoolsRenderers.find(
         (renderer) => renderer.rendererPackageName === 'react-on-rails-rsc',
       );
       expect(flightRenderer).toBeDefined();
-      expect(flightRenderer!.version).toBe(intendedVersion);
+      expect(flightRenderer!.version).toBe(INTENDED_FORK_VERSION);
 
       // And react-dom in the client bundle is the consumer-installed copy.
       const reactDomVersion = readJson<{ version: string }>(
@@ -392,13 +395,6 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
 
 describe('installed tarball version integrity', () => {
   it('ships the intended React fork version in the packed runtime', () => {
-    const intendedVersion = readJson<{ version: string }>(
-      REPO_ROOT,
-      'src',
-      'react-server-dom-webpack',
-      'package.json',
-    ).version;
-
     // The runtime package.json inside the installed dist…
     const installedRuntimeVersion = readJson<{ version: string }>(
       INSTALLED_PKG,
@@ -406,7 +402,7 @@ describe('installed tarball version integrity', () => {
       'react-server-dom-webpack',
       'package.json',
     ).version;
-    expect(installedRuntimeVersion).toBe(intendedVersion);
+    expect(installedRuntimeVersion).toBe(INTENDED_FORK_VERSION);
 
     // …and every version string embedded in the installed runtime sources.
     const cjsDir = path.join(INSTALLED_PKG, 'dist', 'react-server-dom-webpack', 'cjs');
@@ -424,7 +420,7 @@ describe('installed tarball version integrity', () => {
     expect(Object.keys(embedded).length).toBeGreaterThan(0);
     for (const [file, versions] of Object.entries(embedded)) {
       for (const version of versions) {
-        expect({ file, version }).toEqual({ file, version: intendedVersion });
+        expect({ file, version }).toEqual({ file, version: INTENDED_FORK_VERSION });
       }
     }
 


### PR DESCRIPTION
Closes #57

## Summary

Full-pipeline E2E suite that runs from the **packed tarball** (`npm pack` → `npm install` into a disposable consumer project — catching exports-map/dist bugs, not just `src/` behavior): a shared fixture app with a server component, nested `"use client"` components, CSS imports, and a splitChunks-shared module is built with **both webpack and rspack**, then Flight-rendered under `--conditions=react-server`, SSR'd to HTML through `createFromNodeStream` + `react-dom/server`, and hydrated in jsdom with zero errors. This is the class of test that would have caught most of the 19.0.5-rc.1→rc.7 regressions and is the verification gate for #60.

## Design rundown (issue items 1–8)

1. **Harness**: `scripts/e2e/run.sh` (callable locally via `yarn test:e2e`, from CI, and from skills) packs the tarball, creates the consumer project, npm-installs, copies `tests/e2e/fixture/`, and runs jest with a dedicated config (`tests/e2e/jest.config.js`). E2E files use the `*.e2e.ts` suffix so the existing `yarn test` selection (`*.test.*`) is untouched — no changes to the main jest config or scripts.
2. **Builds**: `tests/e2e/fixture/scripts/build.js` builds client + SSR bundles per bundler with the real installed plugins (`react-on-rails-rsc/WebpackPlugin`, `react-on-rails-rsc/RspackPlugin`), CSS extraction, `runtimeChunk: 'single'`, a forced `shared-format` splitChunks group, and (webpack) seeded `.hot-update.css/.js` files attached to a real chunk so the hot-update exclusion is exercised non-vacuously.
3. **Flight render**: child node process under `--conditions=react-server` (`render-flight.js`), going through the package exports map (`react-on-rails-rsc/server.node` under the react-server condition); payload captured to disk.
4. **Manifest assertions**: exact per-component chunk lists (post-#54 dependency-chunk-group semantics) via whole-map `toEqual`, CSS hints, runtime-chunk exclusion, `.hot-update.*` exclusion, server-only modules never present — for both client and SSR manifests, both bundlers.
5. **SSR**: `render-ssr.js` decodes via `buildClientRenderer().createFromNodeStream` and renders with `react-dom/server.renderToPipeableStream`, all inside ONE bundled module graph (commonjs2 SSR bundle) so the Flight client, React, and react-dom share instances and real chunk loading happens. Asserts fully executed client-component boundaries in the HTML (state, shared module, nested client component).
6. **Hydration**: jsdom proved sufficient — no playwright needed. `hydrate.js` serves the client build over local HTTP (`publicPath /assets/`), executes the real bundle (script-tag chunk loading), hydrates from the captured payload, asserts **zero console errors/warnings, zero recoverable hydration errors**, clicks the counter (3 → 4, interactivity), and checks stylesheet `<link>`s in `<head>`.
7. **Version integrity**: the jsdom harness stubs `__REACT_DEVTOOLS_GLOBAL_HOOK__` and captures the runtime's devtools registration — the embedded `version` of the `react-on-rails-rsc` renderer must equal `src/react-server-dom-webpack/package.json`'s version (would have caught the rc.4 "runtime still reports 19.0.3" incident). A static scan additionally asserts every `version:`/`reconcilerVersion:` string in the installed `dist/react-server-dom-webpack/cjs/*.js` matches, and the installed package version matches the repo version.
8. **CI**: new separate workflow `.github/workflows/e2e-tests.yml` running `yarn test:e2e` — same actions and pinning style as the existing `unit-tests.yml`; existing CI untouched (the job can be disabled by reverting this one file).

### rspack-leg divergences pinned as current behavior

The suite tests current `main` behavior and locks these documented gaps so any change is surfaced (relevant for #56 parity work):

- rspack manifest entries carry **no `css` field** → no Flight stylesheet hints (CSS still reaches the DOM via rspack's chunk-CSS runtime; asserted in hydration).
- the rspack plugin **excludes generated client-reference chunks from splitChunks** (matches `tests/rspack-plugin/plugin.test.ts`), so the shared module is duplicated per chunk instead of split.
- rspack chunk names expand `[request]` to the sanitized absolute module path (expectations computed from the project dir).

## Mutation check

Seeded regression (never committed): in `src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js` line 337, changed the manifest CSS collection from `file.endsWith(".css")` to `file.endsWith(".mutated-css")` — i.e. the manifest path silently drops CSS hints. Rebuilt + repacked + reran:

```
$ yarn test:e2e   # with mutation
  webpack leg (packed tarball pipeline)
    ✕ emits the exact per-component client manifest (6 ms)
    ...
    ✕ emits stylesheet hints for the referenced client components

  ● webpack leg › Flight → SSR → hydration › emits stylesheet hints for the referenced client components
    - Array [
    -   Array [ "/assets/client-Counter-js.chunk.css", "rsc-css" ],
    -   Array [ "/assets/client-ThemeSection-js.chunk.css", "rsc-css" ],
    - ]
    + Array []

Test Suites: 1 failed, 1 total
Tests:       2 failed, 19 passed, 21 total
exit: 1
```

Reverted (`git checkout -- src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js`), reran:

```
$ yarn test:e2e   # after revert
Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
exit: 0
```

## Local validation

| Command | Result |
| --- | --- |
| `yarn build` | tsc clean |
| `yarn test` | 17 suites / 158 tests passed (existing selection untouched) |
| `yarn test:e2e` (clean run: pack → fresh npm install → both legs) | 21/21 passed — webpack leg 10 tests, rspack leg 10 tests, version-integrity 1 |
| `RSC_E2E_BUNDLER=webpack` / `=rspack` | leg filtering works via `describe.each` selection |
| `actionlint .github/workflows/e2e-tests.yml` | clean |

## Conventions for #61 (shared pack plumbing)

Documented in the `scripts/e2e/run.sh` header; #61 should reuse:

- `RSC_E2E_WORK_DIR` — base temp dir (default `mktemp -d ror-rsc-e2e.XXXXXX`)
- `RSC_E2E_PROJECT_DIR` — consumer project (default `$RSC_E2E_WORK_DIR/project`), exported to the suite
- `RSC_E2E_BUNDLER` — `webpack | rspack | both`
- `RSC_E2E_KEEP=1` — keep work dir for debugging; `RSC_E2E_REUSE=1` — skip pack+install on an already-installed project (fast local iteration)
- Tarball: `npm pack` default naming at `$RSC_E2E_WORK_DIR/react-on-rails-rsc-<version>.tgz`, name captured from `npm pack` stdout
- Consumer installs use **npm** (real-consumer fidelity for the tarball + exports map); repo operations stay yarn

## New-gate rollout note

This adds a new CI job that will run on every PR once merged (pull_request workflows evaluate against the merged ref). Open-PR sweep: #55 is docs-only (unaffected); #56 rewrites the webpack plugin in TS — this suite is intentionally its parity harness and #56 must pass it after rebasing on this.

## Codex Decision Log

Pre-push gates run on the committed branch diff:

- **Codex review** (`codex review --base origin/main`, codex-cli 0.136.0): 2 findings, both accepted —
  - [P2] realpath the project root in `render-flight.js` before registering client references (runs passed empirically because Node realpaths the main module, but explicit realpath removes the dependence on that behavior) → fixed.
  - [P2] pin the disposable consumer's dependencies → fixed: exact versions derived from the repo's installed (yarn.lock-resolved) packages; jsdom pinned explicitly.
- **Claude Code review pass** (`claude -p '/code-review'`): 10 findings triaged —
  - Accepted: realpath (dup of Codex), Flight `onError` must fail the render step (now reports `ok:false` + exit 1), sort both sides of the stylesheet-link comparison.
  - Already fixed pre-review-completion: tarball discovery via glob (now taken from `npm pack` stdout).
  - Rejected (verified against real code): "missing PassThrough error handlers / top-level reads produce empty-JSON failures" — wrong failure-mode claim; non-zero exits surface stderr through the suite's `runNode` wrapper, so diagnosis is already clear. "SSR watchdog timeout" — speculative; `runNode` enforces a 240s timeout. "`chunk.files.add` could become read-only" — webpack 5 documents mutable `chunk.files`; the mutation check proves the assertion path is live. "registerClientReference via internal dist path" — intentional and documented (same-module-instance requirement, mirrors the existing in-repo e2e test); flagged by /simplify as a possible future public export (package change, out of scope).
- **Simplify gate** (`claude -p '/simplify origin/main' --model claude-opus-4-8 --max-budget-usd 20`): ran; one accepted change (hoist the intended-fork-version read to a module-level constant). Rejections recorded by the pass itself: shared-helper extraction (cross-cutting, out of diff), metadata factory (assertion fixtures favor explicit literals), deriving expected links from the manifest (false positive — would be circular and break the rspack leg), build parallelization (complexity > benefit). Validation re-run green after the change.

## Merge readiness evaluation

- Gates: local validation green (above); mutation check demonstrated; workflow-change audit comment posted on this PR; pre-push Codex review + Claude review pass + `/simplify` gate recorded below.
- Residual risk: the consumer project installs deps from the npm registry with caret ranges — a future webpack/rspack/react minor could shift pinned chunk names or behavior and fail this job independently of repo changes (acceptable: that is signal for a real consumer too). jsdom hydration depends on polyfilled `MessageChannel`/`ReadableStream` — stable across jsdom 26.
- Rollback: revert the squash commit; the CI job alone can be disabled by reverting `.github/workflows/e2e-tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI-only changes; no production library behavior is modified. CI runtime and flakiness from pinned bundler chunk assertions are the main operational risks.
> 
> **Overview**
> Adds a **packed-tarball** end-to-end gate: `yarn test:e2e` runs `scripts/e2e/run.sh`, which builds, `npm pack`s, installs into a disposable consumer with pinned webpack/rspack/React versions, then runs Jest via `tests/e2e/jest.config.js` (`*.e2e.ts` only, so `yarn test` is unchanged).
> 
> The suite drives a fixture through **webpack and rspack** — client + SSR bundles with the installed plugins, Flight render under `--conditions=react-server`, SSR HTML via the SSR bundle, and **jsdom** hydration over HTTP — with strict manifest, Flight wire, HTML, hydration, and embedded runtime version checks. A new **`.github/workflows/e2e-tests.yml`** runs this on every pull request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5e13eccaccae9181b11cfe6b8aa921e5498663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->