### PR TITLE
Allow artifact verifier to accept covering root peer ranges

### DIFF
--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -247,8 +247,46 @@ function assertEqual(actual, expected, label) {
   }
 }
 
-assertEqual(rootPackage.peerDependencies?.react, expectedPeerRange, 'root peerDependencies.react');
-assertEqual(rootPackage.peerDependencies?.['react-dom'], expectedPeerRange, 'root peerDependencies.react-dom');
+function parseVersion(version, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    throw new Error(`${label} expected X.Y.Z, got ${version}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareVersions(a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+function assertCaretRangeIncludesVersion(range, version, label) {
+  const match = /^\^(\d+\.\d+\.\d+)$/.exec(range || '');
+  if (!match) {
+    throw new Error(`${label} expected a caret X.Y.Z range that includes ${version}, got ${range}`);
+  }
+
+  const minimum = parseVersion(match[1], label);
+  const target = parseVersion(version, 'runtime version');
+  if (minimum.major !== target.major || compareVersions(minimum, target) > 0) {
+    throw new Error(`${label} ${range} does not include vendored runtime ${version}`);
+  }
+}
+
+assertCaretRangeIncludesVersion(
+  rootPackage.peerDependencies?.react,
+  runtimeVersion,
+  'root peerDependencies.react'
+);
+assertCaretRangeIncludesVersion(
+  rootPackage.peerDependencies?.['react-dom'],
+  runtimeVersion,
+  'root peerDependencies.react-dom'
+);
 assertEqual(runtimePackage.peerDependencies?.react, expectedPeerRange, 'runtime peerDependencies.react');
 assertEqual(runtimePackage.peerDependencies?.['react-dom'], expectedPeerRange, 'runtime peerDependencies.react-dom');
 
@@ -266,7 +304,9 @@ for (const marker of [`version: "${runtimeVersion}"`, `reconcilerVersion: "${run
   }
 }
 
-console.log(`  - Runtime version ${runtimeVersion} matches peer policy ${expectedPeerRange}`);
+console.log(
+  `  - Runtime version ${runtimeVersion} is included by root peers and matches runtime peer policy ${expectedPeerRange}`
+);
 NODE
 
 log "Verifying embedded React runtime version policy"


### PR DESCRIPTION
## Summary

Fixes the artifact verification gate after #86 updated the vendored react-server-dom-webpack runtime to 19.0.7 while intentionally leaving the public root React peers at ^19.0.4.

The verifier now:
- requires the root React and React DOM peer ranges to be caret ranges that include the vendored runtime version
- still requires the vendored runtime package peers to match the exact runtime version policy

## Merge Criteria

- Full GitHub check list is green, not only required checks
- Review threads are resolved or explicitly triaged
- mergeStateStatus is CLEAN / mergeable is MERGEABLE
- This PR restores the artifact gate on current main; it performs no publish, tag, release, or registry mutation

## Verification

- yarn install --frozen-lockfile
- yarn verify:artifacts
- yarn build
- git diff --check

Fixes the red artifact-checks gate introduced by the #77/#86 interaction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only release/CI verification logic in `verify-release.sh` changes; no runtime, publish, or consumer install behavior is modified.
> 
> **Overview**
> **Relaxes root peer version checks** in the artifact verifier so `react` and `react-dom` no longer must equal `^${vendoredRuntimeVersion}` exactly. They must still be caret `X.Y.Z` ranges on the same major whose minimum is not above the vendored runtime (e.g. `^19.0.4` passes when the bundle ships `19.0.7`).
> 
> **Vendored runtime peer policy is unchanged**: the embedded `react-server-dom-webpack` package still must declare peers exactly `^${runtimeVersion}`, and the development bundle must still embed matching `version` / `reconcilerVersion` markers. The success log now states that the runtime is covered by root peers and aligned with runtime peers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5615b2f1f96691c1ae059e0d2a681a82c03c1177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->