### PR TITLE
Add downstream Pro dummy release gate

### DIFF
--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           ruby-version: ${{ steps.downstream-versions.outputs.ruby-version }}
           working-directory: react_on_rails/react_on_rails_pro/spec/dummy
-          bundler-cache: false
+          bundler-cache: true
 
       - name: Setup Node
         # Pinned immutable actions/setup-node@v4 release SHA verified via git ls-remote.

--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -31,7 +31,6 @@ jobs:
     env:
       REACT_ON_RAILS_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.react_on_rails_ref || 'main' }}
       RSC_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.rsc_ref || github.ref }}
-      RSC_DOWNSTREAM_KEEP: '1'
       RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS: '1'
     steps:
       - name: Check out react-on-rails-rsc

--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -1,0 +1,111 @@
+name: Downstream E2E (React on Rails Pro dummy)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      react_on_rails_ref:
+        description: React on Rails ref to test
+        required: false
+        type: string
+        default: main
+      rsc_ref:
+        description: react_on_rails_rsc ref to test (defaults to the dispatch ref)
+        required: false
+        type: string
+        default: ''
+  schedule:
+    - cron: '37 11 * * *'
+
+concurrency:
+  group: downstream-e2e-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pro-dummy-rsc-playwright:
+    name: Pro dummy RSC Playwright subset
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      REACT_ON_RAILS_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.react_on_rails_ref || 'main' }}
+      RSC_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.rsc_ref || github.ref }}
+      RSC_DOWNSTREAM_KEEP: '1'
+      RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS: '1'
+    steps:
+      - name: Check out react-on-rails-rsc
+        # Pinned immutable actions/checkout@v5 release SHA verified via git ls-remote.
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          ref: ${{ env.RSC_REF }}
+          persist-credentials: false
+
+      - name: Check out React on Rails
+        # Pinned immutable actions/checkout@v5 release SHA verified via git ls-remote.
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          repository: shakacode/react_on_rails
+          ref: ${{ env.REACT_ON_RAILS_REF }}
+          path: react_on_rails
+          persist-credentials: false
+
+      - name: Read downstream runtime versions
+        id: downstream-versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "ruby-version=$(react_on_rails/bin/read-tool-version react_on_rails/.minimum.tool-versions ruby)"
+            echo "node-version=$(react_on_rails/bin/read-tool-version react_on_rails/.tool-versions nodejs)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Ruby
+        # Pinned immutable ruby/setup-ruby@v1.313.0 release SHA verified via git ls-remote.
+        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af
+        with:
+          ruby-version: ${{ steps.downstream-versions.outputs.ruby-version }}
+          working-directory: react_on_rails/react_on_rails_pro/spec/dummy
+          bundler-cache: false
+
+      - name: Setup Node
+        # Pinned immutable actions/setup-node@v4 release SHA verified via git ls-remote.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: ${{ steps.downstream-versions.outputs.node-version }}
+
+      - name: Enable package managers
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          corepack prepare "$(node -p "require('./react_on_rails/package.json').packageManager")" --activate
+          echo "Node: $(node --version)"
+          echo "Yarn: $(yarn --version)"
+          echo "pnpm: $(pnpm --version)"
+          echo "Ruby: $(ruby --version)"
+          echo "Bundler: $(bundle --version)"
+
+      - name: Install react-on-rails-rsc dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Run downstream RSC E2E
+        env:
+          RSC_DOWNSTREAM_WORK_DIR: ${{ runner.temp }}/react-on-rails-rsc-downstream
+        run: |
+          bash scripts/e2e/downstream.sh \
+            --react-on-rails-dir react_on_rails \
+            --react-on-rails-ref "$REACT_ON_RAILS_REF"
+
+      - name: Upload downstream logs
+        # Pinned immutable actions/upload-artifact@v4 release SHA verified via git ls-remote.
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: downstream-rsc-e2e-logs
+          path: |
+            ${{ runner.temp }}/react-on-rails-rsc-downstream/logs
+            react_on_rails/react_on_rails_pro/spec/dummy/test-results
+            react_on_rails/react_on_rails_pro/spec/dummy/playwright-report
+          if-no-files-found: ignore

