### PR TITLE
Apply React 19.0.7 RSC reply-decode DoS fixes (CVE-2026-23869, CVE-2026-23870) to vendored runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Updated the vendored `react-server-dom-webpack` runtime from the React 19.0.4 security level to 19.0.7, applying the upstream React Server Components reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh) while preserving the in-repo Flight CSS hint behavior. ([#86])
+
 ## [19.0.5-rc.7] - 2026-06-09
 
 ### Added
@@ -80,3 +85,4 @@ All notable changes to this package will be documented in this file.
 [19.0.5-rc.1]: https://github.com/shakacode/react_on_rails_rsc/releases/tag/19.0.5-rc.1
 
 [#52]: https://github.com/shakacode/react_on_rails_rsc/pull/52
+[#86]: https://github.com/shakacode/react_on_rails_rsc/pull/86

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Updated the vendored `react-server-dom-webpack` runtime from the React 19.0.4 security level to 19.0.7, applying the upstream React Server Components reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh) while preserving the in-repo Flight CSS hint behavior. ([#86])
+- Updated the vendored `react-server-dom-webpack` runtime from the React 19.0.4 security level to 19.0.7, applying the upstream React Server Components reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh) while preserving the in-repo Flight CSS hint behavior. Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime (both are shipped together in this package); pairing with a pre-19.0.5 `react-server-dom-webpack` on the other side silently drops nested `FormData` entries. ([#86])
 
 ## [19.0.5-rc.7] - 2026-06-09
 

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
@@ -555,7 +555,7 @@
             null === formData && (formData = new FormData());
             var _data3 = formData;
             key = nextPartId++;
-            var prefix = formFieldPrefix + key + "_";
+            var prefix = formFieldPrefix + "_" + key + "_";
             value.forEach(function (originalValue, originalKey) {
               _data3.append(prefix + originalKey, originalValue);
             });
@@ -2511,10 +2511,10 @@
       return hook.checkDCE ? !0 : !1;
     })({
       bundleType: 1,
-      version: "19.0.4",
+      version: "19.0.7",
       rendererPackageName: "react-on-rails-rsc",
       currentDispatcherRef: ReactSharedInternals,
-      reconcilerVersion: "19.0.4",
+      reconcilerVersion: "19.0.7",
       getCurrentComponentInfo: function () {
         return currentOwnerInDEV;
       }

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js
@@ -346,7 +346,7 @@ function processReply(
         null === formData && (formData = new FormData());
         var data$32 = formData;
         key = nextPartId++;
-        var prefix = formFieldPrefix + key + "_";
+        var prefix = formFieldPrefix + "_" + key + "_";
         value.forEach(function (originalValue, originalKey) {
           data$32.append(prefix + originalKey, originalValue);
         });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
@@ -576,7 +576,7 @@
             null === formData && (formData = new FormData());
             var _data3 = formData;
             key = nextPartId++;
-            var prefix = formFieldPrefix + key + "_";
+            var prefix = formFieldPrefix + "_" + key + "_";
             value.forEach(function (originalValue, originalKey) {
               _data3.append(prefix + originalKey, originalValue);
             });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
@@ -358,7 +358,7 @@ function processReply(
         null === formData && (formData = new FormData());
         var data$32 = formData;
         key = nextPartId++;
-        var prefix = formFieldPrefix + key + "_";
+        var prefix = formFieldPrefix + "_" + key + "_";
         value.forEach(function (originalValue, originalKey) {
           data$32.append(prefix + originalKey, originalValue);
         });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
@@ -576,7 +576,7 @@
             null === formData && (formData = new FormData());
             var _data3 = formData;
             key = nextPartId++;
-            var prefix = formFieldPrefix + key + "_";
+            var prefix = formFieldPrefix + "_" + key + "_";
             value.forEach(function (originalValue, originalKey) {
               _data3.append(prefix + originalKey, originalValue);
             });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
@@ -359,7 +359,7 @@ function processReply(
         null === formData && (formData = new FormData());
         var data$32 = formData;
         key = nextPartId++;
-        var prefix = formFieldPrefix + key + "_";
+        var prefix = formFieldPrefix + "_" + key + "_";
         value.forEach(function (originalValue, originalKey) {
           data$32.append(prefix + originalKey, originalValue);
         });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
@@ -539,7 +539,7 @@
             null === formData && (formData = new FormData());
             var _data3 = formData;
             key = nextPartId++;
-            var prefix = formFieldPrefix + key + "_";
+            var prefix = formFieldPrefix + "_" + key + "_";
             value.forEach(function (originalValue, originalKey) {
               _data3.append(prefix + originalKey, originalValue);
             });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
@@ -325,7 +325,7 @@ function processReply(
         null === formData && (formData = new FormData());
         var data$32 = formData;
         key = nextPartId++;
-        var prefix = formFieldPrefix + key + "_";
+        var prefix = formFieldPrefix + "_" + key + "_";
         value.forEach(function (originalValue, originalKey) {
           data$32.append(prefix + originalKey, originalValue);
         });

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2853,7 +2853,7 @@
       var chunks = response._chunks,
         chunk = chunks.get(id);
       chunk ||
-        ((chunk = response._formData.get(response._prefix + id)),
+        ((chunk = response._formData.data.get(response._prefix + id)),
         (chunk =
           "string" === typeof chunk
             ? new ReactPromise(
@@ -2963,6 +2963,10 @@
         case "fulfilled":
           id = chunk.value;
           chunk = chunk.reason;
+          if (null !== chunk && "error" in chunk)
+            throw Error(
+              "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+            );
           for (
             var localLength = 0,
               rootArrayContexts = response._rootArrayContexts,
@@ -3054,23 +3058,20 @@
     function createMap(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-      response = new Map(model);
       model.$$consumed = !0;
-      return response;
+      return new Map(model);
     }
     function createSet(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-      response = new Set(model);
       model.$$consumed = !0;
-      return response;
+      return new Set(model);
     }
     function extractIterator(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-      response = model[Symbol.iterator]();
       model.$$consumed = !0;
-      return response;
+      return model[Symbol.iterator]();
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -3108,7 +3109,7 @@
           Error("Already initialized typed array.")
         )
       );
-      reference = response._formData.get(key).arrayBuffer();
+      reference = response._formData.data.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -3152,7 +3153,7 @@
       var chunks = response._chunks;
       stream = new ReactPromise("fulfilled", stream, controller);
       chunks.set(id, stream);
-      response = response._formData.getAll(response._prefix + id);
+      response = response._formData.data.getAll(response._prefix + id);
       for (id = 0; id < response.length; id++)
         (chunks = response[id]),
           "string" === typeof chunks &&
@@ -3372,24 +3373,33 @@
               getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
-            obj = value.slice(2);
-            obj = response._prefix + obj + "_";
-            key = new FormData();
-            response = response._formData;
-            arrayRoot = Array.from(response.keys());
-            for (value = 0; value < arrayRoot.length; value++)
-              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            key = value.slice(2);
+            obj = response._prefix + "_";
+            key = obj + key + "_";
+            arrayRoot = new FormData();
+            for (response = response._formData; ; ) {
+              value = response;
+              reference = value.keys;
+              null === reference &&
+                ((reference = value.keys = Array.from(value.data.keys())),
+                (value.keyPointer = 0));
+              value = reference[value.keyPointer];
+              if (void 0 === value) break;
+              if (value.startsWith(key)) {
+                reference = response.data.getAll(value);
                 for (
-                  var entries = response.getAll(reference),
-                    newKey = reference.slice(obj.length),
-                    j = 0;
-                  j < entries.length;
-                  j++
+                  var referencedFormDataKey = value.slice(key.length), i = 0;
+                  i < reference.length;
+                  i++
                 )
-                  key.append(newKey, entries[j]);
-                response.delete(reference);
-              }
-            return key;
+                  arrayRoot.append(referencedFormDataKey, reference[i]);
+                reference = response;
+                reference.data.delete(value);
+                reference.keyPointer++;
+              } else if (value.startsWith(obj)) break;
+              else response.keyPointer++;
+            }
+            return arrayRoot;
           case "i":
             return (
               (arrayRoot = value.slice(2)),
@@ -3560,7 +3570,7 @@
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
-              response._formData.get(response._prefix + obj)
+              response._formData.data.get(response._prefix + obj)
             );
         }
         switch (value[1]) {
@@ -3601,7 +3611,7 @@
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
-        _formData: backingFormData,
+        _formData: { data: backingFormData, keyPointer: -1, keys: null },
         _chunks: chunks,
         _temporaryReferences: temporaryReferences,
         _rootArrayContexts: new WeakMap(),

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.production.js
@@ -2405,7 +2405,7 @@ function getChunk(response, id) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
   chunk ||
-    ((chunk = response._formData.get(response._prefix + id)),
+    ((chunk = response._formData.data.get(response._prefix + id)),
     (chunk =
       "string" === typeof chunk
         ? createResolvedModelChunk(response, chunk, id)
@@ -2504,6 +2504,10 @@ function getOutlinedModel(
     case "fulfilled":
       id = chunk.value;
       chunk = chunk.reason;
+      if (null !== chunk && "error" in chunk)
+        throw Error(
+          "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+        );
       for (
         var localLength = 0,
           rootArrayContexts = response._rootArrayContexts,
@@ -2586,23 +2590,20 @@ function getOutlinedModel(
 function createMap(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-  response = new Map(model);
   model.$$consumed = !0;
-  return response;
+  return new Map(model);
 }
 function createSet(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-  response = new Set(model);
   model.$$consumed = !0;
-  return response;
+  return new Set(model);
 }
 function extractIterator(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-  response = model[Symbol.iterator]();
   model.$$consumed = !0;
-  return response;
+  return model[Symbol.iterator]();
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2640,7 +2641,7 @@ function parseTypedArray(
       Error("Already initialized typed array.")
     )
   );
-  reference = response._formData.get(key).arrayBuffer();
+  reference = response._formData.data.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2684,7 +2685,7 @@ function resolveStream(response, id, stream, controller) {
   var chunks = response._chunks;
   stream = new ReactPromise("fulfilled", stream, controller);
   chunks.set(id, stream);
-  response = response._formData.getAll(response._prefix + id);
+  response = response._formData.data.getAll(response._prefix + id);
   for (id = 0; id < response.length; id++)
     (chunks = response[id]),
       "string" === typeof chunks &&
@@ -2899,24 +2900,31 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
           getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
-        obj = value.slice(2);
-        obj = response._prefix + obj + "_";
-        key = new FormData();
-        response = response._formData;
-        arrayRoot = Array.from(response.keys());
-        for (value = 0; value < arrayRoot.length; value++)
-          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+        key = value.slice(2);
+        obj = response._prefix + "_";
+        key = obj + key + "_";
+        arrayRoot = new FormData();
+        for (response = response._formData; ; ) {
+          value = response.keys;
+          null === value &&
+            ((value = response.keys = Array.from(response.data.keys())),
+            (response.keyPointer = 0));
+          value = value[response.keyPointer];
+          if (void 0 === value) break;
+          if (value.startsWith(key)) {
+            reference = response.data.getAll(value);
             for (
-              var entries = response.getAll(reference),
-                newKey = reference.slice(obj.length),
-                j = 0;
-              j < entries.length;
-              j++
+              var referencedFormDataKey = value.slice(key.length), i = 0;
+              i < reference.length;
+              i++
             )
-              key.append(newKey, entries[j]);
-            response.delete(reference);
-          }
-        return key;
+              arrayRoot.append(referencedFormDataKey, reference[i]);
+            response.data.delete(value);
+            response.keyPointer++;
+          } else if (value.startsWith(obj)) break;
+          else response.keyPointer++;
+        }
+        return arrayRoot;
       case "i":
         return (
           (arrayRoot = value.slice(2)),
@@ -3077,7 +3085,7 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
-          response._formData.get(response._prefix + obj)
+          response._formData.data.get(response._prefix + obj)
         );
     }
     switch (value[1]) {
@@ -3107,7 +3115,7 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
-    _formData: backingFormData,
+    _formData: { data: backingFormData, keyPointer: -1, keys: null },
     _chunks: chunks,
     _temporaryReferences: temporaryReferences,
     _rootArrayContexts: new WeakMap(),

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2887,7 +2887,7 @@
       var chunks = response._chunks,
         chunk = chunks.get(id);
       chunk ||
-        ((chunk = response._formData.get(response._prefix + id)),
+        ((chunk = response._formData.data.get(response._prefix + id)),
         (chunk =
           "string" === typeof chunk
             ? new ReactPromise(
@@ -2997,6 +2997,10 @@
         case "fulfilled":
           id = chunk.value;
           chunk = chunk.reason;
+          if (null !== chunk && "error" in chunk)
+            throw Error(
+              "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+            );
           for (
             var localLength = 0,
               rootArrayContexts = response._rootArrayContexts,
@@ -3088,23 +3092,20 @@
     function createMap(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-      response = new Map(model);
       model.$$consumed = !0;
-      return response;
+      return new Map(model);
     }
     function createSet(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-      response = new Set(model);
       model.$$consumed = !0;
-      return response;
+      return new Set(model);
     }
     function extractIterator(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-      response = model[Symbol.iterator]();
       model.$$consumed = !0;
-      return response;
+      return model[Symbol.iterator]();
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -3142,7 +3143,7 @@
           Error("Already initialized typed array.")
         )
       );
-      reference = response._formData.get(key).arrayBuffer();
+      reference = response._formData.data.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -3186,7 +3187,7 @@
       var chunks = response._chunks;
       stream = new ReactPromise("fulfilled", stream, controller);
       chunks.set(id, stream);
-      response = response._formData.getAll(response._prefix + id);
+      response = response._formData.data.getAll(response._prefix + id);
       for (id = 0; id < response.length; id++)
         (chunks = response[id]),
           "string" === typeof chunks &&
@@ -3406,24 +3407,33 @@
               getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
-            obj = value.slice(2);
-            obj = response._prefix + obj + "_";
-            key = new FormData();
-            response = response._formData;
-            arrayRoot = Array.from(response.keys());
-            for (value = 0; value < arrayRoot.length; value++)
-              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            key = value.slice(2);
+            obj = response._prefix + "_";
+            key = obj + key + "_";
+            arrayRoot = new FormData();
+            for (response = response._formData; ; ) {
+              value = response;
+              reference = value.keys;
+              null === reference &&
+                ((reference = value.keys = Array.from(value.data.keys())),
+                (value.keyPointer = 0));
+              value = reference[value.keyPointer];
+              if (void 0 === value) break;
+              if (value.startsWith(key)) {
+                reference = response.data.getAll(value);
                 for (
-                  var entries = response.getAll(reference),
-                    newKey = reference.slice(obj.length),
-                    j = 0;
-                  j < entries.length;
-                  j++
+                  var referencedFormDataKey = value.slice(key.length), i = 0;
+                  i < reference.length;
+                  i++
                 )
-                  key.append(newKey, entries[j]);
-                response.delete(reference);
-              }
-            return key;
+                  arrayRoot.append(referencedFormDataKey, reference[i]);
+                reference = response;
+                reference.data.delete(value);
+                reference.keyPointer++;
+              } else if (value.startsWith(obj)) break;
+              else response.keyPointer++;
+            }
+            return arrayRoot;
           case "i":
             return (
               (arrayRoot = value.slice(2)),
@@ -3594,7 +3604,7 @@
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
-              response._formData.get(response._prefix + obj)
+              response._formData.data.get(response._prefix + obj)
             );
         }
         switch (value[1]) {
@@ -3635,7 +3645,7 @@
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
-        _formData: backingFormData,
+        _formData: { data: backingFormData, keyPointer: -1, keys: null },
         _chunks: chunks,
         _temporaryReferences: temporaryReferences,
         _rootArrayContexts: new WeakMap(),

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2407,7 +2407,7 @@ function getChunk(response, id) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
   chunk ||
-    ((chunk = response._formData.get(response._prefix + id)),
+    ((chunk = response._formData.data.get(response._prefix + id)),
     (chunk =
       "string" === typeof chunk
         ? createResolvedModelChunk(response, chunk, id)
@@ -2506,6 +2506,10 @@ function getOutlinedModel(
     case "fulfilled":
       id = chunk.value;
       chunk = chunk.reason;
+      if (null !== chunk && "error" in chunk)
+        throw Error(
+          "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+        );
       for (
         var localLength = 0,
           rootArrayContexts = response._rootArrayContexts,
@@ -2588,23 +2592,20 @@ function getOutlinedModel(
 function createMap(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-  response = new Map(model);
   model.$$consumed = !0;
-  return response;
+  return new Map(model);
 }
 function createSet(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-  response = new Set(model);
   model.$$consumed = !0;
-  return response;
+  return new Set(model);
 }
 function extractIterator(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-  response = model[Symbol.iterator]();
   model.$$consumed = !0;
-  return response;
+  return model[Symbol.iterator]();
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2642,7 +2643,7 @@ function parseTypedArray(
       Error("Already initialized typed array.")
     )
   );
-  reference = response._formData.get(key).arrayBuffer();
+  reference = response._formData.data.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2686,7 +2687,7 @@ function resolveStream(response, id, stream, controller) {
   var chunks = response._chunks;
   stream = new ReactPromise("fulfilled", stream, controller);
   chunks.set(id, stream);
-  response = response._formData.getAll(response._prefix + id);
+  response = response._formData.data.getAll(response._prefix + id);
   for (id = 0; id < response.length; id++)
     (chunks = response[id]),
       "string" === typeof chunks &&
@@ -2901,24 +2902,31 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
           getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
-        obj = value.slice(2);
-        obj = response._prefix + obj + "_";
-        key = new FormData();
-        response = response._formData;
-        arrayRoot = Array.from(response.keys());
-        for (value = 0; value < arrayRoot.length; value++)
-          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+        key = value.slice(2);
+        obj = response._prefix + "_";
+        key = obj + key + "_";
+        arrayRoot = new FormData();
+        for (response = response._formData; ; ) {
+          value = response.keys;
+          null === value &&
+            ((value = response.keys = Array.from(response.data.keys())),
+            (response.keyPointer = 0));
+          value = value[response.keyPointer];
+          if (void 0 === value) break;
+          if (value.startsWith(key)) {
+            reference = response.data.getAll(value);
             for (
-              var entries = response.getAll(reference),
-                newKey = reference.slice(obj.length),
-                j = 0;
-              j < entries.length;
-              j++
+              var referencedFormDataKey = value.slice(key.length), i = 0;
+              i < reference.length;
+              i++
             )
-              key.append(newKey, entries[j]);
-            response.delete(reference);
-          }
-        return key;
+              arrayRoot.append(referencedFormDataKey, reference[i]);
+            response.data.delete(value);
+            response.keyPointer++;
+          } else if (value.startsWith(obj)) break;
+          else response.keyPointer++;
+        }
+        return arrayRoot;
       case "i":
         return (
           (arrayRoot = value.slice(2)),
@@ -3079,7 +3087,7 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
-          response._formData.get(response._prefix + obj)
+          response._formData.data.get(response._prefix + obj)
         );
     }
     switch (value[1]) {
@@ -3109,7 +3117,7 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
-    _formData: backingFormData,
+    _formData: { data: backingFormData, keyPointer: -1, keys: null },
     _chunks: chunks,
     _temporaryReferences: temporaryReferences,
     _rootArrayContexts: new WeakMap(),

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -2898,7 +2898,7 @@
       var chunks = response._chunks,
         chunk = chunks.get(id);
       chunk ||
-        ((chunk = response._formData.get(response._prefix + id)),
+        ((chunk = response._formData.data.get(response._prefix + id)),
         (chunk =
           "string" === typeof chunk
             ? new ReactPromise(
@@ -3008,6 +3008,10 @@
         case "fulfilled":
           id = chunk.value;
           chunk = chunk.reason;
+          if (null !== chunk && "error" in chunk)
+            throw Error(
+              "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+            );
           for (
             var localLength = 0,
               rootArrayContexts = response._rootArrayContexts,
@@ -3099,23 +3103,20 @@
     function createMap(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-      response = new Map(model);
       model.$$consumed = !0;
-      return response;
+      return new Map(model);
     }
     function createSet(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-      response = new Set(model);
       model.$$consumed = !0;
-      return response;
+      return new Set(model);
     }
     function extractIterator(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-      response = model[Symbol.iterator]();
       model.$$consumed = !0;
-      return response;
+      return model[Symbol.iterator]();
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -3153,7 +3154,7 @@
           Error("Already initialized typed array.")
         )
       );
-      reference = response._formData.get(key).arrayBuffer();
+      reference = response._formData.data.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -3197,7 +3198,7 @@
       var chunks = response._chunks;
       stream = new ReactPromise("fulfilled", stream, controller);
       chunks.set(id, stream);
-      response = response._formData.getAll(response._prefix + id);
+      response = response._formData.data.getAll(response._prefix + id);
       for (id = 0; id < response.length; id++)
         (chunks = response[id]),
           "string" === typeof chunks &&
@@ -3417,24 +3418,33 @@
               getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
-            obj = value.slice(2);
-            obj = response._prefix + obj + "_";
-            key = new FormData();
-            response = response._formData;
-            arrayRoot = Array.from(response.keys());
-            for (value = 0; value < arrayRoot.length; value++)
-              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            key = value.slice(2);
+            obj = response._prefix + "_";
+            key = obj + key + "_";
+            arrayRoot = new FormData();
+            for (response = response._formData; ; ) {
+              value = response;
+              reference = value.keys;
+              null === reference &&
+                ((reference = value.keys = Array.from(value.data.keys())),
+                (value.keyPointer = 0));
+              value = reference[value.keyPointer];
+              if (void 0 === value) break;
+              if (value.startsWith(key)) {
+                reference = response.data.getAll(value);
                 for (
-                  var entries = response.getAll(reference),
-                    newKey = reference.slice(obj.length),
-                    j = 0;
-                  j < entries.length;
-                  j++
+                  var referencedFormDataKey = value.slice(key.length), i = 0;
+                  i < reference.length;
+                  i++
                 )
-                  key.append(newKey, entries[j]);
-                response.delete(reference);
-              }
-            return key;
+                  arrayRoot.append(referencedFormDataKey, reference[i]);
+                reference = response;
+                reference.data.delete(value);
+                reference.keyPointer++;
+              } else if (value.startsWith(obj)) break;
+              else response.keyPointer++;
+            }
+            return arrayRoot;
           case "i":
             return (
               (arrayRoot = value.slice(2)),
@@ -3605,7 +3615,7 @@
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
-              response._formData.get(response._prefix + obj)
+              response._formData.data.get(response._prefix + obj)
             );
         }
         switch (value[1]) {
@@ -3646,7 +3656,7 @@
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
-        _formData: backingFormData,
+        _formData: { data: backingFormData, keyPointer: -1, keys: null },
         _chunks: chunks,
         _temporaryReferences: temporaryReferences,
         _rootArrayContexts: new WeakMap(),
@@ -3654,14 +3664,19 @@
       };
     }
     function resolveField(response, key, value) {
-      response._formData.append(key, value);
-      var prefix = response._prefix;
-      if (key.startsWith(prefix)) {
-        var chunks = response._chunks;
-        key = +key.slice(prefix.length);
-        (chunks = chunks.get(key)) &&
-          resolveModelChunk(response, chunks, value, key);
-      }
+      var backingStore = response._formData;
+      backingStore.data.append(key, value);
+      var keys = backingStore.keys;
+      null === keys
+        ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+          (backingStore.keyPointer = 0))
+        : keys.push(key);
+      keys = response._prefix;
+      key.startsWith(keys) &&
+        ((backingStore = response._chunks),
+        (key = +key.slice(keys.length)),
+        (backingStore = backingStore.get(key)) &&
+          resolveModelChunk(response, backingStore, value, key));
     }
     function close(response) {
       reportGlobalError(response, Error("Connection closed."));
@@ -4281,20 +4296,58 @@
       webpackMap,
       options
     ) {
-      var response = createResponse(
+      function flush() {
+        for (; null !== head; ) {
+          var current = head;
+          if (!current.complete) return;
+          try {
+            var response = response$jscomp$0,
+              key = current.name,
+              handle = current.file,
+              blob = new Blob(handle.chunks, { type: handle.mime }),
+              backingStore = response._formData;
+            response = key;
+            backingStore.data.append(response, blob, handle.filename);
+            var keys = backingStore.keys;
+            null === keys
+              ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+                (backingStore.keyPointer = 0))
+              : keys.push(response);
+            var queuedFields = current.queuedFields;
+            if (null !== queuedFields)
+              for (response = 0; response < queuedFields.length; response += 2)
+                resolveField(
+                  response$jscomp$0,
+                  queuedFields[response],
+                  queuedFields[response + 1]
+                );
+          } catch (error) {
+            busboyStream.destroy(error);
+            return;
+          }
+          head = current.next;
+        }
+        tail = null;
+        bodyFinished && !closed && ((closed = !0), close(response$jscomp$0));
+      }
+      var response$jscomp$0 = createResponse(
           webpackMap,
           "",
           options ? options.temporaryReferences : void 0,
           void 0,
           options ? options.arraySizeLimit : void 0
         ),
-        pendingFiles = 0,
-        queuedFields = [];
+        head = null,
+        tail = null,
+        bodyFinished = !1,
+        closed = !1;
       busboyStream.on("field", function (name, value) {
-        if (0 < pendingFiles) queuedFields.push(name, value);
+        if (null !== tail)
+          null === tail.queuedFields && (tail.queuedFields = []),
+            tail.queuedFields.push(name, value);
         else
           try {
-            resolveField(response, name, value);
+            resolveField(response$jscomp$0, name, value);
           } catch (error) {
             busboyStream.destroy(error);
           }
@@ -4309,40 +4362,45 @@
             )
           );
         else {
-          pendingFiles++;
-          var JSCompiler_object_inline_chunks_149 = [];
+          var file = { chunks: [], filename: filename, mime: mimeType },
+            pendingFile = {
+              name: name,
+              file: file,
+              complete: !1,
+              queuedFields: null,
+              next: null
+            };
+          null === tail ? (head = pendingFile) : (tail.next = pendingFile);
+          tail = pendingFile;
           value.on("data", function (chunk) {
-            JSCompiler_object_inline_chunks_149.push(chunk);
-          });
-          value.on("end", function () {
             try {
-              var blob = new Blob(JSCompiler_object_inline_chunks_149, {
-                type: mimeType
-              });
-              response._formData.append(name, blob, filename);
-              pendingFiles--;
-              if (0 === pendingFiles) {
-                for (blob = 0; blob < queuedFields.length; blob += 2)
-                  resolveField(
-                    response,
-                    queuedFields[blob],
-                    queuedFields[blob + 1]
-                  );
-                queuedFields.length = 0;
-              }
+              file.chunks.push(chunk);
             } catch (error) {
               busboyStream.destroy(error);
             }
           });
+          value.on("error", function (error) {
+            busboyStream.destroy(error);
+          });
+          value.on("end", function () {
+            pendingFile.complete = !0;
+            flush();
+          });
         }
       });
       busboyStream.on("finish", function () {
-        close(response);
+        bodyFinished = !0;
+        flush();
+        closed ||
+          reportGlobalError(
+            response$jscomp$0,
+            Error("Reply finished with incomplete file part.")
+          );
       });
       busboyStream.on("error", function (err) {
-        reportGlobalError(response, err);
+        reportGlobalError(response$jscomp$0, err);
       });
-      return getChunk(response, 0);
+      return getChunk(response$jscomp$0, 0);
     };
     exports.registerClientReference = function (
       proxyImplementation,

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -2443,7 +2443,7 @@ function getChunk(response, id) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
   chunk ||
-    ((chunk = response._formData.get(response._prefix + id)),
+    ((chunk = response._formData.data.get(response._prefix + id)),
     (chunk =
       "string" === typeof chunk
         ? createResolvedModelChunk(response, chunk, id)
@@ -2542,6 +2542,10 @@ function getOutlinedModel(
     case "fulfilled":
       id = chunk.value;
       chunk = chunk.reason;
+      if (null !== chunk && "error" in chunk)
+        throw Error(
+          "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+        );
       for (
         var localLength = 0,
           rootArrayContexts = response._rootArrayContexts,
@@ -2624,23 +2628,20 @@ function getOutlinedModel(
 function createMap(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-  response = new Map(model);
   model.$$consumed = !0;
-  return response;
+  return new Map(model);
 }
 function createSet(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-  response = new Set(model);
   model.$$consumed = !0;
-  return response;
+  return new Set(model);
 }
 function extractIterator(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-  response = model[Symbol.iterator]();
   model.$$consumed = !0;
-  return response;
+  return model[Symbol.iterator]();
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2678,7 +2679,7 @@ function parseTypedArray(
       Error("Already initialized typed array.")
     )
   );
-  reference = response._formData.get(key).arrayBuffer();
+  reference = response._formData.data.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2722,7 +2723,7 @@ function resolveStream(response, id, stream, controller) {
   var chunks = response._chunks;
   stream = new ReactPromise("fulfilled", stream, controller);
   chunks.set(id, stream);
-  response = response._formData.getAll(response._prefix + id);
+  response = response._formData.data.getAll(response._prefix + id);
   for (id = 0; id < response.length; id++)
     (chunks = response[id]),
       "string" === typeof chunks &&
@@ -2937,24 +2938,31 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
           getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
-        obj = value.slice(2);
-        obj = response._prefix + obj + "_";
-        key = new FormData();
-        response = response._formData;
-        arrayRoot = Array.from(response.keys());
-        for (value = 0; value < arrayRoot.length; value++)
-          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+        key = value.slice(2);
+        obj = response._prefix + "_";
+        key = obj + key + "_";
+        arrayRoot = new FormData();
+        for (response = response._formData; ; ) {
+          value = response.keys;
+          null === value &&
+            ((value = response.keys = Array.from(response.data.keys())),
+            (response.keyPointer = 0));
+          value = value[response.keyPointer];
+          if (void 0 === value) break;
+          if (value.startsWith(key)) {
+            reference = response.data.getAll(value);
             for (
-              var entries = response.getAll(reference),
-                newKey = reference.slice(obj.length),
-                j = 0;
-              j < entries.length;
-              j++
+              var referencedFormDataKey = value.slice(key.length), i = 0;
+              i < reference.length;
+              i++
             )
-              key.append(newKey, entries[j]);
-            response.delete(reference);
-          }
-        return key;
+              arrayRoot.append(referencedFormDataKey, reference[i]);
+            response.data.delete(value);
+            response.keyPointer++;
+          } else if (value.startsWith(obj)) break;
+          else response.keyPointer++;
+        }
+        return arrayRoot;
       case "i":
         return (
           (arrayRoot = value.slice(2)),
@@ -3115,7 +3123,7 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
-          response._formData.get(response._prefix + obj)
+          response._formData.data.get(response._prefix + obj)
         );
     }
     switch (value[1]) {
@@ -3145,7 +3153,7 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
-    _formData: backingFormData,
+    _formData: { data: backingFormData, keyPointer: -1, keys: null },
     _chunks: chunks,
     _temporaryReferences: temporaryReferences,
     _rootArrayContexts: new WeakMap(),
@@ -3153,14 +3161,19 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
   };
 }
 function resolveField(response, key, value) {
-  response._formData.append(key, value);
-  var prefix = response._prefix;
-  if (key.startsWith(prefix)) {
-    var chunks = response._chunks;
-    key = +key.slice(prefix.length);
-    (chunks = chunks.get(key)) &&
-      resolveModelChunk(response, chunks, value, key);
-  }
+  var backingStore = response._formData;
+  backingStore.data.append(key, value);
+  var keys = backingStore.keys;
+  null === keys
+    ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+      (backingStore.keyPointer = 0))
+    : keys.push(key);
+  keys = response._prefix;
+  key.startsWith(keys) &&
+    ((backingStore = response._chunks),
+    (key = +key.slice(keys.length)),
+    (backingStore = backingStore.get(key)) &&
+      resolveModelChunk(response, backingStore, value, key));
 }
 function close(response) {
   reportGlobalError(response, Error("Connection closed."));
@@ -3289,6 +3302,43 @@ exports.decodeReply = function (body, webpackMap, options) {
   return webpackMap;
 };
 exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
+  function flush() {
+    for (; null !== head; ) {
+      var current = head;
+      if (!current.complete) return;
+      try {
+        var key = current.name,
+          handle = current.file,
+          blob = new Blob(handle.chunks, { type: handle.mime }),
+          backingStore = response._formData,
+          key$jscomp$0 = key;
+        backingStore.data.append(key$jscomp$0, blob, handle.filename);
+        var keys = backingStore.keys;
+        null === keys
+          ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+            (backingStore.keyPointer = 0))
+          : keys.push(key$jscomp$0);
+        var queuedFields = current.queuedFields;
+        if (null !== queuedFields)
+          for (
+            key$jscomp$0 = 0;
+            key$jscomp$0 < queuedFields.length;
+            key$jscomp$0 += 2
+          )
+            resolveField(
+              response,
+              queuedFields[key$jscomp$0],
+              queuedFields[key$jscomp$0 + 1]
+            );
+      } catch (error) {
+        busboyStream.destroy(error);
+        return;
+      }
+      head = current.next;
+    }
+    tail = null;
+    bodyFinished && !closed && ((closed = !0), close(response));
+  }
   var response = createResponse(
       webpackMap,
       "",
@@ -3296,10 +3346,14 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
       void 0,
       options ? options.arraySizeLimit : void 0
     ),
-    pendingFiles = 0,
-    queuedFields = [];
+    head = null,
+    tail = null,
+    bodyFinished = !1,
+    closed = !1;
   busboyStream.on("field", function (name, value) {
-    if (0 < pendingFiles) queuedFields.push(name, value);
+    if (null !== tail)
+      null === tail.queuedFields && (tail.queuedFields = []),
+        tail.queuedFields.push(name, value);
     else
       try {
         resolveField(response, name, value);
@@ -3317,35 +3371,40 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
         )
       );
     else {
-      pendingFiles++;
-      var JSCompiler_object_inline_chunks_229 = [];
+      var file = { chunks: [], filename: filename, mime: mimeType },
+        pendingFile = {
+          name: name,
+          file: file,
+          complete: !1,
+          queuedFields: null,
+          next: null
+        };
+      null === tail ? (head = pendingFile) : (tail.next = pendingFile);
+      tail = pendingFile;
       value.on("data", function (chunk) {
-        JSCompiler_object_inline_chunks_229.push(chunk);
-      });
-      value.on("end", function () {
         try {
-          var blob = new Blob(JSCompiler_object_inline_chunks_229, {
-            type: mimeType
-          });
-          response._formData.append(name, blob, filename);
-          pendingFiles--;
-          if (0 === pendingFiles) {
-            for (blob = 0; blob < queuedFields.length; blob += 2)
-              resolveField(
-                response,
-                queuedFields[blob],
-                queuedFields[blob + 1]
-              );
-            queuedFields.length = 0;
-          }
+          file.chunks.push(chunk);
         } catch (error) {
           busboyStream.destroy(error);
         }
       });
+      value.on("error", function (error) {
+        busboyStream.destroy(error);
+      });
+      value.on("end", function () {
+        pendingFile.complete = !0;
+        flush();
+      });
     }
   });
   busboyStream.on("finish", function () {
-    close(response);
+    bodyFinished = !0;
+    flush();
+    closed ||
+      reportGlobalError(
+        response,
+        Error("Reply finished with incomplete file part.")
+      );
   });
   busboyStream.on("error", function (err) {
     reportGlobalError(response, err);

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -2862,7 +2862,7 @@
       var chunks = response._chunks,
         chunk = chunks.get(id);
       chunk ||
-        ((chunk = response._formData.get(response._prefix + id)),
+        ((chunk = response._formData.data.get(response._prefix + id)),
         (chunk =
           "string" === typeof chunk
             ? new ReactPromise(
@@ -2972,6 +2972,10 @@
         case "fulfilled":
           id = chunk.value;
           chunk = chunk.reason;
+          if (null !== chunk && "error" in chunk)
+            throw Error(
+              "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+            );
           for (
             var localLength = 0,
               rootArrayContexts = response._rootArrayContexts,
@@ -3063,23 +3067,20 @@
     function createMap(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-      response = new Map(model);
       model.$$consumed = !0;
-      return response;
+      return new Map(model);
     }
     function createSet(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-      response = new Set(model);
       model.$$consumed = !0;
-      return response;
+      return new Set(model);
     }
     function extractIterator(response, model) {
       if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
       if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-      response = model[Symbol.iterator]();
       model.$$consumed = !0;
-      return response;
+      return model[Symbol.iterator]();
     }
     function createModel(response, model, parentObject, key) {
       return "then" === key && "function" === typeof model ? null : model;
@@ -3117,7 +3118,7 @@
           Error("Already initialized typed array.")
         )
       );
-      reference = response._formData.get(key).arrayBuffer();
+      reference = response._formData.data.get(key).arrayBuffer();
       if (initializingHandler) {
         var handler = initializingHandler;
         handler.deps++;
@@ -3161,7 +3162,7 @@
       var chunks = response._chunks;
       stream = new ReactPromise("fulfilled", stream, controller);
       chunks.set(id, stream);
-      response = response._formData.getAll(response._prefix + id);
+      response = response._formData.data.getAll(response._prefix + id);
       for (id = 0; id < response.length; id++)
         (chunks = response[id]),
           "string" === typeof chunks &&
@@ -3381,24 +3382,33 @@
               getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
             );
           case "K":
-            obj = value.slice(2);
-            obj = response._prefix + obj + "_";
-            key = new FormData();
-            response = response._formData;
-            arrayRoot = Array.from(response.keys());
-            for (value = 0; value < arrayRoot.length; value++)
-              if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+            key = value.slice(2);
+            obj = response._prefix + "_";
+            key = obj + key + "_";
+            arrayRoot = new FormData();
+            for (response = response._formData; ; ) {
+              value = response;
+              reference = value.keys;
+              null === reference &&
+                ((reference = value.keys = Array.from(value.data.keys())),
+                (value.keyPointer = 0));
+              value = reference[value.keyPointer];
+              if (void 0 === value) break;
+              if (value.startsWith(key)) {
+                reference = response.data.getAll(value);
                 for (
-                  var entries = response.getAll(reference),
-                    newKey = reference.slice(obj.length),
-                    j = 0;
-                  j < entries.length;
-                  j++
+                  var referencedFormDataKey = value.slice(key.length), i = 0;
+                  i < reference.length;
+                  i++
                 )
-                  key.append(newKey, entries[j]);
-                response.delete(reference);
-              }
-            return key;
+                  arrayRoot.append(referencedFormDataKey, reference[i]);
+                reference = response;
+                reference.data.delete(value);
+                reference.keyPointer++;
+              } else if (value.startsWith(obj)) break;
+              else response.keyPointer++;
+            }
+            return arrayRoot;
           case "i":
             return (
               (arrayRoot = value.slice(2)),
@@ -3569,7 +3579,7 @@
           case "B":
             return (
               (obj = parseInt(value.slice(2), 16)),
-              response._formData.get(response._prefix + obj)
+              response._formData.data.get(response._prefix + obj)
             );
         }
         switch (value[1]) {
@@ -3610,7 +3620,7 @@
       return {
         _bundlerConfig: bundlerConfig,
         _prefix: formFieldPrefix,
-        _formData: backingFormData,
+        _formData: { data: backingFormData, keyPointer: -1, keys: null },
         _chunks: chunks,
         _temporaryReferences: temporaryReferences,
         _rootArrayContexts: new WeakMap(),
@@ -3618,14 +3628,19 @@
       };
     }
     function resolveField(response, key, value) {
-      response._formData.append(key, value);
-      var prefix = response._prefix;
-      if (key.startsWith(prefix)) {
-        var chunks = response._chunks;
-        key = +key.slice(prefix.length);
-        (chunks = chunks.get(key)) &&
-          resolveModelChunk(response, chunks, value, key);
-      }
+      var backingStore = response._formData;
+      backingStore.data.append(key, value);
+      var keys = backingStore.keys;
+      null === keys
+        ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+          (backingStore.keyPointer = 0))
+        : keys.push(key);
+      keys = response._prefix;
+      key.startsWith(keys) &&
+        ((backingStore = response._chunks),
+        (key = +key.slice(keys.length)),
+        (backingStore = backingStore.get(key)) &&
+          resolveModelChunk(response, backingStore, value, key));
     }
     function close(response) {
       reportGlobalError(response, Error("Connection closed."));
@@ -4245,20 +4260,58 @@
       webpackMap,
       options
     ) {
-      var response = createResponse(
+      function flush() {
+        for (; null !== head; ) {
+          var current = head;
+          if (!current.complete) return;
+          try {
+            var response = response$jscomp$0,
+              key = current.name,
+              handle = current.file,
+              blob = new Blob(handle.chunks, { type: handle.mime }),
+              backingStore = response._formData;
+            response = key;
+            backingStore.data.append(response, blob, handle.filename);
+            var keys = backingStore.keys;
+            null === keys
+              ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+                (backingStore.keyPointer = 0))
+              : keys.push(response);
+            var queuedFields = current.queuedFields;
+            if (null !== queuedFields)
+              for (response = 0; response < queuedFields.length; response += 2)
+                resolveField(
+                  response$jscomp$0,
+                  queuedFields[response],
+                  queuedFields[response + 1]
+                );
+          } catch (error) {
+            busboyStream.destroy(error);
+            return;
+          }
+          head = current.next;
+        }
+        tail = null;
+        bodyFinished && !closed && ((closed = !0), close(response$jscomp$0));
+      }
+      var response$jscomp$0 = createResponse(
           webpackMap,
           "",
           options ? options.temporaryReferences : void 0,
           void 0,
           options ? options.arraySizeLimit : void 0
         ),
-        pendingFiles = 0,
-        queuedFields = [];
+        head = null,
+        tail = null,
+        bodyFinished = !1,
+        closed = !1;
       busboyStream.on("field", function (name, value) {
-        if (0 < pendingFiles) queuedFields.push(name, value);
+        if (null !== tail)
+          null === tail.queuedFields && (tail.queuedFields = []),
+            tail.queuedFields.push(name, value);
         else
           try {
-            resolveField(response, name, value);
+            resolveField(response$jscomp$0, name, value);
           } catch (error) {
             busboyStream.destroy(error);
           }
@@ -4273,40 +4326,45 @@
             )
           );
         else {
-          pendingFiles++;
-          var JSCompiler_object_inline_chunks_149 = [];
+          var file = { chunks: [], filename: filename, mime: mimeType },
+            pendingFile = {
+              name: name,
+              file: file,
+              complete: !1,
+              queuedFields: null,
+              next: null
+            };
+          null === tail ? (head = pendingFile) : (tail.next = pendingFile);
+          tail = pendingFile;
           value.on("data", function (chunk) {
-            JSCompiler_object_inline_chunks_149.push(chunk);
-          });
-          value.on("end", function () {
             try {
-              var blob = new Blob(JSCompiler_object_inline_chunks_149, {
-                type: mimeType
-              });
-              response._formData.append(name, blob, filename);
-              pendingFiles--;
-              if (0 === pendingFiles) {
-                for (blob = 0; blob < queuedFields.length; blob += 2)
-                  resolveField(
-                    response,
-                    queuedFields[blob],
-                    queuedFields[blob + 1]
-                  );
-                queuedFields.length = 0;
-              }
+              file.chunks.push(chunk);
             } catch (error) {
               busboyStream.destroy(error);
             }
           });
+          value.on("error", function (error) {
+            busboyStream.destroy(error);
+          });
+          value.on("end", function () {
+            pendingFile.complete = !0;
+            flush();
+          });
         }
       });
       busboyStream.on("finish", function () {
-        close(response);
+        bodyFinished = !0;
+        flush();
+        closed ||
+          reportGlobalError(
+            response$jscomp$0,
+            Error("Reply finished with incomplete file part.")
+          );
       });
       busboyStream.on("error", function (err) {
-        reportGlobalError(response, err);
+        reportGlobalError(response$jscomp$0, err);
       });
-      return getChunk(response, 0);
+      return getChunk(response$jscomp$0, 0);
     };
     exports.registerClientReference = function (
       proxyImplementation,

--- a/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/src/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -2410,7 +2410,7 @@ function getChunk(response, id) {
   var chunks = response._chunks,
     chunk = chunks.get(id);
   chunk ||
-    ((chunk = response._formData.get(response._prefix + id)),
+    ((chunk = response._formData.data.get(response._prefix + id)),
     (chunk =
       "string" === typeof chunk
         ? createResolvedModelChunk(response, chunk, id)
@@ -2509,6 +2509,10 @@ function getOutlinedModel(
     case "fulfilled":
       id = chunk.value;
       chunk = chunk.reason;
+      if (null !== chunk && "error" in chunk)
+        throw Error(
+          "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React."
+        );
       for (
         var localLength = 0,
           rootArrayContexts = response._rootArrayContexts,
@@ -2591,23 +2595,20 @@ function getOutlinedModel(
 function createMap(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Map initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Map.");
-  response = new Map(model);
   model.$$consumed = !0;
-  return response;
+  return new Map(model);
 }
 function createSet(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Set initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Set.");
-  response = new Set(model);
   model.$$consumed = !0;
-  return response;
+  return new Set(model);
 }
 function extractIterator(response, model) {
   if (!isArrayImpl(model)) throw Error("Invalid Iterator initializer.");
   if (!0 === model.$$consumed) throw Error("Already initialized Iterator.");
-  response = model[Symbol.iterator]();
   model.$$consumed = !0;
-  return response;
+  return model[Symbol.iterator]();
 }
 function createModel(response, model, parentObject, key) {
   return "then" === key && "function" === typeof model ? null : model;
@@ -2645,7 +2646,7 @@ function parseTypedArray(
       Error("Already initialized typed array.")
     )
   );
-  reference = response._formData.get(key).arrayBuffer();
+  reference = response._formData.data.get(key).arrayBuffer();
   if (initializingHandler) {
     var handler = initializingHandler;
     handler.deps++;
@@ -2689,7 +2690,7 @@ function resolveStream(response, id, stream, controller) {
   var chunks = response._chunks;
   stream = new ReactPromise("fulfilled", stream, controller);
   chunks.set(id, stream);
-  response = response._formData.getAll(response._prefix + id);
+  response = response._formData.data.getAll(response._prefix + id);
   for (id = 0; id < response.length; id++)
     (chunks = response[id]),
       "string" === typeof chunks &&
@@ -2904,24 +2905,31 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
           getOutlinedModel(response, arrayRoot, obj, key, null, createSet)
         );
       case "K":
-        obj = value.slice(2);
-        obj = response._prefix + obj + "_";
-        key = new FormData();
-        response = response._formData;
-        arrayRoot = Array.from(response.keys());
-        for (value = 0; value < arrayRoot.length; value++)
-          if (((reference = arrayRoot[value]), reference.startsWith(obj))) {
+        key = value.slice(2);
+        obj = response._prefix + "_";
+        key = obj + key + "_";
+        arrayRoot = new FormData();
+        for (response = response._formData; ; ) {
+          value = response.keys;
+          null === value &&
+            ((value = response.keys = Array.from(response.data.keys())),
+            (response.keyPointer = 0));
+          value = value[response.keyPointer];
+          if (void 0 === value) break;
+          if (value.startsWith(key)) {
+            reference = response.data.getAll(value);
             for (
-              var entries = response.getAll(reference),
-                newKey = reference.slice(obj.length),
-                j = 0;
-              j < entries.length;
-              j++
+              var referencedFormDataKey = value.slice(key.length), i = 0;
+              i < reference.length;
+              i++
             )
-              key.append(newKey, entries[j]);
-            response.delete(reference);
-          }
-        return key;
+              arrayRoot.append(referencedFormDataKey, reference[i]);
+            response.data.delete(value);
+            response.keyPointer++;
+          } else if (value.startsWith(obj)) break;
+          else response.keyPointer++;
+        }
+        return arrayRoot;
       case "i":
         return (
           (arrayRoot = value.slice(2)),
@@ -3082,7 +3090,7 @@ function parseModelString(response, obj, key, value, reference, arrayRoot) {
       case "B":
         return (
           (obj = parseInt(value.slice(2), 16)),
-          response._formData.get(response._prefix + obj)
+          response._formData.data.get(response._prefix + obj)
         );
     }
     switch (value[1]) {
@@ -3112,7 +3120,7 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
   return {
     _bundlerConfig: bundlerConfig,
     _prefix: formFieldPrefix,
-    _formData: backingFormData,
+    _formData: { data: backingFormData, keyPointer: -1, keys: null },
     _chunks: chunks,
     _temporaryReferences: temporaryReferences,
     _rootArrayContexts: new WeakMap(),
@@ -3120,14 +3128,19 @@ function createResponse(bundlerConfig, formFieldPrefix, temporaryReferences) {
   };
 }
 function resolveField(response, key, value) {
-  response._formData.append(key, value);
-  var prefix = response._prefix;
-  if (key.startsWith(prefix)) {
-    var chunks = response._chunks;
-    key = +key.slice(prefix.length);
-    (chunks = chunks.get(key)) &&
-      resolveModelChunk(response, chunks, value, key);
-  }
+  var backingStore = response._formData;
+  backingStore.data.append(key, value);
+  var keys = backingStore.keys;
+  null === keys
+    ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+      (backingStore.keyPointer = 0))
+    : keys.push(key);
+  keys = response._prefix;
+  key.startsWith(keys) &&
+    ((backingStore = response._chunks),
+    (key = +key.slice(keys.length)),
+    (backingStore = backingStore.get(key)) &&
+      resolveModelChunk(response, backingStore, value, key));
 }
 function close(response) {
   reportGlobalError(response, Error("Connection closed."));
@@ -3256,6 +3269,43 @@ exports.decodeReply = function (body, webpackMap, options) {
   return webpackMap;
 };
 exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
+  function flush() {
+    for (; null !== head; ) {
+      var current = head;
+      if (!current.complete) return;
+      try {
+        var key = current.name,
+          handle = current.file,
+          blob = new Blob(handle.chunks, { type: handle.mime }),
+          backingStore = response._formData,
+          key$jscomp$0 = key;
+        backingStore.data.append(key$jscomp$0, blob, handle.filename);
+        var keys = backingStore.keys;
+        null === keys
+          ? ((backingStore.keys = Array.from(backingStore.data.keys())),
+            (backingStore.keyPointer = 0))
+          : keys.push(key$jscomp$0);
+        var queuedFields = current.queuedFields;
+        if (null !== queuedFields)
+          for (
+            key$jscomp$0 = 0;
+            key$jscomp$0 < queuedFields.length;
+            key$jscomp$0 += 2
+          )
+            resolveField(
+              response,
+              queuedFields[key$jscomp$0],
+              queuedFields[key$jscomp$0 + 1]
+            );
+      } catch (error) {
+        busboyStream.destroy(error);
+        return;
+      }
+      head = current.next;
+    }
+    tail = null;
+    bodyFinished && !closed && ((closed = !0), close(response));
+  }
   var response = createResponse(
       webpackMap,
       "",
@@ -3263,10 +3313,14 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
       void 0,
       options ? options.arraySizeLimit : void 0
     ),
-    pendingFiles = 0,
-    queuedFields = [];
+    head = null,
+    tail = null,
+    bodyFinished = !1,
+    closed = !1;
   busboyStream.on("field", function (name, value) {
-    if (0 < pendingFiles) queuedFields.push(name, value);
+    if (null !== tail)
+      null === tail.queuedFields && (tail.queuedFields = []),
+        tail.queuedFields.push(name, value);
     else
       try {
         resolveField(response, name, value);
@@ -3284,35 +3338,40 @@ exports.decodeReplyFromBusboy = function (busboyStream, webpackMap, options) {
         )
       );
     else {
-      pendingFiles++;
-      var JSCompiler_object_inline_chunks_229 = [];
+      var file = { chunks: [], filename: filename, mime: mimeType },
+        pendingFile = {
+          name: name,
+          file: file,
+          complete: !1,
+          queuedFields: null,
+          next: null
+        };
+      null === tail ? (head = pendingFile) : (tail.next = pendingFile);
+      tail = pendingFile;
       value.on("data", function (chunk) {
-        JSCompiler_object_inline_chunks_229.push(chunk);
-      });
-      value.on("end", function () {
         try {
-          var blob = new Blob(JSCompiler_object_inline_chunks_229, {
-            type: mimeType
-          });
-          response._formData.append(name, blob, filename);
-          pendingFiles--;
-          if (0 === pendingFiles) {
-            for (blob = 0; blob < queuedFields.length; blob += 2)
-              resolveField(
-                response,
-                queuedFields[blob],
-                queuedFields[blob + 1]
-              );
-            queuedFields.length = 0;
-          }
+          file.chunks.push(chunk);
         } catch (error) {
           busboyStream.destroy(error);
         }
       });
+      value.on("error", function (error) {
+        busboyStream.destroy(error);
+      });
+      value.on("end", function () {
+        pendingFile.complete = !0;
+        flush();
+      });
     }
   });
   busboyStream.on("finish", function () {
-    close(response);
+    bodyFinished = !0;
+    flush();
+    closed ||
+      reportGlobalError(
+        response,
+        Error("Reply finished with incomplete file part.")
+      );
   });
   busboyStream.on("error", function (err) {
     reportGlobalError(response, err);

--- a/src/react-server-dom-webpack/package.json
+++ b/src/react-server-dom-webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-server-dom-webpack",
   "description": "React Server Components bindings for DOM using Webpack. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly.",
-  "version": "19.0.4",
+  "version": "19.0.7",
   "keywords": [
     "react"
   ],
@@ -99,8 +99,8 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^19.0.4",
-    "react-dom": "^19.0.4",
+    "react": "^19.0.7",
+    "react-dom": "^19.0.7",
     "webpack": "^5.59.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Brings the vendored `react-server-dom-webpack` runtime (`src/react-server-dom-webpack/`) from the 19.0.4 security level up to **19.0.7**, picking up the two 2026 React Server Components reply-decoding DoS fixes:

- **CVE-2026-23869** ([GHSA-479c-33wc-g2pg](https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg)) — vulnerable `>=19.0.0 <19.0.5`, patched upstream in 19.0.5
- **CVE-2026-23870** ([GHSA-rv78-f8rc-xrxh](https://github.com/facebook/react/security/advisories/GHSA-rv78-f8rc-xrxh)) — vulnerable `>=19.0.0 <19.0.6`, patched upstream in 19.0.6

## Approach

Per the #55 spike decision, the vendored runtime is slated for replacement with stock npm `react-server-dom-webpack` in #60 — but that migration has not started, so this is the interim fix. Instead of rebasing the `abanoubghadban/react` fork patches onto a newer upstream commit, this applies the **full npm 19.0.4 → 19.0.7 built-artifact diff** (extracted via `npm pack`) directly to the vendored cjs files, mirroring how dc4dfb4/867634f previously patched built artifacts in place.

The 19.0.x line is security-only, so the entire diff is the reply-decode hardening (FormData access wrapper with key-pointer scanning, form-field prefix separator change, "initialized stream chunk" guard, `$$consumed` ordering) plus version strings. 16 of 17 hunk sets applied cleanly with `patch`; the one reject (DevTools registration block in `client.browser.development.js`, where the fork sets `rendererPackageName: "react-on-rails-rsc"`) was applied by hand preserving the fork value.

**Delta-preservation check:** for every vendored cjs file, `diff(stock 19.0.7, vendored-after)` is byte-identical to `diff(stock 19.0.4, vendored-before)` — i.e. the runtime is now exactly stock 19.0.7 plus the pre-existing in-repo deltas (Flight CSS hint emission from dc4dfb4/867634f/8781f08, and the fork's bound-args + `rendererPackageName` changes). Nothing else moved.

The vendored `package.json` (previously byte-identical to stock 19.0.4) takes the stock 19.0.7 version/peerDeps bump; it is internal to the shipped package and not resolved by npm. The outer package's peerDependencies are untouched (that belongs to #60). `esm/` only contains the node loader, which is unchanged between 19.0.4 and 19.0.7.

## Relationship to #60

This does **not** close #60 — it is the stopgap that keeps released artifacts off the vulnerable runtime until the stock-npm migration lands. If #60 lands soon, this diff is simply deleted along with the vendored tree.

## Test plan

- `yarn build` — passes (tsc clean)
- `yarn test` — 17 suites / 158 tests pass (matches baseline)
- `NODE_CONDITIONS=react-server yarn jest tests/react-flight-client-reference-css.rsc.test.ts` — passes (FOUC CSS Flight-hint behavior from dc4dfb4/867634f preserved)
- Hardening markers present post-patch: `_formData.data.get` and the "initialized stream chunk" guard now appear in the vendored server builds (previously 0 hits)

## Deployment note (split client/server rollout)

The CVE-2026-23869 fix changes the reply wire format for nested `FormData`: field keys gain a `"_"` separator between the form-field prefix and the part ID. Client (`encodeReply`) and server (`decodeReply`/`decodeReplyFromBusboy`) are updated in lock-step in this PR, but operators who cache or CDN-serve client JS separately from the server runtime should deploy both together — a pre-19.0.5 runtime on either side silently drops nested `FormData` entries (no error). Plain values, Maps, Sets, and non-nested forms are unaffected. This is also noted in the CHANGELOG entry.

## Post-review smoke test (nested FormData round-trip)

Per review suggestion, verified the patched `$K` path end-to-end against the built `dist/` runtime (`node --conditions=react-server`): `encodeReply([FormData, 'plain', FormData, Map, Set])` from `client.browser` emits the new wire format (`_1_alpha`, `_1_beta`, `_2_gamma` — leading `_` separator present), and `decodeReply` from `server.node` reconstructs both nested `FormData` objects with all entries plus the Map/Set/plain values intact:

```
wire keys: ["_1_alpha","_1_beta","_2_gamma","3","4","0"]
decoded fd1: {"alpha":"one","beta":"two"}
decoded fd2: {"gamma":"three"}
SMOKE TEST PASS: nested FormData round-trips through patched 19.0.7 runtime
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-critical RSC reply decoding and a breaking nested FormData wire format; mismatched client/server versions can lose data without errors.
> 
> **Overview**
> Bumps the vendored **react-server-dom-webpack** runtime from **19.0.4** to **19.0.7**, bringing in upstream reply-decoding hardening for **CVE-2026-23869** and **CVE-2026-23870** (DoS in RSC reply parsing). The **CHANGELOG** documents the security fix and a deployment caveat for nested **FormData**.
> 
> **Client** `encodeReply` now prefixes nested FormData field keys with an extra `_` (`prefix + "_" + key + "_"` instead of `prefix + key + "_"`). **Server** `decodeReply` paths wrap backing FormData in `{ data, keyPointer, keys }`, scan keys with a pointer instead of materializing all keys at once, add an “initialized stream chunk” guard on fulfilled chunks, and rework **`decodeReplyFromBusboy`** to queue file parts in order before flushing. Version strings and the vendored **package.json** move to **19.0.7** / `^19.0.7` peers.
> 
> **Client and server must ship together** on this package; mixing with pre-19.0.5 runtimes can silently drop nested FormData entries. In-repo fork deltas (e.g. Flight CSS hints, `rendererPackageName: "react-on-rails-rsc"`) are preserved per the PR approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25bba9f8d9e78819dc1c463dec0a5e3f1dbc756c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->