--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -55,9 +55,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          rortv="react_on_rails/bin/read-tool-version"
+          if [[ ! -x "$rortv" ]]; then
+            echo "::error::Expected $rortv not found in the downstream checkout." >&2
+            exit 1
+          fi
           {
-            echo "ruby-version=$(react_on_rails/bin/read-tool-version react_on_rails/.minimum.tool-versions ruby)"
-            echo "node-version=$(react_on_rails/bin/read-tool-version react_on_rails/.tool-versions nodejs)"
+            echo "ruby-version=$("$rortv" react_on_rails/.minimum.tool-versions ruby)"
+            echo "node-version=$("$rortv" react_on_rails/.tool-versions nodejs)"
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
@@ -83,7 +88,9 @@ jobs:
           corepack prepare "$(node -p "require('./react_on_rails/package.json').packageManager")" --activate
           echo "Node: $(node --version)"
           echo "Yarn: $(yarn --version)"
-          echo "pnpm: $(pnpm --version)"
+          if command -v pnpm >/dev/null 2>&1; then
+            echo "pnpm: $(pnpm --version)"
+          fi
           echo "Ruby: $(ruby --version)"
           echo "Bundler: $(bundle --version)"
 

--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -20,7 +20,7 @@ on:
     - cron: '37 11 * * *'
 
 concurrency:
-  group: downstream-e2e-${{ github.event_name }}-${{ github.ref }}
+  group: downstream-e2e-${{ github.event_name }}-${{ github.ref }}-${{ inputs.rsc_ref || github.ref }}-${{ inputs.react_on_rails_ref || 'main' }}
   cancel-in-progress: false
 
 jobs:
@@ -59,6 +59,8 @@ jobs:
             echo "::error::Expected $rortv not found in the downstream checkout." >&2
             exit 1
           fi
+          # Ruby intentionally runs at the downstream minimum supported version;
+          # Node uses the downstream exact toolchain version for JS build parity.
           {
             echo "ruby-version=$("$rortv" react_on_rails/.minimum.tool-versions ruby)"
             echo "node-version=$("$rortv" react_on_rails/.tool-versions nodejs)"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,11 +37,12 @@ Tags in this repository do not use a `v` prefix. For example, use
 
 - The npm `latest` dist-tag moves only on final releases from `main`, after the
   downstream React on Rails release gate has accepted the candidate. That gate
-  is the rollout PR in
+  is the `Downstream E2E (React on Rails Pro dummy)` workflow in this repository
+  and, when a React on Rails rollout branch is needed, the rollout PR in
   [shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) that
   pins `react-on-rails-rsc@X.Y.Z-rc.N` and confirms the downstream app release
-  path is ready. `latest` must not advance until that rollout PR is merged to
-  `main` in `react_on_rails`.
+  path is ready. `latest` must not advance until the workflow is green for the
+  candidate and any required rollout PR is merged to `main` in `react_on_rails`.
 
 ## Prerequisites
 
@@ -106,7 +107,45 @@ readiness without publishing. In dry-run mode, missing npm or GitHub auth is a
 warning instead of a release blocker, and no npm publish, git tag, tag push, or
 GitHub release is created.
 
-### 3. Publish From GitHub Actions
+### 3. Run The Downstream React On Rails Gate
+
+Before promoting a candidate to `latest`, dispatch `Downstream E2E (React on
+Rails Pro dummy)` from GitHub Actions. Use these inputs:
+
+1. `rsc_ref`: the `react_on_rails_rsc` candidate ref to test. Use the release
+   candidate tag, release branch, or exact SHA.
+2. `react_on_rails_ref`: the downstream React on Rails ref to test. Use `main`
+   by default, or the rollout PR branch when the downstream package pin is being
+   changed there.
+
+The workflow builds and packs this package, installs the tarball into the
+downstream `shakacode/react_on_rails` checkout, builds the Pro dummy app, starts
+the Rails server and Pro node renderer, and runs the maintained RSC Playwright
+subset:
+
+- `e2e-tests/rsc_echo_props.spec.ts`: verifies server-rendered RSC props with
+  special characters while blocking client fallback payload requests, so SSR
+  serialization failures cannot be masked.
+- `e2e-tests/rsc_route_ssr_false.spec.ts`: verifies `RSCRoute ssr={false}`
+  payload fetching, lazy client roots, streamed roots, and that a normal
+  client-rendered page does not load the RSC fetch runtime.
+
+The subset intentionally matches the downstream dummy app's `e2e-test:rsc`
+script. Broader Playwright specs such as streaming, refetch stress, async props,
+and JSON parse race coverage remain downstream React on Rails responsibilities;
+they exercise Pro renderer, Redis, or app-level behavior that is useful but not
+specific to the `react-on-rails-rsc` package boundary.
+
+For local maintainer debugging, run the same gate from this repository:
+
+```bash
+yarn test:e2e:downstream -- --react-on-rails-ref main
+```
+
+The script also accepts `--react-on-rails-dir PATH` for testing an existing
+downstream checkout or rollout branch.
+
+### 4. Publish From GitHub Actions
 
 After the changelog/version PR lands on `main`, open GitHub Actions and run
 `Release package` from the `main` branch.
@@ -140,7 +179,7 @@ Prereleases such as `X.Y.Z-rc.N` publish with the npm `next` dist-tag. Final
 versions publish with `latest`; dispatch a final release only after the
 downstream React on Rails release gate has accepted the candidate.
 
-### 4. Maintainer-Only Local Fallback
+### 5. Maintainer-Only Local Fallback
 
 Use the local publish path only if the GitHub Actions release path is blocked
 and a maintainer explicitly chooses to publish from a trusted workstation:
@@ -159,7 +198,7 @@ The script will:
 6. Run `release-it` to commit any needed version bump, tag, and publish to npm.
 7. Create a GitHub release from the matching `CHANGELOG.md` section.
 
-### 5. Verify
+### 6. Verify
 
 #### Release Artifact Parity Checklist
 
@@ -233,8 +272,10 @@ the exact target version, including any `-rc.N` prerelease suffix.
 
 #### Promote latest after a final release
 
-After checklist items 1-6 pass for a final release and the downstream React on
-Rails rollout PR is merged to `main`, first confirm the current dist-tag state:
+After checklist items 1-6 pass for a final release, the `Downstream E2E (React
+on Rails Pro dummy)` workflow is green for the candidate, and any downstream
+React on Rails rollout PR is merged to `main`, first confirm the current
+dist-tag state:
 
 ```bash
 npm view react-on-rails-rsc dist-tags --json

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:rsc": "NODE_CONDITIONS=react-server jest tests/*.rsc.test.*",
     "test:non-rsc": "jest tests --testPathIgnorePatterns=\".*\\.rsc\\.test\\..*\"",
     "test:e2e": "bash scripts/e2e/run.sh",
+    "test:e2e:downstream": "bash scripts/e2e/downstream.sh",
     "build": "rm -rf dist tsconfig.tsbuildinfo && yarn run tsc",
     "verify:artifacts": "bash scripts/verify-release.sh",
     "prepublishOnly": "yarn run build",

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -121,10 +121,7 @@ cleanup() {
   local status=$?
 
   for pid in "$RAILS_PID" "$NODE_RENDERER_PID"; do
-    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-      kill "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
-    fi
+    kill_process_tree "$pid"
   done
 
   if [[ "$AUTO_WORK_DIR" != "1" ]]; then
@@ -138,6 +135,24 @@ cleanup() {
   exit "$status"
 }
 trap cleanup EXIT
+
+kill_process_tree() {
+  local pid="$1"
+
+  if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+    return
+  fi
+
+  if command -v pgrep >/dev/null 2>&1; then
+    local child_pid
+    while IFS= read -r child_pid; do
+      kill_process_tree "$child_pid"
+    done < <(pgrep -P "$pid" 2>/dev/null || true)
+  fi
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
 
 on_error() {
   local status=$?
@@ -187,7 +202,10 @@ checkout_downstream() {
 
   if [[ -n "$REACT_ON_RAILS_DIR" ]]; then
     REACT_ON_RAILS_DIR="$(cd "$REACT_ON_RAILS_DIR" && pwd)"
-    test -d "$REACT_ON_RAILS_DIR/.git"
+    if [[ ! -e "$REACT_ON_RAILS_DIR/.git" ]]; then
+      echo "Not a git repo or worktree: $REACT_ON_RAILS_DIR" >&2
+      return 1
+    fi
     echo "Using existing checkout: $REACT_ON_RAILS_DIR"
   else
     REACT_ON_RAILS_DIR="$WORK_DIR/react_on_rails"

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -276,7 +276,7 @@ checkout_downstream() {
     else
       git -C "$REACT_ON_RAILS_DIR" remote add origin "$REACT_ON_RAILS_REPO"
     fi
-    git -C "$REACT_ON_RAILS_DIR" fetch --depth 1 origin "$REACT_ON_RAILS_REF"
+    git -C "$REACT_ON_RAILS_DIR" fetch --depth 1 origin -- "$REACT_ON_RAILS_REF"
     git -C "$REACT_ON_RAILS_DIR" checkout --detach FETCH_HEAD
     USING_EXISTING_REACT_ON_RAILS_DIR="0"
   fi

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -400,12 +400,17 @@ wait_for_http() {
   local url="$2"
   local timeout_seconds="${3:-300}"
   local log_path="${4:-$LOG_DIR/rails.log}"
+  local monitor_pid="${5:-}"
   local start_time="$SECONDS"
 
   while true; do
     if curl --fail --silent --max-time 5 "$url" >/dev/null; then
       echo "$name ready at $url after $((SECONDS - start_time))s"
       return 0
+    fi
+
+    if ! ensure_service_process_running "$name" "$monitor_pid" "$log_path"; then
+      return 1
     fi
 
     if ((SECONDS - start_time >= timeout_seconds)); then
@@ -422,6 +427,8 @@ wait_for_h2c() {
   local authority="$2"
   local path="$3"
   local timeout_seconds="${4:-300}"
+  local monitor_pid="${5:-}"
+  local log_path="${6:-$LOG_DIR/node-renderer.log}"
   local start_time="$SECONDS"
 
   while true; do
@@ -460,21 +467,49 @@ NODE
       return 0
     fi
 
+    if ! ensure_service_process_running "$name" "$monitor_pid" "$log_path"; then
+      return 1
+    fi
+
     if ((SECONDS - start_time >= timeout_seconds)); then
       echo "Timed out waiting for $name at $authority$path" >&2
-      tail -100 "$LOG_DIR/node-renderer.log" >&2 || true
+      tail -100 "$log_path" >&2 || true
       return 1
     fi
     sleep 2
   done
 }
 
+ensure_service_process_running() {
+  local name="$1"
+  local pid="$2"
+  local log_path="$3"
+
+  if [[ -z "$pid" ]] || kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "$name process ($pid) exited before becoming ready" >&2
+  tail -100 "$log_path" >&2 || true
+  return 1
+}
+
 wait_for_services() {
   log_step "Waiting for downstream services"
   # /empty is a stable React on Rails Pro dummy route used as a cheap Rails
   # liveness probe without depending on rendered RSC content.
-  wait_for_http "Rails server" "http://127.0.0.1:${RAILS_PORT}${RAILS_READY_PATH}"
-  wait_for_h2c "Node renderer" "http://127.0.0.1:${RENDERER_PORT}" "/info"
+  wait_for_http \
+    "Rails server" \
+    "http://127.0.0.1:${RAILS_PORT}${RAILS_READY_PATH}" \
+    300 \
+    "$LOG_DIR/rails.log" \
+    "$RAILS_PID"
+  wait_for_h2c \
+    "Node renderer" \
+    "http://127.0.0.1:${RENDERER_PORT}" \
+    "/info" \
+    300 \
+    "$NODE_RENDERER_PID"
 }
 
 install_playwright_browsers() {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -210,7 +210,11 @@ checkout_downstream() {
   else
     REACT_ON_RAILS_DIR="$WORK_DIR/react_on_rails"
     git init "$REACT_ON_RAILS_DIR"
-    git -C "$REACT_ON_RAILS_DIR" remote add origin "$REACT_ON_RAILS_REPO"
+    if git -C "$REACT_ON_RAILS_DIR" remote get-url origin >/dev/null 2>&1; then
+      git -C "$REACT_ON_RAILS_DIR" remote set-url origin "$REACT_ON_RAILS_REPO"
+    else
+      git -C "$REACT_ON_RAILS_DIR" remote add origin "$REACT_ON_RAILS_REPO"
+    fi
     git -C "$REACT_ON_RAILS_DIR" fetch --depth 1 origin "$REACT_ON_RAILS_REF"
     git -C "$REACT_ON_RAILS_DIR" checkout --detach FETCH_HEAD
   fi

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -23,6 +23,7 @@ REACT_ON_RAILS_DIR="${RSC_DOWNSTREAM_REACT_ON_RAILS_DIR:-}"
 WORK_DIR="${RSC_DOWNSTREAM_WORK_DIR:-}"
 AUTO_WORK_DIR="0"
 KEEP_WORK_DIR="${RSC_DOWNSTREAM_KEEP:-0}"
+USING_EXISTING_REACT_ON_RAILS_DIR="0"
 DUMMY_BUILD_SCRIPT="${RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT:-$DEFAULT_DUMMY_BUILD_SCRIPT}"
 INSTALL_PLAYWRIGHT="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT:-1}"
 INSTALL_PLAYWRIGHT_DEPS="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS:-0}"
@@ -171,6 +172,14 @@ kill_process_tree() {
   fi
 
   kill "$pid" 2>/dev/null || true
+  local deadline=$((SECONDS + 10))
+  while kill -0 "$pid" 2>/dev/null && ((SECONDS < deadline)); do
+    sleep 1
+  done
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
   wait "$pid" 2>/dev/null || true
 }
 
@@ -245,6 +254,7 @@ checkout_downstream() {
   log_step "Preparing React on Rails checkout"
 
   if [[ -n "$REACT_ON_RAILS_DIR" ]]; then
+    USING_EXISTING_REACT_ON_RAILS_DIR="1"
     REACT_ON_RAILS_DIR="$(cd "$REACT_ON_RAILS_DIR" && pwd)"
     if [[ ! -e "$REACT_ON_RAILS_DIR/.git" ]]; then
       echo "Not a git repo or worktree: $REACT_ON_RAILS_DIR" >&2
@@ -261,6 +271,7 @@ checkout_downstream() {
     fi
     git -C "$REACT_ON_RAILS_DIR" fetch --depth 1 origin "$REACT_ON_RAILS_REF"
     git -C "$REACT_ON_RAILS_DIR" checkout --detach FETCH_HEAD
+    USING_EXISTING_REACT_ON_RAILS_DIR="0"
   fi
 
   DOWNSTREAM_SHA="$(git -C "$REACT_ON_RAILS_DIR" rev-parse HEAD)"
@@ -282,6 +293,11 @@ install_downstream_dependencies() {
   if [[ "$REQUIRE_PRO_LICENSE" == "1" && -z "${REACT_ON_RAILS_PRO_LICENSE:-}" ]]; then
     echo "REACT_ON_RAILS_PRO_LICENSE is required for the Pro dummy app." >&2
     return 1
+  fi
+
+  if [[ "$USING_EXISTING_REACT_ON_RAILS_DIR" == "1" ]]; then
+    echo "Warning: mutating package manifests in existing checkout: $REACT_ON_RAILS_DIR" >&2
+    echo "Restore with: git -C \"$REACT_ON_RAILS_DIR\" checkout -- package.json packages/react-on-rails-pro/package.json react_on_rails_pro/spec/dummy/package.json pnpm-lock.yaml" >&2
   fi
 
   node - "$REACT_ON_RAILS_DIR" "$TARBALL" <<'NODE'

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -525,7 +525,12 @@ ensure_service_process_running() {
   local pid="$2"
   local log_path="$3"
 
-  if [[ -z "$pid" ]] || kill -0 "$pid" 2>/dev/null; then
+  if [[ -z "$pid" ]]; then
+    echo "$name was never started (empty PID)" >&2
+    return 1
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
     return 0
   fi
 
@@ -587,16 +592,21 @@ const decode = (value) =>
     .replace(/&gt;/g, '>')
     .replace(/&amp;/g, '&');
 const failures = [];
-const testcasePattern = /<testcase\b([^>]*)>([\s\S]*?)<\/testcase>/g;
+const testcasePattern =
+  /<testcase\b((?:[^>"']|"[^"]*"|'[^']*')*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
 let match;
 
 while ((match = testcasePattern.exec(xml)) !== null) {
   const attributes = match[1];
-  const body = match[2];
+  const body = match[2] || '';
   if (!/<(?:failure|error)\b/.test(body)) continue;
   const classname = attributes.match(/\bclassname="([^"]*)"/)?.[1];
   const name = attributes.match(/\bname="([^"]*)"/)?.[1];
   failures.push([classname, name].filter(Boolean).map(decode).join(' - '));
+}
+
+if (failures.length === 0 && /<(?:failure|error)\b/.test(xml)) {
+  failures.push('Playwright reported failures; see JUnit XML for details.');
 }
 
 for (const failure of failures) {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -9,6 +9,9 @@ cd "$ROOT"
 DEFAULT_REACT_ON_RAILS_REPO="https://github.com/shakacode/react_on_rails.git"
 DEFAULT_REACT_ON_RAILS_REF="main"
 DEFAULT_DUMMY_BUILD_SCRIPT="build:test:rspack"
+DEFAULT_RENDERER_PORT="3800"
+DEFAULT_RAILS_PORT="3000"
+DEFAULT_RAILS_READY_PATH="/empty"
 DEFAULT_SPECS=(
   "e2e-tests/rsc_echo_props.spec.ts"
   "e2e-tests/rsc_route_ssr_false.spec.ts"
@@ -24,7 +27,14 @@ DUMMY_BUILD_SCRIPT="${RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT:-$DEFAULT_DUMMY_BUILD_SC
 INSTALL_PLAYWRIGHT="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT:-1}"
 INSTALL_PLAYWRIGHT_DEPS="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS:-0}"
 REQUIRE_PRO_LICENSE="${RSC_DOWNSTREAM_REQUIRE_PRO_LICENSE:-0}"
+RENDERER_PORT="${RENDERER_PORT:-$DEFAULT_RENDERER_PORT}"
+RAILS_PORT="${RSC_DOWNSTREAM_RAILS_PORT:-${RAILS_PORT:-$DEFAULT_RAILS_PORT}}"
+RAILS_READY_PATH="${RSC_DOWNSTREAM_RAILS_READY_PATH:-$DEFAULT_RAILS_READY_PATH}"
 SPEC_ARGS=()
+
+if [[ "$RAILS_READY_PATH" != /* ]]; then
+  RAILS_READY_PATH="/$RAILS_READY_PATH"
+fi
 
 usage() {
   cat <<'USAGE'
@@ -42,9 +52,19 @@ Options:
   -h, --help                 Show this help.
 
 Environment:
+  RSC_DOWNSTREAM_REACT_ON_RAILS_REPO      Downstream repository URL.
+  RSC_DOWNSTREAM_REACT_ON_RAILS_REF       Downstream ref to test. Default: main.
+  RSC_DOWNSTREAM_REACT_ON_RAILS_DIR       Existing downstream checkout path.
+  RSC_DOWNSTREAM_WORK_DIR                 Directory for packed tarball, logs, and clone.
+  RSC_DOWNSTREAM_KEEP                     1 = preserve generated work dir.
   RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT       Dummy build script. Default: build:test:rspack.
+  RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT       0 = skip Playwright browser installation.
   RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS  1 = pass --with-deps to Playwright install.
   RSC_DOWNSTREAM_REQUIRE_PRO_LICENSE      1 = fail early if REACT_ON_RAILS_PRO_LICENSE is empty.
+  RSC_DOWNSTREAM_RAILS_PORT               Rails server port. Default: 3000.
+  RSC_DOWNSTREAM_RAILS_READY_PATH         Rails readiness path. Default: /empty.
+  RENDERER_PORT                           Node renderer port. Default: 3800.
+  RAILS_PORT                              Rails server port fallback when RSC_DOWNSTREAM_RAILS_PORT is unset.
 
 Default spec subset:
   e2e-tests/rsc_echo_props.spec.ts
@@ -190,7 +210,31 @@ configure_pnpm() {
   local package_manager
   package_manager="$(
     cd "$REACT_ON_RAILS_DIR"
-    node -e "const pm=require('./package.json').packageManager||''; if (!pm.startsWith('pnpm@')) process.exit(1); process.stdout.write(pm)"
+    node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const packageJsonPath = path.join(process.cwd(), 'package.json');
+let packageJson;
+try {
+  packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to parse downstream package JSON at ${packageJsonPath}: ${message}`);
+  process.exit(1);
+}
+
+const packageManager = packageJson.packageManager || '';
+if (!packageManager.startsWith('pnpm@')) {
+  console.error(
+    `Expected downstream packageManager to start with "pnpm@" in ${packageJsonPath}; found ` +
+      (packageManager || '<missing>')
+  );
+  process.exit(1);
+}
+
+process.stdout.write(packageManager);
+NODE
   )"
   corepack enable
   corepack prepare "$package_manager" --activate
@@ -227,7 +271,7 @@ checkout_downstream() {
 pack_local_package() {
   log_step "Building and packing react-on-rails-rsc"
   yarn build
-  TARBALL="$PACKAGE_DIR/$(npm pack --quiet --pack-destination "$PACKAGE_DIR")"
+  TARBALL="$PACKAGE_DIR/$(npm pack --quiet --pack-destination "$PACKAGE_DIR" | tail -1)"
   test -f "$TARBALL"
   echo "Packed tarball: $TARBALL"
 }
@@ -253,12 +297,22 @@ const packageJsonPaths = [
   'react_on_rails_pro/spec/dummy/package.json',
 ];
 
-for (const relativePath of packageJsonPaths) {
-  const fullPath = path.join(root, relativePath);
+function readPackageJson(fullPath) {
   if (!fs.existsSync(fullPath)) {
     throw new Error(`Expected downstream package file not found: ${fullPath}`);
   }
-  const packageJson = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+
+  try {
+    return JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse downstream package JSON at ${fullPath}: ${message}`);
+  }
+}
+
+for (const relativePath of packageJsonPaths) {
+  const fullPath = path.join(root, relativePath);
+  const packageJson = readPackageJson(fullPath);
 
   for (const sectionName of ['dependencies', 'devDependencies', 'optionalDependencies']) {
     if (packageJson[sectionName]?.[dependencyName]) {
@@ -277,6 +331,9 @@ for (const relativePath of packageJsonPaths) {
 NODE
 
   configure_pnpm
+  # The disposable downstream checkout has its package manifests rewritten to
+  # point at the local tarball, so the lockfile must be allowed to refresh that
+  # expected spec while preserving existing locked versions for unchanged deps.
   (cd "$REACT_ON_RAILS_DIR" && pnpm install --no-frozen-lockfile)
 
   local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
@@ -300,13 +357,13 @@ start_background_services() {
 
   (
     cd "$dummy_dir"
-    RENDERER_PORT="${RENDERER_PORT:-3800}" pnpm run node-renderer
+    RENDERER_PORT="$RENDERER_PORT" pnpm run node-renderer
   ) >"$LOG_DIR/node-renderer.log" 2>&1 &
   NODE_RENDERER_PID="$!"
 
   (
     cd "$dummy_dir"
-    RAILS_ENV="test" bundle exec rails server
+    RAILS_ENV="test" bundle exec rails server -p "$RAILS_PORT"
   ) >"$LOG_DIR/rails.log" 2>&1 &
   RAILS_PID="$!"
 }
@@ -340,6 +397,8 @@ wait_for_h2c() {
   local start_time="$SECONDS"
 
   while true; do
+    # The React on Rails Pro node renderer exposes its /info readiness endpoint
+    # over h2c, so use Node's http2 client rather than curl's HTTP/1.1 probe.
     if node - "$authority" "$path" <<'NODE'
 const http2 = require('node:http2');
 
@@ -384,8 +443,10 @@ NODE
 
 wait_for_services() {
   log_step "Waiting for downstream services"
-  wait_for_http "Rails server" "http://127.0.0.1:3000/empty"
-  wait_for_h2c "Node renderer" "http://127.0.0.1:${RENDERER_PORT:-3800}" "/info"
+  # /empty is a stable React on Rails Pro dummy route used as a cheap Rails
+  # liveness probe without depending on rendered RSC content.
+  wait_for_http "Rails server" "http://127.0.0.1:${RAILS_PORT}${RAILS_READY_PATH}"
+  wait_for_h2c "Node renderer" "http://127.0.0.1:${RENDERER_PORT}" "/info"
 }
 
 install_playwright_browsers() {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -581,6 +581,8 @@ write_playwright_config() {
   local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
   PLAYWRIGHT_CONFIG_FILE="$dummy_dir/.react-on-rails-rsc-downstream.playwright.config.ts"
 
+  # The Pro dummy currently uses playwright.config.ts; update this generated
+  # import if the downstream app moves that base config to JavaScript.
   node - "$PLAYWRIGHT_CONFIG_FILE" "$RAILS_PORT" <<'NODE'
 const fs = require('fs');
 

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -157,7 +157,7 @@ cleanup() {
   elif [[ "$KEEP_WORK_DIR" == "1" ]]; then
     echo "RSC_DOWNSTREAM_KEEP=1 - keeping work dir: $WORK_DIR"
   else
-    rm -rf "$WORK_DIR"
+    rm -rf "$WORK_DIR" || true
   fi
 
   exit "$status"
@@ -399,6 +399,7 @@ wait_for_http() {
   local name="$1"
   local url="$2"
   local timeout_seconds="${3:-300}"
+  local log_path="${4:-$LOG_DIR/rails.log}"
   local start_time="$SECONDS"
 
   while true; do
@@ -409,7 +410,7 @@ wait_for_http() {
 
     if ((SECONDS - start_time >= timeout_seconds)); then
       echo "Timed out waiting for $name at $url" >&2
-      tail -100 "$LOG_DIR/rails.log" >&2 || true
+      tail -100 "$log_path" >&2 || true
       return 1
     fi
     sleep 1
@@ -464,7 +465,7 @@ NODE
       tail -100 "$LOG_DIR/node-renderer.log" >&2 || true
       return 1
     fi
-    sleep 1
+    sleep 2
   done
 }
 
@@ -653,9 +654,9 @@ main() {
   pack_local_package
   install_downstream_dependencies
   build_downstream_dummy
+  install_playwright_browsers
   start_background_services
   wait_for_services
-  install_playwright_browsers
   run_playwright_subset
 }
 

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -148,6 +148,12 @@ PLAYWRIGHT_CONFIG_FILE=""
 LAST_STEP="initialization"
 FAILED_SPECS_FILE="$WORK_DIR/failed-specs.txt"
 FAILURE_SUMMARY_WRITTEN="0"
+DOWNSTREAM_MUTATED_PATHS=(
+  "package.json"
+  "packages/react-on-rails-pro/package.json"
+  "react_on_rails_pro/spec/dummy/package.json"
+  "pnpm-lock.yaml"
+)
 
 cleanup() {
   local status=$?
@@ -179,11 +185,7 @@ restore_existing_checkout_manifests() {
     return
   fi
 
-  git -C "$REACT_ON_RAILS_DIR" checkout -- \
-    package.json \
-    packages/react-on-rails-pro/package.json \
-    react_on_rails_pro/spec/dummy/package.json \
-    pnpm-lock.yaml 2>/dev/null || true
+  git -C "$REACT_ON_RAILS_DIR" checkout -- "${DOWNSTREAM_MUTATED_PATHS[@]}" 2>/dev/null || true
 }
 
 kill_process_tree() {
@@ -345,8 +347,9 @@ install_downstream_dependencies() {
   fi
 
   if [[ "$USING_EXISTING_REACT_ON_RAILS_DIR" == "1" ]]; then
+    ensure_existing_checkout_mutation_targets_clean
     echo "Warning: mutating package manifests in existing checkout: $REACT_ON_RAILS_DIR" >&2
-    echo "Restore with: git -C \"$REACT_ON_RAILS_DIR\" checkout -- package.json packages/react-on-rails-pro/package.json react_on_rails_pro/spec/dummy/package.json pnpm-lock.yaml" >&2
+    echo "Restore with: git -C \"$REACT_ON_RAILS_DIR\" checkout -- ${DOWNSTREAM_MUTATED_PATHS[*]}" >&2
   fi
 
   node - "$REACT_ON_RAILS_DIR" "$TARBALL" <<'NODE'
@@ -405,6 +408,26 @@ NODE
   if ! (cd "$dummy_dir" && bundle check); then
     (cd "$dummy_dir" && bundle install --jobs 4 --retry 3)
   fi
+}
+
+ensure_existing_checkout_mutation_targets_clean() {
+  local dirty_paths=()
+  local relative_path
+
+  for relative_path in "${DOWNSTREAM_MUTATED_PATHS[@]}"; do
+    if [[ -n "$(git -C "$REACT_ON_RAILS_DIR" status --porcelain -- "$relative_path")" ]]; then
+      dirty_paths+=("$relative_path")
+    fi
+  done
+
+  if ((${#dirty_paths[@]} == 0)); then
+    return
+  fi
+
+  echo "Existing checkout has uncommitted edits in files this script must mutate:" >&2
+  printf '  - %s\n' "${dirty_paths[@]}" >&2
+  echo "Commit, stash, or restore those files before using --react-on-rails-dir." >&2
+  return 1
 }
 
 build_downstream_dummy() {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -28,7 +28,7 @@ DUMMY_BUILD_SCRIPT="${RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT:-$DEFAULT_DUMMY_BUILD_SC
 INSTALL_PLAYWRIGHT="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT:-1}"
 INSTALL_PLAYWRIGHT_DEPS="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS:-0}"
 REQUIRE_PRO_LICENSE="${RSC_DOWNSTREAM_REQUIRE_PRO_LICENSE:-0}"
-RENDERER_PORT="${RENDERER_PORT:-$DEFAULT_RENDERER_PORT}"
+RENDERER_PORT="${RSC_DOWNSTREAM_RENDERER_PORT:-${RENDERER_PORT:-$DEFAULT_RENDERER_PORT}}"
 RAILS_PORT="${RSC_DOWNSTREAM_RAILS_PORT:-${RAILS_PORT:-$DEFAULT_RAILS_PORT}}"
 RAILS_READY_PATH="${RSC_DOWNSTREAM_RAILS_READY_PATH:-$DEFAULT_RAILS_READY_PATH}"
 SPEC_ARGS=()
@@ -64,7 +64,8 @@ Environment:
   RSC_DOWNSTREAM_REQUIRE_PRO_LICENSE      1 = fail early if REACT_ON_RAILS_PRO_LICENSE is empty.
   RSC_DOWNSTREAM_RAILS_PORT               Rails server port. Default: 3000.
   RSC_DOWNSTREAM_RAILS_READY_PATH         Rails readiness path. Default: /empty.
-  RENDERER_PORT                           Node renderer port. Default: 3800.
+  RSC_DOWNSTREAM_RENDERER_PORT            Node renderer port. Default: 3800.
+  RENDERER_PORT                           Node renderer port fallback when RSC_DOWNSTREAM_RENDERER_PORT is unset.
   RAILS_PORT                              Rails server port fallback when RSC_DOWNSTREAM_RAILS_PORT is unset.
 
 Default spec subset:
@@ -128,12 +129,14 @@ mkdir -p "$WORK_DIR"
 WORK_DIR="$(cd "$WORK_DIR" && pwd)"
 PACKAGE_DIR="$WORK_DIR/package"
 LOG_DIR="$WORK_DIR/logs"
-mkdir -p "$PACKAGE_DIR" "$LOG_DIR"
+NPM_CACHE_DIR="$WORK_DIR/npm-cache"
+mkdir -p "$PACKAGE_DIR" "$LOG_DIR" "$NPM_CACHE_DIR"
 
 TARBALL=""
 DOWNSTREAM_SHA="UNKNOWN"
 NODE_RENDERER_PID=""
 RAILS_PID=""
+PLAYWRIGHT_CONFIG_FILE=""
 LAST_STEP="initialization"
 FAILED_SPECS_FILE="$WORK_DIR/failed-specs.txt"
 FAILURE_SUMMARY_WRITTEN="0"
@@ -144,6 +147,10 @@ cleanup() {
   for pid in "$RAILS_PID" "$NODE_RENDERER_PID"; do
     kill_process_tree "$pid"
   done
+
+  if [[ -n "$PLAYWRIGHT_CONFIG_FILE" ]]; then
+    rm -f "$PLAYWRIGHT_CONFIG_FILE"
+  fi
 
   if [[ "$AUTO_WORK_DIR" != "1" ]]; then
     echo "Preserving user-supplied work dir: $WORK_DIR"
@@ -282,7 +289,9 @@ checkout_downstream() {
 pack_local_package() {
   log_step "Building and packing react-on-rails-rsc"
   yarn build
-  TARBALL="$PACKAGE_DIR/$(npm pack --quiet --pack-destination "$PACKAGE_DIR" | tail -1)"
+  TARBALL="$PACKAGE_DIR/$(
+    npm_config_cache="$NPM_CACHE_DIR" npm pack --quiet --pack-destination "$PACKAGE_DIR" | tail -1
+  )"
   test -f "$TARBALL"
   echo "Packed tarball: $TARBALL"
 }
@@ -379,7 +388,9 @@ start_background_services() {
 
   (
     cd "$dummy_dir"
-    RAILS_ENV="test" bundle exec rails server -p "$RAILS_PORT"
+    RAILS_ENV="test" \
+      REACT_RENDERER_URL="http://127.0.0.1:$RENDERER_PORT" \
+      bundle exec rails server -p "$RAILS_PORT"
   ) >"$LOG_DIR/rails.log" 2>&1 &
   RAILS_PID="$!"
 }
@@ -566,13 +577,54 @@ write_github_summary() {
   } >>"$GITHUB_STEP_SUMMARY"
 }
 
+write_playwright_config() {
+  local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
+  PLAYWRIGHT_CONFIG_FILE="$dummy_dir/.react-on-rails-rsc-downstream.playwright.config.ts"
+
+  node - "$PLAYWRIGHT_CONFIG_FILE" "$RAILS_PORT" <<'NODE'
+const fs = require('fs');
+
+const [configPath, railsPort] = process.argv.slice(2);
+const baseURL = `http://127.0.0.1:${railsPort}/`;
+
+fs.writeFileSync(
+  configPath,
+  `import { defineConfig } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+const baseURL = ${JSON.stringify(baseURL)};
+
+export default defineConfig({
+  ...baseConfig,
+  use: {
+    ...baseConfig.use,
+    baseURL,
+  },
+  projects: baseConfig.projects?.map((project) => ({
+    ...project,
+    use: {
+      ...project.use,
+      baseURL,
+    },
+  })),
+});
+`
+);
+NODE
+}
+
 run_playwright_subset() {
   log_step "Running downstream RSC Playwright subset"
   local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
   local test_status=0
 
+  write_playwright_config
+
   set +e
-  (cd "$dummy_dir" && CI="${CI:-}" pnpm exec playwright test "${SPEC_ARGS[@]}")
+  (
+    cd "$dummy_dir" &&
+      CI="${CI:-}" pnpm exec playwright test --config "$PLAYWRIGHT_CONFIG_FILE" "${SPEC_ARGS[@]}"
+  )
   test_status=$?
   set -e
 

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -227,7 +227,7 @@ checkout_downstream() {
 pack_local_package() {
   log_step "Building and packing react-on-rails-rsc"
   yarn build
-  TARBALL="$PACKAGE_DIR/$(npm pack --pack-destination "$PACKAGE_DIR" | tail -1)"
+  TARBALL="$PACKAGE_DIR/$(npm pack --quiet --pack-destination "$PACKAGE_DIR")"
   test -f "$TARBALL"
   echo "Packed tarball: $TARBALL"
 }
@@ -289,9 +289,9 @@ build_downstream_dummy() {
   log_step "Building downstream Pro dummy app"
   local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
 
-  (cd "$REACT_ON_RAILS_DIR" && pnpm run build)
-  (cd "$dummy_dir" && bundle exec rake react_on_rails:generate_packs)
-  (cd "$dummy_dir" && pnpm run "$DUMMY_BUILD_SCRIPT")
+  (cd "$REACT_ON_RAILS_DIR" && pnpm run build) 2>&1 | tee "$LOG_DIR/pnpm-build.log"
+  (cd "$dummy_dir" && bundle exec rake react_on_rails:generate_packs) 2>&1 | tee "$LOG_DIR/generate-packs.log"
+  (cd "$dummy_dir" && pnpm run "$DUMMY_BUILD_SCRIPT") 2>&1 | tee "$LOG_DIR/dummy-build.log"
 }
 
 start_background_services() {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -290,7 +290,7 @@ pack_local_package() {
   log_step "Building and packing react-on-rails-rsc"
   yarn build
   TARBALL="$PACKAGE_DIR/$(
-    npm_config_cache="$NPM_CACHE_DIR" npm pack --quiet --pack-destination "$PACKAGE_DIR" | tail -1
+    npm_config_cache="$NPM_CACHE_DIR" npm pack --loglevel=error --pack-destination "$PACKAGE_DIR" | tail -1
   )"
   test -f "$TARBALL"
   echo "Packed tarball: $TARBALL"

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -233,6 +233,9 @@ const packageJsonPaths = [
 
 for (const relativePath of packageJsonPaths) {
   const fullPath = path.join(root, relativePath);
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`Expected downstream package file not found: ${fullPath}`);
+  }
   const packageJson = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
 
   for (const sectionName of ['dependencies', 'devDependencies', 'optionalDependencies']) {
@@ -360,7 +363,7 @@ NODE
 wait_for_services() {
   log_step "Waiting for downstream services"
   wait_for_http "Rails server" "http://127.0.0.1:3000/empty"
-  wait_for_h2c "Node renderer" "http://127.0.0.1:3800" "/info"
+  wait_for_h2c "Node renderer" "http://127.0.0.1:${RENDERER_PORT:-3800}" "/info"
 }
 
 install_playwright_browsers() {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -310,8 +310,8 @@ checkout_downstream() {
     fi
   else
     REACT_ON_RAILS_DIR="$WORK_DIR/react_on_rails"
-    # Use init+fetch because workflow_dispatch may pass a commit SHA; clone
-    # --branch only handles branch and tag names.
+    # Use init+fetch so workflow_dispatch can pass branch, tag, or ref names
+    # without relying on clone --branch semantics.
     git init "$REACT_ON_RAILS_DIR"
     if git -C "$REACT_ON_RAILS_DIR" remote get-url origin >/dev/null 2>&1; then
       git -C "$REACT_ON_RAILS_DIR" remote set-url origin "$REACT_ON_RAILS_REPO"
@@ -712,6 +712,7 @@ const baseURL = ${JSON.stringify(baseURL)};
 
 export default defineConfig({
   ...baseConfig,
+  webServer: undefined,
   use: {
     ...baseConfig.use,
     baseURL,

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -19,6 +19,10 @@ DEFAULT_SPECS=(
 
 REACT_ON_RAILS_REPO="${RSC_DOWNSTREAM_REACT_ON_RAILS_REPO:-$DEFAULT_REACT_ON_RAILS_REPO}"
 REACT_ON_RAILS_REF="${RSC_DOWNSTREAM_REACT_ON_RAILS_REF:-$DEFAULT_REACT_ON_RAILS_REF}"
+REACT_ON_RAILS_REF_EXPLICIT="0"
+if [[ -n "${RSC_DOWNSTREAM_REACT_ON_RAILS_REF:-}" ]]; then
+  REACT_ON_RAILS_REF_EXPLICIT="1"
+fi
 REACT_ON_RAILS_DIR="${RSC_DOWNSTREAM_REACT_ON_RAILS_DIR:-}"
 WORK_DIR="${RSC_DOWNSTREAM_WORK_DIR:-}"
 AUTO_WORK_DIR="0"
@@ -44,6 +48,8 @@ Usage:
 
 Options:
   --react-on-rails-ref REF   Downstream ref to test. Default: main.
+                             Existing checkouts use current HEAD unless this
+                             option or RSC_DOWNSTREAM_REACT_ON_RAILS_REF is set.
   --react-on-rails-repo URL  Downstream repository URL.
   --react-on-rails-dir PATH  Use an existing downstream checkout instead of cloning.
   --work-dir PATH            Directory for the packed tarball, logs, and clone.
@@ -54,7 +60,7 @@ Options:
 
 Environment:
   RSC_DOWNSTREAM_REACT_ON_RAILS_REPO      Downstream repository URL.
-  RSC_DOWNSTREAM_REACT_ON_RAILS_REF       Downstream ref to test. Default: main.
+  RSC_DOWNSTREAM_REACT_ON_RAILS_REF       Downstream ref to test. Default: main for clones.
   RSC_DOWNSTREAM_REACT_ON_RAILS_DIR       Existing downstream checkout path.
   RSC_DOWNSTREAM_WORK_DIR                 Directory for packed tarball, logs, and clone.
   RSC_DOWNSTREAM_KEEP                     1 = preserve generated work dir.
@@ -78,6 +84,7 @@ while (($# > 0)); do
   case "$1" in
     --react-on-rails-ref)
       REACT_ON_RAILS_REF="${2:?--react-on-rails-ref requires a value}"
+      REACT_ON_RAILS_REF_EXPLICIT="1"
       shift 2
       ;;
     --react-on-rails-repo)
@@ -134,6 +141,7 @@ mkdir -p "$PACKAGE_DIR" "$LOG_DIR" "$NPM_CACHE_DIR"
 
 TARBALL=""
 DOWNSTREAM_SHA="UNKNOWN"
+DOWNSTREAM_REF_LABEL="$REACT_ON_RAILS_REF"
 NODE_RENDERER_PID=""
 RAILS_PID=""
 PLAYWRIGHT_CONFIG_FILE=""
@@ -268,6 +276,22 @@ checkout_downstream() {
       return 1
     fi
     echo "Using existing checkout: $REACT_ON_RAILS_DIR"
+    if [[ "$REACT_ON_RAILS_REF_EXPLICIT" == "1" ]]; then
+      if ! git -C "$REACT_ON_RAILS_DIR" diff-index --quiet HEAD --; then
+        echo "Existing checkout has uncommitted changes; cannot check out $REACT_ON_RAILS_REF." >&2
+        echo "Restore or stash the checkout, or omit --react-on-rails-ref to use the current HEAD." >&2
+        return 1
+      fi
+      if ! git -C "$REACT_ON_RAILS_DIR" remote get-url origin >/dev/null 2>&1; then
+        echo "Existing checkout has no origin remote, so $REACT_ON_RAILS_REF cannot be fetched." >&2
+        return 1
+      fi
+      git -C "$REACT_ON_RAILS_DIR" fetch --depth 1 origin -- "$REACT_ON_RAILS_REF"
+      git -C "$REACT_ON_RAILS_DIR" checkout --detach FETCH_HEAD
+    else
+      DOWNSTREAM_REF_LABEL="existing checkout"
+      echo "No downstream ref explicitly requested; using the existing checkout HEAD."
+    fi
   else
     REACT_ON_RAILS_DIR="$WORK_DIR/react_on_rails"
     git init "$REACT_ON_RAILS_DIR"
@@ -282,7 +306,7 @@ checkout_downstream() {
   fi
 
   DOWNSTREAM_SHA="$(git -C "$REACT_ON_RAILS_DIR" rev-parse HEAD)"
-  echo "React on Rails ref: $REACT_ON_RAILS_REF"
+  echo "React on Rails ref: $DOWNSTREAM_REF_LABEL"
   echo "React on Rails SHA: $DOWNSTREAM_SHA"
 }
 
@@ -592,7 +616,7 @@ write_github_summary() {
       echo "- Detail: $detail"
     fi
     echo "- react-on-rails-rsc SHA: $(git rev-parse HEAD)"
-    echo "- React on Rails ref: $REACT_ON_RAILS_REF"
+    echo "- React on Rails ref: $DOWNSTREAM_REF_LABEL"
     echo "- React on Rails SHA: $DOWNSTREAM_SHA"
     if [[ -n "$TARBALL" ]]; then
       echo "- Tarball: $(basename "$TARBALL")"

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -160,6 +160,8 @@ cleanup() {
     rm -f "$PLAYWRIGHT_CONFIG_FILE"
   fi
 
+  restore_existing_checkout_manifests
+
   if [[ "$AUTO_WORK_DIR" != "1" ]]; then
     echo "Preserving user-supplied work dir: $WORK_DIR"
   elif [[ "$KEEP_WORK_DIR" == "1" ]]; then
@@ -171,6 +173,18 @@ cleanup() {
   exit "$status"
 }
 trap cleanup EXIT
+
+restore_existing_checkout_manifests() {
+  if [[ "$USING_EXISTING_REACT_ON_RAILS_DIR" != "1" ]] || [[ -z "$REACT_ON_RAILS_DIR" ]]; then
+    return
+  fi
+
+  git -C "$REACT_ON_RAILS_DIR" checkout -- \
+    package.json \
+    packages/react-on-rails-pro/package.json \
+    react_on_rails_pro/spec/dummy/package.json \
+    pnpm-lock.yaml 2>/dev/null || true
+}
 
 kill_process_tree() {
   local pid="$1"
@@ -294,6 +308,8 @@ checkout_downstream() {
     fi
   else
     REACT_ON_RAILS_DIR="$WORK_DIR/react_on_rails"
+    # Use init+fetch because workflow_dispatch may pass a commit SHA; clone
+    # --branch only handles branch and tag names.
     git init "$REACT_ON_RAILS_DIR"
     if git -C "$REACT_ON_RAILS_DIR" remote get-url origin >/dev/null 2>&1; then
       git -C "$REACT_ON_RAILS_DIR" remote set-url origin "$REACT_ON_RAILS_REPO"
@@ -643,6 +659,11 @@ write_playwright_config() {
 
   # The Pro dummy currently uses playwright.config.ts; update this generated
   # import if the downstream app moves that base config to JavaScript.
+  if [[ ! -f "$dummy_dir/playwright.config.ts" ]]; then
+    echo "Expected playwright.config.ts not found in $dummy_dir; update the generated config import." >&2
+    return 1
+  fi
+
   node - "$PLAYWRIGHT_CONFIG_FILE" "$RAILS_PORT" <<'NODE'
 const fs = require('fs');
 

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# Downstream E2E harness: pack this package, install it into the React on Rails
+# Pro dummy app, and run the maintained RSC Playwright subset.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DEFAULT_REACT_ON_RAILS_REPO="https://github.com/shakacode/react_on_rails.git"
+DEFAULT_REACT_ON_RAILS_REF="main"
+DEFAULT_DUMMY_BUILD_SCRIPT="build:test:rspack"
+DEFAULT_SPECS=(
+  "e2e-tests/rsc_echo_props.spec.ts"
+  "e2e-tests/rsc_route_ssr_false.spec.ts"
+)
+
+REACT_ON_RAILS_REPO="${RSC_DOWNSTREAM_REACT_ON_RAILS_REPO:-$DEFAULT_REACT_ON_RAILS_REPO}"
+REACT_ON_RAILS_REF="${RSC_DOWNSTREAM_REACT_ON_RAILS_REF:-$DEFAULT_REACT_ON_RAILS_REF}"
+REACT_ON_RAILS_DIR="${RSC_DOWNSTREAM_REACT_ON_RAILS_DIR:-}"
+WORK_DIR="${RSC_DOWNSTREAM_WORK_DIR:-}"
+AUTO_WORK_DIR="0"
+KEEP_WORK_DIR="${RSC_DOWNSTREAM_KEEP:-0}"
+DUMMY_BUILD_SCRIPT="${RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT:-$DEFAULT_DUMMY_BUILD_SCRIPT}"
+INSTALL_PLAYWRIGHT="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT:-1}"
+INSTALL_PLAYWRIGHT_DEPS="${RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS:-0}"
+REQUIRE_PRO_LICENSE="${RSC_DOWNSTREAM_REQUIRE_PRO_LICENSE:-0}"
+SPEC_ARGS=()
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/e2e/downstream.sh [options] [-- <playwright spec>...]
+
+Options:
+  --react-on-rails-ref REF   Downstream ref to test. Default: main.
+  --react-on-rails-repo URL  Downstream repository URL.
+  --react-on-rails-dir PATH  Use an existing downstream checkout instead of cloning.
+  --work-dir PATH            Directory for the packed tarball, logs, and clone.
+                             User-supplied work dirs are preserved after exit.
+  --keep                     Keep the generated work directory for debugging.
+  --skip-playwright-install  Skip Playwright browser installation.
+  -h, --help                 Show this help.
+
+Environment:
+  RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT       Dummy build script. Default: build:test:rspack.
+  RSC_DOWNSTREAM_INSTALL_PLAYWRIGHT_DEPS  1 = pass --with-deps to Playwright install.
+  RSC_DOWNSTREAM_REQUIRE_PRO_LICENSE      1 = fail early if REACT_ON_RAILS_PRO_LICENSE is empty.
+
+Default spec subset:
+  e2e-tests/rsc_echo_props.spec.ts
+  e2e-tests/rsc_route_ssr_false.spec.ts
+USAGE
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --react-on-rails-ref)
+      REACT_ON_RAILS_REF="${2:?--react-on-rails-ref requires a value}"
+      shift 2
+      ;;
+    --react-on-rails-repo)
+      REACT_ON_RAILS_REPO="${2:?--react-on-rails-repo requires a value}"
+      shift 2
+      ;;
+    --react-on-rails-dir)
+      REACT_ON_RAILS_DIR="${2:?--react-on-rails-dir requires a value}"
+      shift 2
+      ;;
+    --work-dir)
+      WORK_DIR="${2:?--work-dir requires a value}"
+      shift 2
+      ;;
+    --keep)
+      KEEP_WORK_DIR="1"
+      shift
+      ;;
+    --skip-playwright-install)
+      INSTALL_PLAYWRIGHT="0"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      SPEC_ARGS=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ((${#SPEC_ARGS[@]} == 0)); then
+  SPEC_ARGS=("${DEFAULT_SPECS[@]}")
+fi
+
+if [[ -z "$WORK_DIR" ]]; then
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ror-rsc-downstream.XXXXXX")"
+  AUTO_WORK_DIR="1"
+fi
+mkdir -p "$WORK_DIR"
+WORK_DIR="$(cd "$WORK_DIR" && pwd)"
+PACKAGE_DIR="$WORK_DIR/package"
+LOG_DIR="$WORK_DIR/logs"
+mkdir -p "$PACKAGE_DIR" "$LOG_DIR"
+
+TARBALL=""
+DOWNSTREAM_SHA="UNKNOWN"
+NODE_RENDERER_PID=""
+RAILS_PID=""
+LAST_STEP="initialization"
+FAILED_SPECS_FILE="$WORK_DIR/failed-specs.txt"
+FAILURE_SUMMARY_WRITTEN="0"
+
+cleanup() {
+  local status=$?
+
+  for pid in "$RAILS_PID" "$NODE_RENDERER_PID"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+
+  if [[ "$AUTO_WORK_DIR" != "1" ]]; then
+    echo "Preserving user-supplied work dir: $WORK_DIR"
+  elif [[ "$KEEP_WORK_DIR" == "1" ]]; then
+    echo "RSC_DOWNSTREAM_KEEP=1 - keeping work dir: $WORK_DIR"
+  else
+    rm -rf "$WORK_DIR"
+  fi
+
+  exit "$status"
+}
+trap cleanup EXIT
+
+on_error() {
+  local status=$?
+  echo "::error title=Downstream RSC E2E failed::Failed during: $LAST_STEP"
+  if [[ "$FAILURE_SUMMARY_WRITTEN" != "1" ]]; then
+    write_github_summary "failed" "$LAST_STEP"
+  fi
+  exit "$status"
+}
+trap on_error ERR
+
+log_step() {
+  LAST_STEP="$1"
+  echo
+  echo "==> $LAST_STEP"
+}
+
+ensure_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command is missing: $command_name" >&2
+    return 1
+  fi
+}
+
+configure_pnpm() {
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm --version
+    return
+  fi
+
+  ensure_command node
+  ensure_command corepack
+
+  local package_manager
+  package_manager="$(
+    cd "$REACT_ON_RAILS_DIR"
+    node -e "const pm=require('./package.json').packageManager||''; if (!pm.startsWith('pnpm@')) process.exit(1); process.stdout.write(pm)"
+  )"
+  corepack enable
+  corepack prepare "$package_manager" --activate
+  pnpm --version
+}
+
+checkout_downstream() {
+  log_step "Preparing React on Rails checkout"
+
+  if [[ -n "$REACT_ON_RAILS_DIR" ]]; then
+    REACT_ON_RAILS_DIR="$(cd "$REACT_ON_RAILS_DIR" && pwd)"
+    test -d "$REACT_ON_RAILS_DIR/.git"
+    echo "Using existing checkout: $REACT_ON_RAILS_DIR"
+  else
+    REACT_ON_RAILS_DIR="$WORK_DIR/react_on_rails"
+    git init "$REACT_ON_RAILS_DIR"
+    git -C "$REACT_ON_RAILS_DIR" remote add origin "$REACT_ON_RAILS_REPO"
+    git -C "$REACT_ON_RAILS_DIR" fetch --depth 1 origin "$REACT_ON_RAILS_REF"
+    git -C "$REACT_ON_RAILS_DIR" checkout --detach FETCH_HEAD
+  fi
+
+  DOWNSTREAM_SHA="$(git -C "$REACT_ON_RAILS_DIR" rev-parse HEAD)"
+  echo "React on Rails ref: $REACT_ON_RAILS_REF"
+  echo "React on Rails SHA: $DOWNSTREAM_SHA"
+}
+
+pack_local_package() {
+  log_step "Building and packing react-on-rails-rsc"
+  yarn build
+  TARBALL="$PACKAGE_DIR/$(npm pack --pack-destination "$PACKAGE_DIR" | tail -1)"
+  test -f "$TARBALL"
+  echo "Packed tarball: $TARBALL"
+}
+
+install_downstream_dependencies() {
+  log_step "Installing downstream dependencies with packed react-on-rails-rsc"
+
+  if [[ "$REQUIRE_PRO_LICENSE" == "1" && -z "${REACT_ON_RAILS_PRO_LICENSE:-}" ]]; then
+    echo "REACT_ON_RAILS_PRO_LICENSE is required for the Pro dummy app." >&2
+    return 1
+  fi
+
+  node - "$REACT_ON_RAILS_DIR" "$TARBALL" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const [root, tarball] = process.argv.slice(2);
+const dependencyName = 'react-on-rails-rsc';
+const tarballSpec = `file:${tarball}`;
+const packageJsonPaths = [
+  'package.json',
+  'packages/react-on-rails-pro/package.json',
+  'react_on_rails_pro/spec/dummy/package.json',
+];
+
+for (const relativePath of packageJsonPaths) {
+  const fullPath = path.join(root, relativePath);
+  const packageJson = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+
+  for (const sectionName of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+    if (packageJson[sectionName]?.[dependencyName]) {
+      packageJson[sectionName][dependencyName] = tarballSpec;
+    }
+  }
+
+  if (relativePath === 'package.json') {
+    packageJson.pnpm ||= {};
+    packageJson.pnpm.overrides ||= {};
+    packageJson.pnpm.overrides[dependencyName] = tarballSpec;
+  }
+
+  fs.writeFileSync(fullPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+NODE
+
+  configure_pnpm
+  (cd "$REACT_ON_RAILS_DIR" && pnpm install --no-frozen-lockfile)
+
+  local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
+  if ! (cd "$dummy_dir" && bundle check); then
+    (cd "$dummy_dir" && bundle install --jobs 4 --retry 3)
+  fi
+}
+
+build_downstream_dummy() {
+  log_step "Building downstream Pro dummy app"
+  local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
+
+  (cd "$REACT_ON_RAILS_DIR" && pnpm run build)
+  (cd "$dummy_dir" && bundle exec rake react_on_rails:generate_packs)
+  (cd "$dummy_dir" && pnpm run "$DUMMY_BUILD_SCRIPT")
+}
+
+start_background_services() {
+  log_step "Starting downstream Rails and node-renderer services"
+  local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
+
+  (
+    cd "$dummy_dir"
+    RENDERER_PORT="${RENDERER_PORT:-3800}" pnpm run node-renderer
+  ) >"$LOG_DIR/node-renderer.log" 2>&1 &
+  NODE_RENDERER_PID="$!"
+
+  (
+    cd "$dummy_dir"
+    RAILS_ENV="test" bundle exec rails server
+  ) >"$LOG_DIR/rails.log" 2>&1 &
+  RAILS_PID="$!"
+}
+
+wait_for_http() {
+  local name="$1"
+  local url="$2"
+  local timeout_seconds="${3:-300}"
+  local start_time="$SECONDS"
+
+  while true; do
+    if curl --fail --silent --max-time 5 "$url" >/dev/null; then
+      echo "$name ready at $url after $((SECONDS - start_time))s"
+      return 0
+    fi
+
+    if ((SECONDS - start_time >= timeout_seconds)); then
+      echo "Timed out waiting for $name at $url" >&2
+      tail -100 "$LOG_DIR/rails.log" >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+wait_for_h2c() {
+  local name="$1"
+  local authority="$2"
+  local path="$3"
+  local timeout_seconds="${4:-300}"
+  local start_time="$SECONDS"
+
+  while true; do
+    if node - "$authority" "$path" <<'NODE'
+const http2 = require('node:http2');
+
+const [authority, requestPath] = process.argv.slice(2);
+const client = http2.connect(authority);
+const request = client.request({ ':method': 'GET', ':path': requestPath });
+let statusCode = 0;
+let finished = false;
+
+const done = (code, destroy = false) => {
+  if (finished) return;
+  finished = true;
+  clearTimeout(timer);
+  if (destroy) client.destroy();
+  else client.close();
+  process.exit(code);
+};
+
+const timer = setTimeout(() => done(1, true), 10000);
+client.on('error', () => done(1, true));
+request.on('error', () => done(1, true));
+request.on('response', (headers) => {
+  statusCode = Number(headers[':status'] || 0);
+});
+request.on('data', () => {});
+request.on('end', () => done(statusCode >= 200 && statusCode < 300 ? 0 : 1));
+request.end();
+NODE
+    then
+      echo "$name ready at $authority$path after $((SECONDS - start_time))s"
+      return 0
+    fi
+
+    if ((SECONDS - start_time >= timeout_seconds)); then
+      echo "Timed out waiting for $name at $authority$path" >&2
+      tail -100 "$LOG_DIR/node-renderer.log" >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+wait_for_services() {
+  log_step "Waiting for downstream services"
+  wait_for_http "Rails server" "http://127.0.0.1:3000/empty"
+  wait_for_h2c "Node renderer" "http://127.0.0.1:3800" "/info"
+}
+
+install_playwright_browsers() {
+  if [[ "$INSTALL_PLAYWRIGHT" != "1" ]]; then
+    return
+  fi
+
+  log_step "Installing Playwright browser dependencies"
+  local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
+
+  if [[ "$INSTALL_PLAYWRIGHT_DEPS" == "1" ]]; then
+    (cd "$dummy_dir" && pnpm exec playwright install --with-deps chromium)
+  else
+    (cd "$dummy_dir" && pnpm exec playwright install chromium)
+  fi
+}
+
+collect_failed_specs() {
+  local results_file="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy/test-results/results.xml"
+  : >"$FAILED_SPECS_FILE"
+
+  if [[ ! -f "$results_file" ]]; then
+    return
+  fi
+
+  node - "$results_file" >"$FAILED_SPECS_FILE" <<'NODE'
+const fs = require('fs');
+
+const xml = fs.readFileSync(process.argv[2], 'utf8');
+const decode = (value) =>
+  value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+const failures = [];
+const testcasePattern = /<testcase\b([^>]*)>([\s\S]*?)<\/testcase>/g;
+let match;
+
+while ((match = testcasePattern.exec(xml)) !== null) {
+  const attributes = match[1];
+  const body = match[2];
+  if (!/<(?:failure|error)\b/.test(body)) continue;
+  const classname = attributes.match(/\bclassname="([^"]*)"/)?.[1];
+  const name = attributes.match(/\bname="([^"]*)"/)?.[1];
+  failures.push([classname, name].filter(Boolean).map(decode).join(' - '));
+}
+
+for (const failure of failures) {
+  console.log(failure);
+}
+NODE
+}
+
+emit_failed_spec_annotations() {
+  if [[ ! -s "$FAILED_SPECS_FILE" ]]; then
+    echo "::error title=Downstream RSC E2E failed::Playwright failed before writing failed spec names."
+    return
+  fi
+
+  while IFS= read -r failed_spec; do
+    echo "::error title=Downstream RSC spec failed::$failed_spec"
+  done <"$FAILED_SPECS_FILE"
+}
+
+write_github_summary() {
+  local result="$1"
+  local detail="${2:-}"
+
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    return
+  fi
+
+  {
+    echo "## Downstream RSC E2E"
+    echo
+    echo "- Result: $result"
+    if [[ -n "$detail" ]]; then
+      echo "- Detail: $detail"
+    fi
+    echo "- react-on-rails-rsc SHA: $(git rev-parse HEAD)"
+    echo "- React on Rails ref: $REACT_ON_RAILS_REF"
+    echo "- React on Rails SHA: $DOWNSTREAM_SHA"
+    if [[ -n "$TARBALL" ]]; then
+      echo "- Tarball: $(basename "$TARBALL")"
+    fi
+    echo "- Dummy build script: $DUMMY_BUILD_SCRIPT"
+    echo "- Specs:"
+    for spec in "${SPEC_ARGS[@]}"; do
+      echo "  - $spec"
+    done
+
+    if [[ -s "$FAILED_SPECS_FILE" ]]; then
+      echo
+      echo "### Failed Specs"
+      while IFS= read -r failed_spec; do
+        echo "- $failed_spec"
+      done <"$FAILED_SPECS_FILE"
+    fi
+  } >>"$GITHUB_STEP_SUMMARY"
+}
+
+run_playwright_subset() {
+  log_step "Running downstream RSC Playwright subset"
+  local dummy_dir="$REACT_ON_RAILS_DIR/react_on_rails_pro/spec/dummy"
+  local test_status=0
+
+  set +e
+  (cd "$dummy_dir" && CI="${CI:-}" pnpm exec playwright test "${SPEC_ARGS[@]}")
+  test_status=$?
+  set -e
+
+  collect_failed_specs
+  if ((test_status != 0)); then
+    emit_failed_spec_annotations
+    write_github_summary "failed" "Playwright exited with $test_status"
+    FAILURE_SUMMARY_WRITTEN="1"
+    return "$test_status"
+  fi
+
+  write_github_summary "passed"
+}
+
+main() {
+  ensure_command git
+  ensure_command yarn
+  ensure_command npm
+  ensure_command node
+  ensure_command bundle
+  ensure_command curl
+
+  checkout_downstream
+  pack_local_package
+  install_downstream_dependencies
+  build_downstream_dummy
+  start_background_services
+  wait_for_services
+  install_playwright_browsers
+  run_playwright_subset
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds a downstream release-gate workflow for the React on Rails Pro dummy app.
- Adds `scripts/e2e/downstream.sh` to build, pack, install, and test this package against `shakacode/react_on_rails`.
- Documents the selected RSC Playwright subset and makes the downstream gate part of the pre-`latest` promotion path.

Refs #59.

## Release / Merge Readiness

- **Release mode:** high-risk workflow/release-gate change; maintainer-gated. Maintainer accepted the workflow audit, review triage, and first-dispatch timing limitation in the Codex session on 2026-06-13 with: “98 looks fine”.
- **Current head SHA:** `4683c8d9d93ab07575182ca271d409b14f61a27f`.
- **Base SHA:** `origin/main` at `2a1b9f5ede69904a48f1b6429510ea7354032570`.
- **CI/check status:** full current-head `gh pr checks 98` is green or expected skips. Passing: all 4 compatibility matrix legs, `e2e-tests`, `unit-tests`, `verify-artifacts`, `claude-review`, Cursor Bugbot, and CodeRabbit. Expected/benign skips: `React canary signal` and `claude` setup rows.
- **Review-thread status:** unresolved review-thread count is `0` by GraphQL after resolving all current-head Claude/Cursor threads.
- **Review feedback triage:** addressed correctness/hardening feedback through `4683c8d`: service readiness fails fast when Rails or the renderer exits, existing checkout runs honor explicit downstream refs or clearly use current HEAD, cleanup restores existing-checkout package/lockfile state, failure reporting is hardened, JUnit failure parsing has a generic fallback, existing checkout edits are protected, and inherited Rails server env is avoided. Triaged as non-blocking/comment-only: TypeScript-only downstream Playwright config support, fallback-port readability, workflow truthiness fallback, full XML-parser replacement, `npm pack --json`, restore-warning polish, and nested lockfile speculation (verified the live downstream tree only has root `pnpm-lock.yaml`).
- **Workflow Change Audit:** posted at https://github.com/shakacode/react_on_rails_rsc/pull/98#issuecomment-4698299240. Review-fix pushes did not add secrets, broaden permissions, add triggers, or add/version-change third-party actions.
- **Validation run:** see exact local evidence below. One earlier `yarn test` attempt failed because I ran it concurrently with `yarn build`, and `yarn build` deletes/recreates `dist`; all sequential reruns passed.
- **Label / CI decision:** no label changes requested. This adds a new workflow gate; no lockfile changed and no Dependabot coverage change is needed.
- **Known residual risk:** no full downstream Pro dummy E2E workflow dispatch has completed for this PR. A brand-new `workflow_dispatch` workflow may not be dispatchable until the workflow file exists on the default branch; nightly becomes active only after merge. The workflow intentionally does not pass `REACT_ON_RAILS_PRO_LICENSE`, so licensed-mode Pro behavior remains outside this gate unless maintainers later add a protected environment and trusted-ref policy for that secret.
- **Merge criteria checked:** full `gh pr checks` list green or expected skips, `mergeStateStatus=CLEAN`, `reviewDecision=APPROVED`, unresolved review threads `0`, local validation green on current head, workflow audit posted, maintainer accepted first-run dispatch timing limitation.
- **Merge recommendation:** merge by squash now. After merge, run/monitor the downstream workflow from `main` when the workflow becomes dispatchable or wait for the nightly.

## Validation

All final commands passed for `4683c8d9d93ab07575182ca271d409b14f61a27f` content:

- `bash -n scripts/e2e/downstream.sh`
- `bash scripts/e2e/downstream.sh --help`
- `shellcheck scripts/e2e/downstream.sh`
- `actionlint .github/workflows/downstream-e2e.yml`
- `git diff --check`
- `yarn build`
- `yarn test` (`18` suites, `169` tests passed)

Earlier on this branch, `yarn test:e2e:downstream -- --help` also passed. Manual fallback downstream verification from the #65 release follow-through passed against published `react-on-rails-rsc@19.0.5`, but that was not a run of this new workflow/script.

## Downstream Subset

The maintained RSC subset is documented in `docs/releasing.md` and defaults to:

- `e2e-tests/rsc_echo_props.spec.ts`
- `e2e-tests/rsc_route_ssr_false.spec.ts`

The broader downstream Playwright coverage remains owned by `shakacode/react_on_rails` because it exercises Pro renderer, Redis, or application-level behavior beyond this package boundary.

## Coordination

`shakacode/react_on_rails#3977` is merged and was picked up as coordination context. Public repo evidence was used for coordination; private coordination backend state was not queried in this PR.

