### PR TITLE
Archive React fork patch history and retire active fork guidance

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -32,7 +32,7 @@ high-risk maintainer-gated) lives in `AGENTS.md` and `.agents/workflows/pr-proce
 | `verify-release` | Adapted — runs `yarn verify:artifacts` / `scripts/verify-release.sh` from #61/#77 |
 | `run-e2e` | Adapted — runs `scripts/e2e/run.sh` with `RSC_E2E_BUNDLER=webpack|rspack|both` |
 | `downstream-e2e` | Stub — documents the intended downstream e2e wrapper and blocks on #59 |
-| `react-upgrade` | Adapted — current `scripts/react-upgrade/upgrade.js` React fork cherry-pick flow |
+| `react-upgrade` | Legacy — emergency vendored-runtime maintenance only; not the Option 4 patch-file fallback |
 | `triage` | Manual stub — refreshes `docs/open-rsc-work-status.md` from live `gh` state and reports `UNKNOWN` for unverifiable facts |
 | `verify-pr-fix` | Adapted — before/after reproduction reframed around jest + plugin output |
 | `update-changelog` | Adapted — Keep-a-Changelog format + `scripts/release.sh` release flow |

--- a/.agents/skills/react-upgrade/SKILL.md
+++ b/.agents/skills/react-upgrade/SKILL.md
@@ -1,26 +1,29 @@
 ---
 name: react-upgrade
-description: "Drive the current react-server-dom-webpack upgrade flow using scripts/react-upgrade/upgrade.js and the React fork cherry-pick workflow."
+description: "Legacy helper for emergency maintenance of the vendored react-server-dom-webpack runtime through scripts/react-upgrade/upgrade.js and the React fork cherry-pick workflow."
 argument-hint: 'See Commands section; set TARGET_VERSION and REACT_FORK_DIR, then pass needed flags.'
 ---
 
 # React Upgrade
 
-Use this skill when upgrading the vendored `react-server-dom-webpack` runtime
-artifacts in `src/react-server-dom-webpack/`.
+Use this skill only when a maintainer explicitly asks for emergency maintenance
+of the vendored `react-server-dom-webpack` runtime artifacts in
+`src/react-server-dom-webpack/`. It is not the Option 4 patch-file fallback
+documented in `docs/eliminate-react-fork.md`.
 
 ## Current Rule
 
-Never hand-edit `src/react-server-dom-webpack/`. The current supported flow is
+Never hand-edit `src/react-server-dom-webpack/`. The legacy supported flow is
 the cherry-pick based script in `scripts/react-upgrade/upgrade.js`.
 
 Read `docs/eliminate-react-fork.md` before changing the upgrade strategy. That
-document describes the planned patch-file future, but the current script still
-uses a local React fork.
+document records Option 5 (stock npm runtime) as the active strategy and Option
+4 patch files as the fallback. This legacy script still uses a local React fork
+and should not be used for new stock-runtime work.
 
-Transition note: patch-file or stock-React tooling is planned after #60/#71.
-Until those issues land in this repo, do not invent patch directories, stock
-React clone behavior, or completed replacement tooling.
+Transition note: fork patch history is archived under
+`patches/archive/abanoubghadban-react/`. Those files preserve provenance only;
+they are not the active fallback patch directory.
 
 ## Prerequisites
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Historical `git format-patch` archives preserve upstream patch text verbatim.
+patches/archive/**/*.patch -whitespace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ here. Source lives in `src/`, tests in `tests/`, build output in `dist/`.
 - When the user wants release artifact verification, use `.agents/skills/verify-release/SKILL.md` (`$verify-release`); it runs `yarn verify:artifacts` / `scripts/verify-release.sh`.
 - When the user wants package-level end-to-end verification, use `.agents/skills/run-e2e/SKILL.md` (`$run-e2e`); it runs `scripts/e2e/run.sh`.
 - When the user wants downstream React on Rails verification, use `.agents/skills/downstream-e2e/SKILL.md` (`$downstream-e2e`); this is a documented stub until `scripts/e2e/downstream.sh` lands.
-- When the user wants to upgrade the vendored React Server DOM runtime, use `.agents/skills/react-upgrade/SKILL.md` (`$react-upgrade`) and never hand-edit `src/react-server-dom-webpack/`.
+- When a maintainer explicitly asks to maintain the legacy vendored React Server DOM runtime, use `.agents/skills/react-upgrade/SKILL.md` (`$react-upgrade`) and never hand-edit `src/react-server-dom-webpack/`.
 - When the user wants to refresh the open RSC work status or live backlog map, use `.agents/skills/triage/SKILL.md` (`$triage`) and report unverifiable facts as `UNKNOWN`.
 - Default simplify model: `claude-opus-4-8`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,18 @@ release notes.
 ## React Runtime Artifacts
 
 Never hand-edit files under `src/react-server-dom-webpack/`. Those files are
-runtime artifacts produced by the React upgrade flow and replacement tooling.
-Use the current `scripts/react-upgrade/upgrade.js` cherry-pick flow, and review
-`docs/eliminate-react-fork.md` before changing upgrade strategy.
+runtime artifacts produced by legacy React upgrade flow and replacement
+tooling. Review `docs/eliminate-react-fork.md` before changing runtime
+strategy.
 
-The current upgrade flow still depends on a local React fork path and
-`[RSC-PATCH]` / `[RSC-REPLACE]` cherry-picks. Patch-file or stock-React tooling
-is planned after #60/#71; do not claim it exists until those changes land.
+The stock-runtime strategy is selected, but `main` still carries the vendored
+runtime and `scripts/react-upgrade/` helper. Use
+`scripts/react-upgrade/upgrade.js` only for maintainer-directed emergency
+maintenance of the current vendored runtime, not for the Option 4 patch-file
+fallback.
+Fork patch history is preserved in
+`patches/archive/abanoubghadban-react/`; that archive is provenance, not an
+active runtime path.
 
 ## Validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ runtime and `scripts/react-upgrade/` helper. Use
 `scripts/react-upgrade/upgrade.js` only for maintainer-directed emergency
 maintenance of the current vendored runtime, not for the Option 4 patch-file
 fallback.
+
 Fork patch history is preserved in
 `patches/archive/abanoubghadban-react/`; that archive is provenance, not an
 active runtime path.

--- a/docs/eliminate-react-fork.md
+++ b/docs/eliminate-react-fork.md
@@ -1,19 +1,26 @@
 # Eliminating the React Fork Repository
 
 **Issue:** [#31](https://github.com/shakacode/react_on_rails_rsc/issues/31), [#55](https://github.com/shakacode/react_on_rails_rsc/issues/55) (Option 5 spike)
-**Status:** Option 5 (stock npm runtime) selected — GO, pending the #60 migration gates. Option 4 (patch files) is the documented fallback.
-**Date:** 2026-04-17 (Options 1–4), 2026-06-12 (Option 5 spike)
+**Status:** Option 5 (stock npm runtime) selected — GO. As of 2026-06-13, `main` still carries the
+vendored runtime and legacy `scripts/react-upgrade/` helper after the interim 19.0.7 CVE patch
+([#86](https://github.com/shakacode/react_on_rails_rsc/pull/86)); the stock-runtime replacement
+itself remains outstanding. Option 4 (patch files) is the documented fallback. Fork patch history is
+archived in this repo; archiving `AbanoubGhadban/react` remains an owner/admin action.
+**Date:** 2026-04-17 (Options 1–4), 2026-06-12 (Option 5 spike), 2026-06-13 (patch archive)
 
 ## Background
 
-Upgrading `react-server-dom-webpack` currently requires two repositories:
+The legacy vendored-runtime upgrade flow required two repositories:
 
 1. **`shakacode/react_on_rails_rsc`** (this repo) — the npm package that ships built RSC artifacts in `src/react-server-dom-webpack/`, plus native code (`WebpackPlugin`, `WebpackLoader`, `RSCRspackPlugin`, etc.)
 2. **`abanoubghadban/react`** — a fork of `facebook/react` hosting `rsc-patches/v<version>` branches, each containing `[RSC-PATCH]` commits on top of upstream React version tags.
 
-The fork exists solely to park a small set of source-level patches against React's `packages/react-server-dom-webpack/`, build the patched package, and copy the output into this repo. It has no independent consumers.
+The fork existed solely to park a small set of source-level patches against React's
+`packages/react-server-dom-webpack/`, build the patched package, and copy the output into this repo.
+It has no independent consumers. This live fork path is now legacy-only; use it only for maintainer
+directed emergency maintenance while the stock-runtime replacement is still outstanding.
 
-### Current upgrade flow (via `scripts/react-upgrade/`)
+### Legacy upgrade flow (via `scripts/react-upgrade/`)
 
 ```
 abanoubghadban/react                           shakacode/react_on_rails_rsc
@@ -330,11 +337,11 @@ Diffed vendored (~19.0.4) vs stock 19.2.7 built files:
    `react-on-rails-rsc`) is acceptable; update any docs/tests that assert the branding.
 8. On React 19.3 stable: bump and confirm the JSON-walk perf patch is included (re-run the parse
    benchmark if desired).
-9. Archive `abanoubghadban/react` and delete `scripts/react-upgrade/` fork tooling.
+9. Archive `abanoubghadban/react` and delete or replace `scripts/react-upgrade/` fork tooling.
    **Prerequisite:** all Option 4 fallback criteria (below) have been ruled out, the step 6 smoke
-   test is green, and the fork branches (`rsc-patches/*`) are confirmed no longer needed as a patch
-   source. Archiving keeps the repo readable on GitHub but treat this as the point of no return for
-   the cherry-pick workflow.
+   test is green, the fork branch history is preserved in `patches/archive/`, and an owner/admin
+   archives the fork. Archiving keeps the repo readable on GitHub but treat this as the point of no
+   return for the cherry-pick workflow.
 
 #### Fallback criteria (Option 4, 2-patch corpus)
 
@@ -351,14 +358,41 @@ JSON-walk only until 19.3) applied to vanilla `facebook/react` — if **any** of
 - Upstream stable falls back behind on a security fix we need faster than a release cycle (unlikely —
   the current situation is the reverse).
 
-Option 4 remains fully specified below (Decision section history) and the fork branches
-(`rsc-patches/v19.0.3` @ `2c29304508`) remain available to export patches from until the migration is
-complete and verified.
+Option 4 remains fully specified below (Decision section history). The fork branch history is now
+preserved under `patches/archive/`; do not use the live fork as the normal patch source.
+
+#### Upstream patch and fork-retirement status
+
+Status verified 2026-06-13 for
+[#58](https://github.com/shakacode/react_on_rails_rsc/issues/58) and
+[#71](https://github.com/shakacode/react_on_rails_rsc/issues/71):
+
+- Patch history is preserved in
+  [`patches/archive/abanoubghadban-react/`](../patches/archive/abanoubghadban-react/).
+  This archive includes the three `rsc-patches/v*` branches plus the two
+  upstream-shaped runtime topic branches. It is historical evidence, not the
+  active fallback patch directory.
+- JSON-walk parsing is already upstreamed in
+  [facebook/react#35776](https://github.com/facebook/react/pull/35776),
+  merge commit `f247ebaf44317ac6648b62f99ceaed1e4fc4dc01`; no new upstream PR
+  is needed for that patch.
+- The FOUC topic branch
+  `fix/3211-rsc-css-deferred-suspense` (`980eda222`) is not upstream in
+  `facebook/react` main or `v19.2.7`, but that exact patch shape is obsolete for
+  this repo: it uses the older loader-wrapper/global-manifest approach that #48
+  and #49 replaced with request-scoped stylesheet hints. If the wrapper-layer
+  stock-runtime design fails, upstream or fallback work should be based on the
+  current hint-emission design, not the archived topic patch.
+- The `loadServerReference` bound-args divergence is a stock-runtime smoke-test
+  gate, not an upstream patch request.
+- `AbanoubGhadban/react` is still public and unarchived. The current token has
+  pull-only permission (`admin=false`, `push=false`), so archiving the fork is
+  blocked on owner/admin action.
 
 ## Decision
 
-**Superseded 2026-06-12 by Option 5 (stock npm runtime) — see above; GO, gated on the #60 checklist,
-with Option 4 as the explicit fallback.**
+**Superseded 2026-06-12 by Option 5 (stock npm runtime) — see above; GO, gated on the
+stock-runtime checklist, with Option 4 as the explicit fallback.**
 
 Original decision (2026-04-17): **We are going with Option 4 (patch files).**
 
@@ -368,10 +402,16 @@ The steps below implement Option 4 and apply **only if** an Option 5 fallback cr
 triggered. The active migration plan is the #60 checklist in the Option 5 section.
 
 Original note: implementation will begin in a follow-up issue after the currently open PRs are merged (#29, #21, #20, #11).
+The historical fork patch corpus has since been archived under
+`patches/archive/abanoubghadban-react/`; use that archive as the provenance source for any fallback
+patch-file work.
 
 High-level steps:
 
-1. **Export existing patches** — Run `git format-patch` on each `rsc-patches/v<version>` branch in `abanoubghadban/react` to produce `.patch` files. Commit them to `patches/react-server-dom-webpack/v<version>/`.
+1. **Seed active fallback patches from the archive** — Start from the preserved
+   `patches/archive/abanoubghadban-react/` history and create the minimal active corpus under
+   `patches/react-server-dom-webpack/v<version>/`. Do not depend on the live fork for normal fallback
+   work.
 
 2. **Rewrite `scripts/react-upgrade/upgrade.js`** — Replace the cherry-pick workflow with:
    - Shallow-clone `facebook/react` at the target tag into a temp directory
@@ -386,4 +426,5 @@ High-level steps:
 
 4. **Update CI** — Remove any references to `abanoubghadban/react`. Add a CI job to validate patches apply cleanly against their target React version.
 
-5. **Archive `abanoubghadban/react`** — Once everything is verified, archive or delete the fork.
+5. **Archive `abanoubghadban/react`** — Once everything is verified, have an owner/admin archive or
+   delete the fork.

--- a/docs/repo-improvement-audit-2026-06.md
+++ b/docs/repo-improvement-audit-2026-06.md
@@ -14,6 +14,12 @@ verified, what it implies, and why the backlog is shaped the way it is. Facts
 below were verified on the audit dates; re-verify anything status-sensitive
 before acting on it months later.
 
+> [!NOTE]
+> Post-audit status update (2026-06-13): fork patch history is now preserved in
+> `patches/archive/abanoubghadban-react/`. References below to the fork and
+> `scripts/react-upgrade/` describe the audit-time legacy path unless explicitly
+> marked otherwise.
+
 ---
 
 ## 1. Executive summary

--- a/patches/archive/abanoubghadban-react/README.md
+++ b/patches/archive/abanoubghadban-react/README.md
@@ -27,6 +27,10 @@ The topic branches are archived relative to `e46103dc9` so their directories
 contain only the topic runtime patch, not another copy of the shared plugin
 patch stack.
 
+The `rsc-patches/v19.2.1` branch only carries patches 1-3 from the shared stack.
+The JSON-walk and FOUC topics are preserved separately below; do not infer a
+complete Option 4 patch corpus from the `v19.2.1` branch directory alone.
+
 ## Generation
 
 The archive was generated from a temporary clone:

--- a/patches/archive/abanoubghadban-react/README.md
+++ b/patches/archive/abanoubghadban-react/README.md
@@ -17,11 +17,11 @@ Verified on 2026-06-13:
 
 | Fork ref | Head SHA | Patch base | Archive directory |
 | --- | --- | --- | --- |
-| `rsc-patches/v19.0.1` | `bf802bd40` | `facebook/react` tag `v19.0.1` | `rsc-patches-v19.0.1/` |
-| `rsc-patches/v19.0.3` | `2c2930450` | `facebook/react` tag `v19.0.3` | `rsc-patches-v19.0.3/` |
-| `rsc-patches/v19.2.1` | `4a646d8b1` | `facebook/react` tag `v19.2.1` | `rsc-patches-v19.2.1/` |
-| `perf/rsc-revive-model-walk` | `9dc1d7e63` | common patch-stack commit `e46103dc9` | `topic-perf-rsc-revive-model-walk/` |
-| `fix/3211-rsc-css-deferred-suspense` | `980eda222` | common patch-stack commit `e46103dc9` | `topic-fix-3211-rsc-css-deferred-suspense/` |
+| `rsc-patches/v19.0.1` | `bf802bd4064699910bae9cd0f618183a30caef04` | `facebook/react` tag `v19.0.1` | `rsc-patches-v19.0.1/` |
+| `rsc-patches/v19.0.3` | `2c29304508de9773450421cdffa1fef6246dc4c1` | `facebook/react` tag `v19.0.3` | `rsc-patches-v19.0.3/` |
+| `rsc-patches/v19.2.1` | `4a646d8b129bf9c080f6654bdfd3c40c47a6bd0b` | `facebook/react` tag `v19.2.1` | `rsc-patches-v19.2.1/` |
+| `perf/rsc-revive-model-walk` | `9dc1d7e63f4a3bd6f1154f66cf108d1132e0fc8a` | common patch-stack commit `e46103dc9f4212ee664ace0c2a5fb5395adcc30c` | `topic-perf-rsc-revive-model-walk/` |
+| `fix/3211-rsc-css-deferred-suspense` | `980eda22244208a90b2a21e2e10847795a85b2be` | common patch-stack commit `e46103dc9f4212ee664ace0c2a5fb5395adcc30c` | `topic-fix-3211-rsc-css-deferred-suspense/` |
 
 The topic branches are archived relative to `e46103dc9` so their directories
 contain only the topic runtime patch, not another copy of the shared plugin
@@ -63,6 +63,11 @@ git format-patch e46103dc9..origin/fix/3211-rsc-css-deferred-suspense -o topic-f
   older loader-wrapper/global-manifest implementation; the current project plan
   is the wrapper-layer stock-runtime design documented in
   `docs/eliminate-react-fork.md`.
+  Do not reapply the archived FOUC patch verbatim: it writes manifest state to
+  `globalThis.__reactFlightClientManifest`, which is unsafe for concurrent
+  renders because one request can overwrite another request's manifest. Any
+  Option 4 fallback must preserve the historical intent while using
+  request-scoped manifest plumbing.
 - Fork archive: `AbanoubGhadban/react` was public and not archived on
   2026-06-13. The token used for this archive had pull-only permission, so
   actual repository archiving remains an owner/admin action.

--- a/patches/archive/abanoubghadban-react/README.md
+++ b/patches/archive/abanoubghadban-react/README.md
@@ -1,0 +1,68 @@
+# AbanoubGhadban React Fork Patch Archive
+
+This directory preserves the patch history from
+`AbanoubGhadban/react` for issues
+[#58](https://github.com/shakacode/react_on_rails_rsc/issues/58) and
+[#71](https://github.com/shakacode/react_on_rails_rsc/issues/71).
+
+These files are historical artifacts only. They are not the active
+runtime-upgrade path. The current strategy is Option 5 in
+[`docs/eliminate-react-fork.md`](../../../docs/eliminate-react-fork.md):
+use stock `react-server-dom-webpack` from npm, with Option 4 patch files as
+the fallback if a stock-runtime migration gate fails.
+
+## Source Refs
+
+Verified on 2026-06-13:
+
+| Fork ref | Head SHA | Patch base | Archive directory |
+| --- | --- | --- | --- |
+| `rsc-patches/v19.0.1` | `bf802bd40` | `facebook/react` tag `v19.0.1` | `rsc-patches-v19.0.1/` |
+| `rsc-patches/v19.0.3` | `2c2930450` | `facebook/react` tag `v19.0.3` | `rsc-patches-v19.0.3/` |
+| `rsc-patches/v19.2.1` | `4a646d8b1` | `facebook/react` tag `v19.2.1` | `rsc-patches-v19.2.1/` |
+| `perf/rsc-revive-model-walk` | `9dc1d7e63` | common patch-stack commit `e46103dc9` | `topic-perf-rsc-revive-model-walk/` |
+| `fix/3211-rsc-css-deferred-suspense` | `980eda222` | common patch-stack commit `e46103dc9` | `topic-fix-3211-rsc-css-deferred-suspense/` |
+
+The topic branches are archived relative to `e46103dc9` so their directories
+contain only the topic runtime patch, not another copy of the shared plugin
+patch stack.
+
+## Generation
+
+The archive was generated from a temporary clone:
+
+```bash
+git clone --filter=blob:none --no-checkout https://github.com/AbanoubGhadban/react.git /tmp/abanoub-react-rsc-archive
+cd /tmp/abanoub-react-rsc-archive
+git remote add upstream https://github.com/facebook/react.git
+git fetch origin \
+  refs/heads/rsc-patches/v19.0.1:refs/remotes/origin/rsc-patches/v19.0.1 \
+  refs/heads/rsc-patches/v19.0.3:refs/remotes/origin/rsc-patches/v19.0.3 \
+  refs/heads/rsc-patches/v19.2.1:refs/remotes/origin/rsc-patches/v19.2.1 \
+  refs/heads/perf/rsc-revive-model-walk:refs/remotes/origin/perf/rsc-revive-model-walk \
+  refs/heads/fix/3211-rsc-css-deferred-suspense:refs/remotes/origin/fix/3211-rsc-css-deferred-suspense
+git fetch upstream \
+  refs/tags/v19.0.1:refs/tags/v19.0.1 \
+  refs/tags/v19.0.3:refs/tags/v19.0.3 \
+  refs/tags/v19.2.1:refs/tags/v19.2.1
+
+git format-patch v19.0.1..origin/rsc-patches/v19.0.1 -o rsc-patches-v19.0.1
+git format-patch v19.0.3..origin/rsc-patches/v19.0.3 -o rsc-patches-v19.0.3
+git format-patch v19.2.1..origin/rsc-patches/v19.2.1 -o rsc-patches-v19.2.1
+git format-patch e46103dc9..origin/perf/rsc-revive-model-walk -o topic-perf-rsc-revive-model-walk
+git format-patch e46103dc9..origin/fix/3211-rsc-css-deferred-suspense -o topic-fix-3211-rsc-css-deferred-suspense
+```
+
+## Upstream Status
+
+- JSON-walk parsing: upstreamed in
+  [facebook/react#35776](https://github.com/facebook/react/pull/35776),
+  merge commit `f247ebaf44317ac6648b62f99ceaed1e4fc4dc01`.
+- FOUC deferred-Suspense CSS behavior: not present in `facebook/react` main or
+  tag `v19.2.7` when checked on 2026-06-13. The archived topic branch is the
+  older loader-wrapper/global-manifest implementation; the current project plan
+  is the wrapper-layer stock-runtime design documented in
+  `docs/eliminate-react-fork.md`.
+- Fork archive: `AbanoubGhadban/react` was public and not archived on
+  2026-06-13. The token used for this archive had pull-only permission, so
+  actual repository archiving remains an owner/admin action.

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.1/0001-Add-server-support-for-React-Flight-Webpack-Plugin.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.1/0001-Add-server-support-for-React-Flight-Webpack-Plugin.patch
@@ -1,0 +1,99 @@
+From 32c37973512d21291fbfbe925482fa09a8e0a682 Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sun, 23 Feb 2025 12:58:14 +0200
+Subject: [PATCH 1/3] Add server support for React Flight Webpack Plugin
+
+---
+ .../src/ReactFlightWebpackPlugin.js           | 33 +++++++++++++------
+ 1 file changed, 23 insertions(+), 10 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index 816b9f2a7..bcd7f353f 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -42,7 +42,8 @@ class ClientReferenceDependency extends ModuleDependency {
+ // without the client runtime so it's the first time in the loading sequence
+ // you might want them.
+ const clientImportName = 'react-server-dom-webpack/client';
+-const clientFileName = require.resolve('../client.browser.js');
++const clientFileNameOnClient = require.resolve('../client.browser.js');
++const clientFileNameOnServer = require.resolve('../client.node.js');
+ 
+ type ClientReferenceSearchPath = {
+   directory: string,
+@@ -68,6 +69,7 @@ export default class ReactFlightWebpackPlugin {
+   chunkName: string;
+   clientManifestFilename: string;
+   serverConsumerManifestFilename: string;
++  isServer: boolean;
+ 
+   constructor(options: Options) {
+     if (!options || typeof options.isServer !== 'boolean') {
+@@ -75,9 +77,6 @@ export default class ReactFlightWebpackPlugin {
+         PLUGIN_NAME + ': You must specify the isServer option as a boolean.',
+       );
+     }
+-    if (options.isServer) {
+-      throw new Error('TODO: Implement the server compiler.');
+-    }
+     if (!options.clientReferences) {
+       this.clientReferences = [
+         {
+@@ -103,8 +102,12 @@ export default class ReactFlightWebpackPlugin {
+     } else {
+       this.chunkName = 'client[index]';
+     }
++    this.isServer = options.isServer;
++    const defaultClientManifestFilename = options.isServer
++      ? 'react-server-client-manifest.json'
++      : 'react-client-manifest.json';
+     this.clientManifestFilename =
+-      options.clientManifestFilename || 'react-client-manifest.json';
++      options.clientManifestFilename || defaultClientManifestFilename;
+     this.serverConsumerManifestFilename =
+       options.serverConsumerManifestFilename || 'react-ssr-manifest.json';
+   }
+@@ -162,6 +165,9 @@ export default class ReactFlightWebpackPlugin {
+           parser.hooks.program.tap(PLUGIN_NAME, () => {
+             const module = parser.state.module;
+ 
++            const clientFileName = _this.isServer
++              ? clientFileNameOnServer
++              : clientFileNameOnClient;
+             if (module.resource !== clientFileName) {
+               return;
+             }
+@@ -305,6 +311,11 @@ export default class ReactFlightWebpackPlugin {
+                   chunks,
+                   name: '*',
+                 };
++
++                if (_this.isServer) {
++                  return;
++                }
++
+                 ssrExports['*'] = {
+                   specifier: href,
+                   name: '*',
+@@ -372,11 +383,13 @@ export default class ReactFlightWebpackPlugin {
+             _this.clientManifestFilename,
+             new sources.RawSource(clientOutput, false),
+           );
+-          const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
+-          compilation.emitAsset(
+-            _this.serverConsumerManifestFilename,
+-            new sources.RawSource(ssrOutput, false),
+-          );
++          if (!_this.isServer) {
++            const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
++            compilation.emitAsset(
++              _this.serverConsumerManifestFilename,
++              new sources.RawSource(ssrOutput, false),
++            );
++          }
+         },
+       );
+     });
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.1/0002-make-rsc-plugin-create-a-manifest-for-server-build.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.1/0002-make-rsc-plugin-create-a-manifest-for-server-build.patch
@@ -1,0 +1,135 @@
+From 0c3ab161aa87f8ddd260363551d4df550379162c Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sun, 8 Jun 2025 15:41:54 +0300
+Subject: [PATCH 2/3] make rsc plugin create a manifest for server build
+
+---
+ .../src/ReactFlightWebpackPlugin.js           | 81 +++----------------
+ 1 file changed, 10 insertions(+), 71 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index bcd7f353f..fd41db05a 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -242,27 +242,23 @@ export default class ReactFlightWebpackPlugin {
+             (resolvedClientReferences || []).map(ref => ref.request),
+           );
+ 
+-          const clientManifest: {
++          type FilePathToModuleMetadata = {
+             [string]: ImportManifestEntry,
+-          } = {};
+-          type ServerConsumerModuleMap = {
+-            [string]: {
+-              [string]: {specifier: string, name: string},
+-            },
+           };
+-          const moduleMap: ServerConsumerModuleMap = {};
+-          const ssrBundleConfig: {
++          type BundleManifest = {
+             moduleLoading: {
+               prefix: string,
+               crossOrigin: string | null,
+             },
+-            moduleMap: ServerConsumerModuleMap,
+-          } = {
++            filePathToModuleMetadata: FilePathToModuleMetadata,
++          };
++          const filePathToModuleMetadata: FilePathToModuleMetadata = {};
++          const bundleManifest: BundleManifest = {
+             moduleLoading: {
+               prefix: compilation.outputOptions.publicPath || '',
+               crossOrigin: crossOriginMode,
+             },
+-            moduleMap,
++            filePathToModuleMetadata,
+           };
+ 
+           // We figure out which files are always loaded by any initial chunk (entrypoint).
+@@ -302,61 +298,11 @@ export default class ReactFlightWebpackPlugin {
+               const href = pathToFileURL(module.resource).href;
+ 
+               if (href !== undefined) {
+-                const ssrExports: {
+-                  [string]: {specifier: string, name: string},
+-                } = {};
+-
+-                clientManifest[href] = {
++                filePathToModuleMetadata[href] = {
+                   id,
+                   chunks,
+                   name: '*',
+                 };
+-
+-                if (_this.isServer) {
+-                  return;
+-                }
+-
+-                ssrExports['*'] = {
+-                  specifier: href,
+-                  name: '*',
+-                };
+-
+-                // TODO: If this module ends up split into multiple modules, then
+-                // we should encode each the chunks needed for the specific export.
+-                // When the module isn't split, it doesn't matter and we can just
+-                // encode the id of the whole module. This code doesn't currently
+-                // deal with module splitting so is likely broken from ESM anyway.
+-                /*
+-                clientManifest[href + '#'] = {
+-                  id,
+-                  chunks,
+-                  name: '',
+-                };
+-                ssrExports[''] = {
+-                  specifier: href,
+-                  name: '',
+-                };
+-
+-                const moduleProvidedExports = compilation.moduleGraph
+-                  .getExportsInfo(module)
+-                  .getProvidedExports();
+-
+-                if (Array.isArray(moduleProvidedExports)) {
+-                  moduleProvidedExports.forEach(function (name) {
+-                    clientManifest[href + '#' + name] = {
+-                      id,
+-                      chunks,
+-                      name: name,
+-                    };
+-                    ssrExports[name] = {
+-                      specifier: href,
+-                      name: name,
+-                    };
+-                  });
+-                }
+-                */
+-
+-                moduleMap[id] = ssrExports;
+               }
+             }
+ 
+@@ -378,18 +324,11 @@ export default class ReactFlightWebpackPlugin {
+             });
+           });
+ 
+-          const clientOutput = JSON.stringify(clientManifest, null, 2);
++          const bundleOutput = JSON.stringify(bundleManifest, null, 2);
+           compilation.emitAsset(
+             _this.clientManifestFilename,
+-            new sources.RawSource(clientOutput, false),
++            new sources.RawSource(bundleOutput, false),
+           );
+-          if (!_this.isServer) {
+-            const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
+-            compilation.emitAsset(
+-              _this.serverConsumerManifestFilename,
+-              new sources.RawSource(ssrOutput, false),
+-            );
+-          }
+         },
+       );
+     });
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.1/0003-RSC-PATCH-Fix-chunk-merge-bug-in-ReactFlightWebpackP.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.1/0003-RSC-PATCH-Fix-chunk-merge-bug-in-ReactFlightWebpackP.patch
@@ -1,0 +1,59 @@
+From bf802bd4064699910bae9cd0f618183a30caef04 Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Tue, 24 Feb 2026 18:11:03 +0200
+Subject: [PATCH 3/3] [RSC-PATCH] Fix chunk-merge bug in
+ ReactFlightWebpackPlugin recordModule
+
+When a 'use client' module appears in multiple webpack chunk groups,
+recordModule() was overwriting the manifest entry instead of merging
+chunk arrays. This caused missing chunk preloads during RSC hydration,
+leading to __webpack_require__ failures under slow networks.
+
+The fix merges chunk arrays from all chunk groups for each module,
+ensuring the flight client preloads all necessary chunks.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../src/ReactFlightWebpackPlugin.js           | 26 +++++++++++++++----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index fd41db05a..17e7169c8 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -298,11 +298,27 @@ export default class ReactFlightWebpackPlugin {
+               const href = pathToFileURL(module.resource).href;
+ 
+               if (href !== undefined) {
+-                filePathToModuleMetadata[href] = {
+-                  id,
+-                  chunks,
+-                  name: '*',
+-                };
++                if (filePathToModuleMetadata[href]) {
++                  // Merge chunks from additional chunk groups instead of overwriting.
++                  // A module can appear in multiple chunk groups, and all chunks
++                  // need to be recorded so the flight client preloads them all.
++                  const existing = filePathToModuleMetadata[href];
++                  const existingChunkIds: Set<mixed> = new Set();
++                  for (let i = 0; i < existing.chunks.length; i += 2) {
++                    existingChunkIds.add(existing.chunks[i]);
++                  }
++                  for (let j = 0; j < chunks.length; j += 2) {
++                    if (!existingChunkIds.has(chunks[j])) {
++                      existing.chunks.push(chunks[j], chunks[j + 1]);
++                    }
++                  }
++                } else {
++                  filePathToModuleMetadata[href] = {
++                    id,
++                    chunks: chunks.slice(),
++                    name: '*',
++                  };
++                }
+               }
+             }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0001-RSC-PATCH-Add-server-support-for-React-Flight-Webpac.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0001-RSC-PATCH-Add-server-support-for-React-Flight-Webpac.patch
@@ -1,0 +1,100 @@
+From 9eaa8a8fefe2830c8e0e6062e00dfaf9cc88c91b Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sun, 23 Feb 2025 12:58:14 +0200
+Subject: [PATCH 1/7] [RSC-PATCH] Add server support for React Flight Webpack
+ Plugin
+
+---
+ .../src/ReactFlightWebpackPlugin.js           | 33 +++++++++++++------
+ 1 file changed, 23 insertions(+), 10 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index 816b9f2a7..bcd7f353f 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -42,7 +42,8 @@ class ClientReferenceDependency extends ModuleDependency {
+ // without the client runtime so it's the first time in the loading sequence
+ // you might want them.
+ const clientImportName = 'react-server-dom-webpack/client';
+-const clientFileName = require.resolve('../client.browser.js');
++const clientFileNameOnClient = require.resolve('../client.browser.js');
++const clientFileNameOnServer = require.resolve('../client.node.js');
+ 
+ type ClientReferenceSearchPath = {
+   directory: string,
+@@ -68,6 +69,7 @@ export default class ReactFlightWebpackPlugin {
+   chunkName: string;
+   clientManifestFilename: string;
+   serverConsumerManifestFilename: string;
++  isServer: boolean;
+ 
+   constructor(options: Options) {
+     if (!options || typeof options.isServer !== 'boolean') {
+@@ -75,9 +77,6 @@ export default class ReactFlightWebpackPlugin {
+         PLUGIN_NAME + ': You must specify the isServer option as a boolean.',
+       );
+     }
+-    if (options.isServer) {
+-      throw new Error('TODO: Implement the server compiler.');
+-    }
+     if (!options.clientReferences) {
+       this.clientReferences = [
+         {
+@@ -103,8 +102,12 @@ export default class ReactFlightWebpackPlugin {
+     } else {
+       this.chunkName = 'client[index]';
+     }
++    this.isServer = options.isServer;
++    const defaultClientManifestFilename = options.isServer
++      ? 'react-server-client-manifest.json'
++      : 'react-client-manifest.json';
+     this.clientManifestFilename =
+-      options.clientManifestFilename || 'react-client-manifest.json';
++      options.clientManifestFilename || defaultClientManifestFilename;
+     this.serverConsumerManifestFilename =
+       options.serverConsumerManifestFilename || 'react-ssr-manifest.json';
+   }
+@@ -162,6 +165,9 @@ export default class ReactFlightWebpackPlugin {
+           parser.hooks.program.tap(PLUGIN_NAME, () => {
+             const module = parser.state.module;
+ 
++            const clientFileName = _this.isServer
++              ? clientFileNameOnServer
++              : clientFileNameOnClient;
+             if (module.resource !== clientFileName) {
+               return;
+             }
+@@ -305,6 +311,11 @@ export default class ReactFlightWebpackPlugin {
+                   chunks,
+                   name: '*',
+                 };
++
++                if (_this.isServer) {
++                  return;
++                }
++
+                 ssrExports['*'] = {
+                   specifier: href,
+                   name: '*',
+@@ -372,11 +383,13 @@ export default class ReactFlightWebpackPlugin {
+             _this.clientManifestFilename,
+             new sources.RawSource(clientOutput, false),
+           );
+-          const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
+-          compilation.emitAsset(
+-            _this.serverConsumerManifestFilename,
+-            new sources.RawSource(ssrOutput, false),
+-          );
++          if (!_this.isServer) {
++            const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
++            compilation.emitAsset(
++              _this.serverConsumerManifestFilename,
++              new sources.RawSource(ssrOutput, false),
++            );
++          }
+         },
+       );
+     });
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0002-RSC-PATCH-make-rsc-plugin-create-a-manifest-for-serv.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0002-RSC-PATCH-make-rsc-plugin-create-a-manifest-for-serv.patch
@@ -1,0 +1,136 @@
+From da4a8e6245370a514bb193a4eb94eccd6e868968 Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sun, 8 Jun 2025 15:41:54 +0300
+Subject: [PATCH 2/7] [RSC-PATCH] make rsc plugin create a manifest for server
+ build
+
+---
+ .../src/ReactFlightWebpackPlugin.js           | 81 +++----------------
+ 1 file changed, 10 insertions(+), 71 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index bcd7f353f..fd41db05a 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -242,27 +242,23 @@ export default class ReactFlightWebpackPlugin {
+             (resolvedClientReferences || []).map(ref => ref.request),
+           );
+ 
+-          const clientManifest: {
++          type FilePathToModuleMetadata = {
+             [string]: ImportManifestEntry,
+-          } = {};
+-          type ServerConsumerModuleMap = {
+-            [string]: {
+-              [string]: {specifier: string, name: string},
+-            },
+           };
+-          const moduleMap: ServerConsumerModuleMap = {};
+-          const ssrBundleConfig: {
++          type BundleManifest = {
+             moduleLoading: {
+               prefix: string,
+               crossOrigin: string | null,
+             },
+-            moduleMap: ServerConsumerModuleMap,
+-          } = {
++            filePathToModuleMetadata: FilePathToModuleMetadata,
++          };
++          const filePathToModuleMetadata: FilePathToModuleMetadata = {};
++          const bundleManifest: BundleManifest = {
+             moduleLoading: {
+               prefix: compilation.outputOptions.publicPath || '',
+               crossOrigin: crossOriginMode,
+             },
+-            moduleMap,
++            filePathToModuleMetadata,
+           };
+ 
+           // We figure out which files are always loaded by any initial chunk (entrypoint).
+@@ -302,61 +298,11 @@ export default class ReactFlightWebpackPlugin {
+               const href = pathToFileURL(module.resource).href;
+ 
+               if (href !== undefined) {
+-                const ssrExports: {
+-                  [string]: {specifier: string, name: string},
+-                } = {};
+-
+-                clientManifest[href] = {
++                filePathToModuleMetadata[href] = {
+                   id,
+                   chunks,
+                   name: '*',
+                 };
+-
+-                if (_this.isServer) {
+-                  return;
+-                }
+-
+-                ssrExports['*'] = {
+-                  specifier: href,
+-                  name: '*',
+-                };
+-
+-                // TODO: If this module ends up split into multiple modules, then
+-                // we should encode each the chunks needed for the specific export.
+-                // When the module isn't split, it doesn't matter and we can just
+-                // encode the id of the whole module. This code doesn't currently
+-                // deal with module splitting so is likely broken from ESM anyway.
+-                /*
+-                clientManifest[href + '#'] = {
+-                  id,
+-                  chunks,
+-                  name: '',
+-                };
+-                ssrExports[''] = {
+-                  specifier: href,
+-                  name: '',
+-                };
+-
+-                const moduleProvidedExports = compilation.moduleGraph
+-                  .getExportsInfo(module)
+-                  .getProvidedExports();
+-
+-                if (Array.isArray(moduleProvidedExports)) {
+-                  moduleProvidedExports.forEach(function (name) {
+-                    clientManifest[href + '#' + name] = {
+-                      id,
+-                      chunks,
+-                      name: name,
+-                    };
+-                    ssrExports[name] = {
+-                      specifier: href,
+-                      name: name,
+-                    };
+-                  });
+-                }
+-                */
+-
+-                moduleMap[id] = ssrExports;
+               }
+             }
+ 
+@@ -378,18 +324,11 @@ export default class ReactFlightWebpackPlugin {
+             });
+           });
+ 
+-          const clientOutput = JSON.stringify(clientManifest, null, 2);
++          const bundleOutput = JSON.stringify(bundleManifest, null, 2);
+           compilation.emitAsset(
+             _this.clientManifestFilename,
+-            new sources.RawSource(clientOutput, false),
++            new sources.RawSource(bundleOutput, false),
+           );
+-          if (!_this.isServer) {
+-            const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
+-            compilation.emitAsset(
+-              _this.serverConsumerManifestFilename,
+-              new sources.RawSource(ssrOutput, false),
+-            );
+-          }
+         },
+       );
+     });
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0003-RSC-PATCH-Fix-chunk-merge-bug-in-ReactFlightWebpackP.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0003-RSC-PATCH-Fix-chunk-merge-bug-in-ReactFlightWebpackP.patch
@@ -1,0 +1,59 @@
+From 0bae75bf2bb74ec8bf507ed058fa2211a6286e84 Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Tue, 24 Feb 2026 18:11:32 +0200
+Subject: [PATCH 3/7] [RSC-PATCH] Fix chunk-merge bug in
+ ReactFlightWebpackPlugin recordModule
+
+When a 'use client' module appears in multiple webpack chunk groups,
+recordModule() was overwriting the manifest entry instead of merging
+chunk arrays. This caused missing chunk preloads during RSC hydration,
+leading to __webpack_require__ failures under slow networks.
+
+The fix merges chunk arrays from all chunk groups for each module,
+ensuring the flight client preloads all necessary chunks.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../src/ReactFlightWebpackPlugin.js           | 26 +++++++++++++++----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index fd41db05a..17e7169c8 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -298,11 +298,27 @@ export default class ReactFlightWebpackPlugin {
+               const href = pathToFileURL(module.resource).href;
+ 
+               if (href !== undefined) {
+-                filePathToModuleMetadata[href] = {
+-                  id,
+-                  chunks,
+-                  name: '*',
+-                };
++                if (filePathToModuleMetadata[href]) {
++                  // Merge chunks from additional chunk groups instead of overwriting.
++                  // A module can appear in multiple chunk groups, and all chunks
++                  // need to be recorded so the flight client preloads them all.
++                  const existing = filePathToModuleMetadata[href];
++                  const existingChunkIds: Set<mixed> = new Set();
++                  for (let i = 0; i < existing.chunks.length; i += 2) {
++                    existingChunkIds.add(existing.chunks[i]);
++                  }
++                  for (let j = 0; j < chunks.length; j += 2) {
++                    if (!existingChunkIds.has(chunks[j])) {
++                      existing.chunks.push(chunks[j], chunks[j + 1]);
++                    }
++                  }
++                } else {
++                  filePathToModuleMetadata[href] = {
++                    id,
++                    chunks: chunks.slice(),
++                    name: '*',
++                  };
++                }
+               }
+             }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0004-RSC-PATCH-Fix-client-manifest-chunk-scan-when-non-JS.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0004-RSC-PATCH-Fix-client-manifest-chunk-scan-when-non-JS.patch
@@ -1,0 +1,129 @@
+From e46103dc9f4212ee664ace0c2a5fb5395adcc30c Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sat, 18 Apr 2026 17:34:58 +0200
+Subject: [PATCH 4/7] [RSC-PATCH] Fix client manifest chunk scan when non-JS
+ assets precede JS
+
+Co-Authored-By: Yassa Tamer <yassatamer99@gmail.com>
+---
+ .../flight/__tests__/__e2e__/smoke.test.js    | 58 +++++++++++++++++++
+ fixtures/flight/src/Dynamic.css               |  3 +
+ fixtures/flight/src/Dynamic.js                |  3 +-
+ .../src/ReactFlightWebpackPlugin.js           |  8 +--
+ 4 files changed, 67 insertions(+), 5 deletions(-)
+ create mode 100644 fixtures/flight/src/Dynamic.css
+
+diff --git a/fixtures/flight/__tests__/__e2e__/smoke.test.js b/fixtures/flight/__tests__/__e2e__/smoke.test.js
+index f2bcbbd11..ad55a2239 100644
+--- a/fixtures/flight/__tests__/__e2e__/smoke.test.js
++++ b/fixtures/flight/__tests__/__e2e__/smoke.test.js
+@@ -27,3 +27,61 @@ test('smoke test', async ({page}) => {
+   await expect(consoleErrors).toEqual([]);
+   await expect(pageErrors).toEqual([]);
+ });
++
++test('records JS chunks for CSS-importing client component and loads it in both paths', async ({
++  page,
++  request,
++}) => {
++  const consoleErrors = [];
++  page.on('console', msg => {
++    const type = msg.type();
++    if (type === 'warn' || type === 'error') {
++      consoleErrors.push({type, text: msg.text()});
++    }
++  });
++
++  const pageErrors = [];
++  page.on('pageerror', error => {
++    pageErrors.push(error.stack || error.message);
++  });
++
++  await page.goto('/');
++
++  const manifestResponse = await request.get('/react-client-manifest.json');
++  expect(manifestResponse.ok()).toBe(true);
++  const manifest = await manifestResponse.json();
++
++  const moduleMetadata =
++    manifest.filePathToModuleMetadata ?? manifest;
++
++  const dynamicEntry = Object.entries(moduleMetadata).find(([key]) =>
++    /\/Dynamic\.js$/.test(key)
++  );
++  expect(dynamicEntry).toBeTruthy();
++
++  const [, entry] = dynamicEntry;
++  expect(entry.chunks.length).toBeGreaterThan(0);
++
++  // chunks array is [chunkId, filename, chunkId, filename, …] pairs
++  const filenames = entry.chunks.filter((_, index) => index % 2 === 1);
++  expect(
++    filenames.some(
++      name => typeof name === 'string' && name.endsWith('.js') && !name.endsWith('.hot-update.js')
++    )
++  ).toBe(true);
++  expect(
++    filenames.some(name => typeof name === 'string' && name.endsWith('.css'))
++  ).toBe(false);
++
++  await expect(page.getByTestId('dynamic-component')).toHaveCount(1);
++  await expect(pageErrors).toEqual([]);
++  await expect(consoleErrors).toEqual([]);
++
++  await page.getByRole('button', {name: 'Load dynamic import Component'}).click();
++
++  await expect(page.getByText('loaded dynamically:')).toBeVisible();
++  await expect(page.getByTestId('dynamic-component')).toHaveCount(2);
++
++  await expect(pageErrors).toEqual([]);
++  await expect(consoleErrors).toEqual([]);
++});
+diff --git a/fixtures/flight/src/Dynamic.css b/fixtures/flight/src/Dynamic.css
+new file mode 100644
+index 000000000..d35585efb
+--- /dev/null
++++ b/fixtures/flight/src/Dynamic.css
+@@ -0,0 +1,3 @@
++.dynamic-component {
++  color: blue;
++}
+diff --git a/fixtures/flight/src/Dynamic.js b/fixtures/flight/src/Dynamic.js
+index dac88887c..e05a4365e 100644
+--- a/fixtures/flight/src/Dynamic.js
++++ b/fixtures/flight/src/Dynamic.js
+@@ -1,10 +1,11 @@
+ 'use client';
+ 
+ import * as React from 'react';
++import './Dynamic.css';
+ 
+ export function Dynamic() {
+   return (
+-    <div>
++    <div data-testid="dynamic-component" className="dynamic-component">
+       This client component should be loaded in a single chunk even when it is
+       used as both a client reference and as a dynamic import.
+     </div>
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index 17e7169c8..a574fd3eb 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -279,10 +279,10 @@ export default class ReactFlightWebpackPlugin {
+             chunkGroup.chunks.forEach(function (c) {
+               // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+               for (const file of c.files) {
+-                if (!file.endsWith('.js')) return;
+-                if (file.endsWith('.hot-update.js')) return;
+-                chunks.push(c.id, file);
+-                break;
++                if (file.endsWith('.js') && !file.endsWith('.hot-update.js')) {
++                  chunks.push(c.id, file);
++                  break;
++                }
+               }
+             });
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0005-RSC-PATCH-Walk-parsed-JSON-instead-of-using-reviver-.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0005-RSC-PATCH-Walk-parsed-JSON-instead-of-using-reviver-.patch
@@ -1,0 +1,141 @@
+From de87a300430ed558a2ae84f68390037c76ded67f Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <ghdbana@gmail.com>
+Date: Mon, 4 May 2026 18:03:01 +0300
+Subject: [PATCH 5/7] [RSC-PATCH] Walk parsed JSON instead of using reviver for
+ parsing RSC payload (#4)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Backport of facebook/react#35776 to v19.0.3.
+
+Replaces the JSON.parse reviver callback in parseModel with a two-step approach: plain JSON.parse() followed by a recursive reviveModel() walk in pure JavaScript. Yields ~75% speedup in RSC chunk deserialization by eliminating C++→JS boundary crossings for every key-value pair.
+
+Also adds a no-op setter on the $Y (omitted object) getter-only property to prevent TypeError under strict mode when reviveModel reassigns the property after parseModelString returns.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+---
+ .../react-client/src/ReactFlightClient.js     | 58 ++++++++++++++-----
+ .../src/ReactNoopFlightClient.js              |  3 -
+ 2 files changed, 45 insertions(+), 16 deletions(-)
+
+diff --git a/packages/react-client/src/ReactFlightClient.js b/packages/react-client/src/ReactFlightClient.js
+index 376f502a7..d28cfb1c3 100644
+--- a/packages/react-client/src/ReactFlightClient.js
++++ b/packages/react-client/src/ReactFlightClient.js
+@@ -276,7 +276,6 @@ export type Response = {
+   _encodeFormAction: void | EncodeFormActionCallback,
+   _nonce: ?string,
+   _chunks: Map<number, SomeChunk<any>>,
+-  _fromJSON: (key: string, value: JSONValue) => any,
+   _stringDecoder: StringDecoder,
+   _rowState: RowParserState,
+   _rowID: number, // parts of a row ID parsed so far
+@@ -1508,6 +1507,11 @@ function parseModelString(
+                 'or more specific objects.'
+               );
+             },
++            // no-op: the walk function may try to reassign this property after
++            // parseModelString returns. With the JSON.parse reviver, the engine's
++            // internal CreateDataProperty silently failed. We use a no-op setter
++            // to match that behavior in strict mode.
++            set: function () {},
+             enumerable: true,
+             configurable: false,
+           });
+@@ -1576,7 +1580,6 @@ function ResponseInstance(
+   this._nonce = nonce;
+   this._chunks = chunks;
+   this._stringDecoder = createStringDecoder();
+-  this._fromJSON = (null: any);
+   this._rowState = 0;
+   this._rowID = 0;
+   this._rowTag = 0;
+@@ -1618,8 +1621,6 @@ function ResponseInstance(
+     this._replayConsole = replayConsole;
+     this._rootEnvironmentName = rootEnv;
+   }
+-  // Don't inline this call because it causes closure to outline the call above.
+-  this._fromJSON = createFromJSONCallback(this);
+ }
+ 
+ export function createResponse(
+@@ -3138,21 +3139,52 @@ export function processStringChunk(response: Response, chunk: string): void {
+ }
+ 
+ function parseModel<T>(response: Response, json: UninitializedModel): T {
+-  return JSON.parse(json, response._fromJSON);
++  const rawModel = JSON.parse(json);
++  // Pass a wrapper object as parentObject to match the original JSON.parse
++  // reviver behavior, where the root value's reviver receives {"": rootValue}
++  // as `this`. This ensures parentObject is never null when accessed downstream.
++  return reviveModel(response, rawModel, {'': rawModel}, '');
+ }
+ 
+-function createFromJSONCallback(response: Response) {
+-  // $FlowFixMe[missing-this-annot]
+-  return function (key: string, value: JSONValue) {
+-    if (typeof value === 'string') {
+-      // We can't use .bind here because we need the "this" value.
+-      return parseModelString(response, this, key, value);
++function reviveModel(
++  response: Response,
++  value: JSONValue,
++  parentObject: Object,
++  key: string,
++): any {
++  if (typeof value === 'string') {
++    if (value[0] === '$') {
++      return parseModelString(response, parentObject, key, value);
++    }
++    return value;
++  }
++  if (typeof value !== 'object' || value === null) {
++    return value;
++  }
++  if (isArray(value)) {
++    for (let i = 0; i < value.length; i++) {
++      (value: any)[i] = reviveModel(response, value[i], value, '' + i);
+     }
+-    if (typeof value === 'object' && value !== null) {
++    if (value[0] === REACT_ELEMENT_TYPE) {
++      // React element tuple
+       return parseModelTuple(response, value);
+     }
+     return value;
+-  };
++  }
++  // Plain object
++  for (const k in value) {
++    if (k === '__proto__') {
++      delete (value: any)[k];
++    } else {
++      const walked = reviveModel(response, (value: any)[k], value, k);
++      if (walked !== undefined) {
++        (value: any)[k] = walked;
++      } else {
++        delete (value: any)[k];
++      }
++    }
++  }
++  return value;
+ }
+ 
+ export function close(response: Response): void {
+diff --git a/packages/react-noop-renderer/src/ReactNoopFlightClient.js b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+index 346433404..aa093fc42 100644
+--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
++++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+@@ -42,9 +42,6 @@ const {createResponse, processBinaryChunk, getRoot, close} = ReactFlightClient({
+   requireModule(idx: string) {
+     return readModule(idx);
+   },
+-  parseModel(response: Response, json) {
+-    return JSON.parse(json, response._fromJSON);
+-  },
+   bindToConsole(methodName, args, badgeName) {
+     return Function.prototype.bind.apply(
+       // eslint-disable-next-line react-internal/no-production-logging
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0006-RSC-PATCH-Fix-FOUC-for-use-client-CSS-in-deferred-Su.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0006-RSC-PATCH-Fix-FOUC-for-use-client-CSS-in-deferred-Su.patch
@@ -1,0 +1,395 @@
+From 4c02caac8888e8e8b6145bc2780a8145cb2c921a Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <ghdbana@gmail.com>
+Date: Tue, 5 May 2026 18:06:56 +0300
+Subject: [PATCH 6/7] [RSC-PATCH] Fix FOUC for use-client CSS in deferred
+ Suspense subtrees (#5)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem
+-------
+
+When a `'use client'` component imports a CSS Module and lives inside a
+deferred Suspense subtree (an async server-component ancestor), the
+resolution chunk that streams in carries the client component's HTML
+but no in-tree stylesheet element. React DOM emits its `$RC` swap
+script (immediate swap), not `$RR` (gated swap). The browser swaps the
+styled <div> into view before its stylesheet has loaded, producing a
+flash of unstyled content. Empirically observed on Slow 3G; verified
+by reading React's resolution-chunk emission protocol — `$RR` is emitted
+exclusively when an in-tree `<link rel="stylesheet" precedence>` element
+is rendered as part of a streaming Suspense resolution. Hint-form
+`preinit` calls do NOT produce `$RR`.
+
+Fix
+---
+
+Three coordinated changes:
+
+1. Plugin (`ReactFlightWebpackPlugin.js`): for every chunkGroup, walk
+   `c.files` for `.css` siblings of the JS chunks. Record them as a
+   sibling `css: string[]` array on each client-reference manifest entry,
+   prefixed with `compilation.outputOptions.publicPath` so they are
+   usable URLs. The `css` field is merged across multiple chunkGroups
+   that resolve the same module, mirroring the existing `chunks` merge.
+
+2. Loader (`ReactFlightWebpackNodeLoader.js` -> `transformClientModule`):
+   instead of emitting raw `registerClientReference(...)` exports, emit
+   server-side wrapper functions per export. Each wrapper, when invoked
+   by React Flight during render, looks up its CSS hrefs from
+   `globalThis.__reactFlightClientManifest` and returns a Fragment
+   containing one `<link rel="stylesheet" precedence="rsc-css" href={css}/>`
+   per file plus the original client reference. React Flight encodes the
+   link as regular in-tree JSX and the client reference as `I[...]` as
+   before; the only thing that changes in the encoded RSC payload is
+   that the bare element `["$","$L<id>",null,props]` becomes a
+   2-element array `[<linkElement>, ["$","$L<id>",null,props]]` (a
+   key-less Fragment).
+
+   When the resolution chunk is a separate flush from the shell (the
+   normal deferred-Suspense case), React DOM sees the in-tree `<link>`
+   inside the resolved subtree, treats it as a precedence-managed
+   stylesheet resource, and emits `$RR(boundary, segment, [[href,
+   precedence]])` instead of `$RC(...)`. `$RR` creates a
+   `<link rel=stylesheet>` in `<head>` client-side, awaits its `load`
+   event, and only then runs the swap. The styled subtree never paints
+   unstyled.
+
+   When the resolution is fast enough to merge into the shell (no async
+   above the boundary), the link goes into the shell directly; the
+   browser's standard CSSOM render-blocking handles FOUC prevention.
+   Either way, no unstyled paint reaches the user.
+
+3. Server entry points (`ReactFlightDOMServerNode.js`,
+   `ReactFlightDOMServerEdge.js`, `ReactFlightDOMServerBrowser.js`):
+   publish the manifest to `globalThis.__reactFlightClientManifest` as
+   a side effect of `renderToPipeableStream`/`renderToReadableStream`/
+   `prerender*`. The loader-emitted wrappers find it without any
+   consumer-side wiring. Single assignment per render call; safe to
+   overwrite each time since the wrappers only read it during the same
+   render that just set it.
+
+Verification
+------------
+
+A standalone harness rendered an async-resolved Suspense subtree
+containing a `'use client'` boundary, with the CSS endpoint delayed by
+4 seconds. With this patch, the SSR HTML contains the wrapping pattern
+in the RSC payload and `$RR(...,[["/path/to.css","rsc-css"]])` in the
+resolution chunk; in the browser, the fallback stays visible until the
+stylesheet load event fires (~5s = 1s async + 4s CSS), then the styled
+subtree appears in a single frame. Without the patch, the styled card
+paints unstyled the moment the resolution chunk arrives — i.e., the
+flash this patch eliminates.
+---
+ .../src/ReactFlightWebpackNodeLoader.js       | 123 ++++++++++++++----
+ .../src/ReactFlightWebpackPlugin.js           |  42 +++++-
+ .../src/server/ReactFlightDOMServerBrowser.js |   5 +
+ .../src/server/ReactFlightDOMServerEdge.js    |   5 +
+ .../src/server/ReactFlightDOMServerNode.js    |   8 ++
+ .../src/shared/ReactFlightImportMetadata.js   |   6 +
+ 6 files changed, 161 insertions(+), 28 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+index 9799acc3a..2cd07cf55 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+@@ -584,37 +584,110 @@ async function transformClientModule(
+     return '';
+   }
+ 
++  // FOUC fix: for component-shaped exports of a 'use client' file, emit a
++  // server-side wrapper that renders
++  //   <><link rel=stylesheet precedence=rsc-css href=…/>...<RealRef {...props}/></>
++  // so React DOM emits its $RR gating script for deferred Suspense subtrees,
++  // holding the swap until the stylesheet's load event fires — the only
++  // mechanism that fully prevents flash-of-unstyled-content for a styled
++  // client component that streams in via Suspense.
++  //
++  // Non-component exports (lowercase-named) keep the original client-
++  // reference shim so they can still be passed across the server/client
++  // boundary as tagged values (hooks, stores, constants, plain utilities,
++  // etc.). Wrapping non-components would turn passing them as values into a
++  // serialization failure.
++  //
++  // CSS hrefs are looked up at runtime from
++  // globalThis.__reactFlightClientManifest, which the public render entry
++  // points (renderToPipeableStream / renderToReadableStream / prerender)
++  // populate as a side effect on entry. The lookup runs on every wrapper
++  // invocation (no closure cache) so HMR rebuilds and multi-bundle setups
++  // always read the current manifest.
++  //
++  // The manifest published on globalThis is the flat ClientManifest the
++  // server APIs receive (a Record<filePath, ImportManifestEntry>). The
++  // lookup also handles the wrapped {filePathToModuleMetadata, ...} shape
++  // that the plugin emits to disk, in case a consumer publishes that shape.
++  //
++  // Children are spread variadic into createElement(Fragment, null, …) via
++  // .apply so React doesn't warn about missing keys for the inner element.
++  //
++  // Known limitations of this loader-level wrap:
++  // - Component-shape heuristic is name-based (PascalCase). False positives
++  //   for non-component PascalCase exports (e.g. `Store`, `ThemeContext`,
++  //   `URL`) and false negatives for lowercase-named components.
++  // - Wrapped exports are no longer client-reference-shaped, so passing a
++  //   client component as a value (`<Outer Component={Inner} />`) breaks.
++  //   Fully resolving these requires moving the wrap site into the React
++  //   Flight server's serializeClientReference, which is out of scope here.
+   let newSrc =
+-    'import {registerClientReference} from "react-server-dom-webpack/server";\n';
++    'import {registerClientReference} from "react-server-dom-webpack/server";\n' +
++    'import {createElement as __rfwn_h, Fragment as __rfwn_F} from "react";\n' +
++    'function __rfwn_css(refUrl){' +
++      'var m=globalThis.__reactFlightClientManifest;' +
++      'if(!m)return [];' +
++      'var entries=m.filePathToModuleMetadata||m;' +
++      'var e=entries[refUrl];' +
++      'return (e&&e.css)||[];' +
++    '}\n' +
++    'function __rfwn_wrap(ref,refUrl){' +
++      'return function __rfwn_wrapped(props){' +
++        'var __h=__rfwn_css(refUrl);' +
++        'if(__h.length===0)return __rfwn_h(ref,props);' +
++        'var c=[__rfwn_F,null];' +
++        'for(var i=0;i<__h.length;i++){' +
++          'c.push(__rfwn_h("link",{key:"__rfwn_link_"+__h[i],rel:"stylesheet",href:__h[i],precedence:"rsc-css"}));' +
++        '}' +
++        'c.push(__rfwn_h(ref,props));' +
++        'return __rfwn_h.apply(null,c);' +
++      '};' +
++    '}\n';
++  // Component-shape: default export OR named export starting with PascalCase
++  // (uppercase letter followed by lowercase). Lowercase, UPPER_SNAKE, and
++  // single-letter names get the bare shim.
++  const isComponentName = (n: string): boolean =>
++    n === 'default' || /^[A-Z][a-z]/.test(n);
++  // Keep the default-export's private variable name in a separate namespace
++  // so a named export literally called "_default" doesn't collide.
++  const refVarFor = (n: string): string =>
++    n === 'default' ? '__rfwn_default_ref__' : '__rfwn_named_ref_' + n;
+   for (let i = 0; i < names.length; i++) {
+     const name = names[i];
++    const errorMessage =
++      name === 'default'
++        ? `Attempted to call the default export of ${url} from the server ` +
++          `but it's on the client. It's not possible to invoke a client function from ` +
++          `the server, it can only be rendered as a Component or passed to props of a ` +
++          `Client Component.`
++        : `Attempted to call ${name}() from the server but ${name} is on the client. ` +
++          `It's not possible to invoke a client function from the server, it can ` +
++          `only be rendered as a Component or passed to props of a Client Component.`;
++    const shim =
++      'registerClientReference(function() { throw new Error(' +
++      JSON.stringify(errorMessage) +
++      '); }, ' +
++      JSON.stringify(url) +
++      ', ' +
++      JSON.stringify(name) +
++      ')';
++    if (!isComponentName(name)) {
++      // Non-component export: emit the bare shim, no wrapping.
++      if (name === 'default') {
++        newSrc += 'export default ' + shim + ';\n';
++      } else {
++        newSrc += 'export const ' + name + ' = ' + shim + ';\n';
++      }
++      continue;
++    }
++    // Component export: bind shim to a private name, then wrap.
++    const refVar = refVarFor(name);
++    newSrc += 'const ' + refVar + ' = ' + shim + ';\n';
+     if (name === 'default') {
+-      newSrc += 'export default ';
+-      newSrc += 'registerClientReference(function() {';
+-      newSrc +=
+-        'throw new Error(' +
+-        JSON.stringify(
+-          `Attempted to call the default export of ${url} from the server ` +
+-            `but it's on the client. It's not possible to invoke a client function from ` +
+-            `the server, it can only be rendered as a Component or passed to props of a ` +
+-            `Client Component.`,
+-        ) +
+-        ');';
++      newSrc += 'export default __rfwn_wrap(' + refVar + ', ' + JSON.stringify(url) + ');\n';
+     } else {
+-      newSrc += 'export const ' + name + ' = ';
+-      newSrc += 'registerClientReference(function() {';
+-      newSrc +=
+-        'throw new Error(' +
+-        JSON.stringify(
+-          `Attempted to call ${name}() from the server but ${name} is on the client. ` +
+-            `It's not possible to invoke a client function from the server, it can ` +
+-            `only be rendered as a Component or passed to props of a Client Component.`,
+-        ) +
+-        ');';
++      newSrc += 'export const ' + name + ' = __rfwn_wrap(' + refVar + ', ' + JSON.stringify(url) + ');\n';
+     }
+-    newSrc += '},';
+-    newSrc += JSON.stringify(url) + ',';
+-    newSrc += JSON.stringify(name) + ');\n';
+   }
+ 
+   // TODO: Generate source maps for Client Reference functions so they can point to their
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index a574fd3eb..3b574adec 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -274,15 +274,42 @@ export default class ReactFlightWebpackPlugin {
+             }
+           });
+ 
++          // FOUC fix: prefix used to turn bare CSS chunk filenames into full
++          // URLs the SSR pipeline can hand to the React DOM stylesheet
++          // resource graph.
++          const cssPrefix: string =
++            typeof compilation.outputOptions.publicPath === 'string'
++              ? compilation.outputOptions.publicPath
++              : '';
++
+           compilation.chunkGroups.forEach(function (chunkGroup) {
+             const chunks: Array<string> = [];
++            // FOUC fix: also collect every .css file emitted alongside the JS
++            // chunks reachable from this chunkGroup. They are recorded on each
++            // resolved client reference's manifest entry so the SSR pipeline
++            // can render <link rel="stylesheet" precedence> JSX siblings of
++            // each client-reference element. React DOM emits its $RR gating
++            // script for deferred Suspense subtrees, holding the swap until
++            // each stylesheet's load event fires.
++            const cssFiles: Array<string> = [];
+             chunkGroup.chunks.forEach(function (c) {
+               // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+               for (const file of c.files) {
+-                if (file.endsWith('.js') && !file.endsWith('.hot-update.js')) {
+-                  chunks.push(c.id, file);
+-                  break;
++                if (file.endsWith('.css')) {
++                  const cssUrl = cssPrefix + file;
++                  if (cssFiles.indexOf(cssUrl) === -1) {
++                    cssFiles.push(cssUrl);
++                  }
++                  continue;
++                }
++                if (!file.endsWith('.js')) {
++                  continue;
++                }
++                if (file.endsWith('.hot-update.js')) {
++                  continue;
+                 }
++                chunks.push(c.id, file);
++                break;
+               }
+             });
+ 
+@@ -312,10 +339,19 @@ export default class ReactFlightWebpackPlugin {
+                       existing.chunks.push(chunks[j], chunks[j + 1]);
+                     }
+                   }
++                  if (existing.css == null) {
++                    existing.css = [];
++                  }
++                  for (let k = 0; k < cssFiles.length; k++) {
++                    if (existing.css.indexOf(cssFiles[k]) === -1) {
++                      existing.css.push(cssFiles[k]);
++                    }
++                  }
+                 } else {
+                   filePathToModuleMetadata[href] = {
+                     id,
+                     chunks: chunks.slice(),
++                    css: cssFiles.slice(),
+                     name: '*',
+                   };
+                 }
+diff --git a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
+index 7954417b9..0ef4e48ff 100644
+--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
++++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
+@@ -59,6 +59,9 @@ function renderToReadableStream(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): ReadableStream {
++  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
++  // can look up each client reference's CSS hrefs at render time.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   const request = createRequest(
+     model,
+     webpackMap,
+@@ -110,6 +113,8 @@ function prerender(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): Promise<StaticResult> {
++  // FOUC fix: see renderToReadableStream above.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   return new Promise((resolve, reject) => {
+     const onFatalError = reject;
+     function onAllReady() {
+diff --git a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+index 7954417b9..0ef4e48ff 100644
+--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
++++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+@@ -59,6 +59,9 @@ function renderToReadableStream(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): ReadableStream {
++  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
++  // can look up each client reference's CSS hrefs at render time.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   const request = createRequest(
+     model,
+     webpackMap,
+@@ -110,6 +113,8 @@ function prerender(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): Promise<StaticResult> {
++  // FOUC fix: see renderToReadableStream above.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   return new Promise((resolve, reject) => {
+     const onFatalError = reject;
+     function onAllReady() {
+diff --git a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+index bf94c9e93..16d887e08 100644
+--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
++++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+@@ -87,6 +87,11 @@ function renderToPipeableStream(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): PipeableStream {
++  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
++  // (see ReactFlightWebpackNodeLoader transformClientModule) can look up
++  // each client reference's CSS hrefs at render time without consumers
++  // having to wire it manually.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   const request = createRequest(
+     model,
+     webpackMap,
+@@ -163,6 +168,9 @@ function prerenderToNodeStream(
+   webpackMap: ClientManifest,
+   options?: PrerenderOptions,
+ ): Promise<StaticResult> {
++  // FOUC fix: same as renderToPipeableStream — publish the manifest so
++  // loader-emitted CSS wrappers can find it via globalThis.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   return new Promise((resolve, reject) => {
+     const onFatalError = reject;
+     function onAllReady() {
+diff --git a/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js b/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
+index 29b012f60..769f9e81f 100644
+--- a/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
++++ b/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
+@@ -11,6 +11,12 @@ export type ImportManifestEntry = {
+   id: string,
+   // chunks is a double indexed array of chunkId / chunkFilename pairs
+   chunks: Array<string>,
++  // FOUC fix: list of CSS file URLs (publicPath-prefixed) emitted alongside
++  // this client reference's JS chunks. Read by the SSR pipeline so a
++  // <link rel="stylesheet" precedence> JSX sibling can be rendered next to
++  // the client reference, triggering React DOM's $RR gating script for
++  // deferred Suspense subtrees.
++  css?: Array<string>,
+   name: string,
+   async?: boolean,
+ };
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0007-RSC-PATCH-Filter-runtime-chunk-from-per-module-clien.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.0.3/0007-RSC-PATCH-Filter-runtime-chunk-from-per-module-clien.patch
@@ -1,0 +1,93 @@
+From 2c29304508de9773450421cdffa1fef6246dc4c1 Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Tue, 5 May 2026 21:01:17 +0300
+Subject: [PATCH 7/7] [RSC-PATCH] Filter runtime chunk from per-module client
+ manifest chunks (#7)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* [RSC-PATCH] Filter runtime chunk from per-module client manifest chunks
+
+`ReactFlightWebpackPlugin` already collects `runtimeChunkFiles` and the
+source comment promises it is used "to filter out chunks that Flight
+will never need to load" — but the filter was never applied. With
+`output.runtimeChunk: 'single'` the runtime chunk file ends up in every
+client reference's `chunks` array in `react-client-manifest.json`, and
+React Flight emits a `<script>` tag for that runtime URL alongside the
+host page's own runtime tag.
+
+Browsers do not deduplicate identical `<script async>` tags by URL, so
+the webpack runtime IIFE evaluates twice: a new `__webpack_require__`,
+a new module cache, and new chunk closures. Any module relying on
+singleton semantics (registered client references, version-checked
+SDKs, global registries) is loaded twice with two distinct instances
+and breaks at runtime — most visibly as singleton-init guards
+asserting that another bundle already initialized them.
+
+This commit adds the filter the comment already promised: when
+iterating a chunk group's files for the manifest, skip files that
+belong to the collected runtime chunk set. Initial entrypoints already
+load these on the host page; Flight should never request them.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+* [RSC-PATCH] Guard runtime-chunk filter to client manifest only
+
+Apply the runtime-chunk filter only when emitting the client manifest
+(`isServer === false`). Server bundles commonly use
+`webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 })` to collapse
+every chunk into the entry. Under that configuration the entrypoint's
+runtime chunk is the server bundle file itself, so the filter would
+strip it from every client reference's `chunks` array and leave each
+manifest entry as `chunks: []`. The RSC encoder then cannot resolve
+any client module reference, the Flight stream emits no further
+chunks, and consumers (e.g. node-renderer with a stream-chunk
+timeout) eventually abort with a stall.
+
+The double-runtime hazard the original commit guards against only
+exists on the client (host page loads the runtime separately, then
+Float emits it again from the manifest). Server-side rendering
+consumes the manifest in-process, so re-listing the runtime there is
+both safe and required.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: AbanoubGhadban <c_yassa@shakacode.com>
+Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ .../src/ReactFlightWebpackPlugin.js              | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index 3b574adec..0145ce19f 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -308,6 +308,22 @@ export default class ReactFlightWebpackPlugin {
+                 if (file.endsWith('.hot-update.js')) {
+                   continue;
+                 }
++                // Skip the runtime chunk on the CLIENT manifest only: it is
++                // always loaded by the host page alongside any initial entry,
++                // so re-emitting it during the Flight stream would re-execute
++                // the webpack runtime IIFE, create a second module cache, and
++                // break singletons that depend on a single runtime instance.
++                //
++                // We must NOT apply this filter to the server manifest. Server
++                // bundles commonly use LimitChunkCountPlugin({maxChunks: 1}),
++                // which collapses every chunk into the entry — making that
++                // single output file the entrypoint's runtime chunk. Filtering
++                // it out leaves every client reference with chunks: [], so the
++                // RSC encoder cannot resolve any client module reference and
++                // the Flight stream stalls.
++                if (!_this.isServer && runtimeChunkFiles.has(file)) {
++                  continue;
++                }
+                 chunks.push(c.id, file);
+                 break;
+               }
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.2.1/0001-RSC-PATCH-Add-server-support-for-React-Flight-Webpac.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.2.1/0001-RSC-PATCH-Add-server-support-for-React-Flight-Webpac.patch
@@ -1,0 +1,100 @@
+From 849bd344c46922c03c93a8a0d192099b4617f01f Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sun, 23 Feb 2025 12:58:14 +0200
+Subject: [PATCH 1/3] [RSC-PATCH] Add server support for React Flight Webpack
+ Plugin
+
+---
+ .../src/ReactFlightWebpackPlugin.js           | 33 +++++++++++++------
+ 1 file changed, 23 insertions(+), 10 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index 59723c903..995cd63e1 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -42,7 +42,8 @@ class ClientReferenceDependency extends ModuleDependency {
+ // without the client runtime so it's the first time in the loading sequence
+ // you might want them.
+ const clientImportName = 'react-server-dom-webpack/client';
+-const clientFileName = require.resolve('../client.browser.js');
++const clientFileNameOnClient = require.resolve('../client.browser.js');
++const clientFileNameOnServer = require.resolve('../client.node.js');
+ 
+ type ClientReferenceSearchPath = {
+   directory: string,
+@@ -68,6 +69,7 @@ export default class ReactFlightWebpackPlugin {
+   chunkName: string;
+   clientManifestFilename: string;
+   serverConsumerManifestFilename: string;
++  isServer: boolean;
+ 
+   constructor(options: Options) {
+     if (!options || typeof options.isServer !== 'boolean') {
+@@ -75,9 +77,6 @@ export default class ReactFlightWebpackPlugin {
+         PLUGIN_NAME + ': You must specify the isServer option as a boolean.',
+       );
+     }
+-    if (options.isServer) {
+-      throw new Error('TODO: Implement the server compiler.');
+-    }
+     if (!options.clientReferences) {
+       this.clientReferences = [
+         {
+@@ -103,8 +102,12 @@ export default class ReactFlightWebpackPlugin {
+     } else {
+       this.chunkName = 'client[index]';
+     }
++    this.isServer = options.isServer;
++    const defaultClientManifestFilename = options.isServer
++      ? 'react-server-client-manifest.json'
++      : 'react-client-manifest.json';
+     this.clientManifestFilename =
+-      options.clientManifestFilename || 'react-client-manifest.json';
++      options.clientManifestFilename || defaultClientManifestFilename;
+     this.serverConsumerManifestFilename =
+       options.serverConsumerManifestFilename || 'react-ssr-manifest.json';
+   }
+@@ -162,6 +165,9 @@ export default class ReactFlightWebpackPlugin {
+           parser.hooks.program.tap(PLUGIN_NAME, () => {
+             const module = parser.state.module;
+ 
++            const clientFileName = _this.isServer
++              ? clientFileNameOnServer
++              : clientFileNameOnClient;
+             if (module.resource !== clientFileName) {
+               return;
+             }
+@@ -311,6 +317,11 @@ export default class ReactFlightWebpackPlugin {
+                   chunks,
+                   name: '*',
+                 };
++
++                if (_this.isServer) {
++                  return;
++                }
++
+                 ssrExports['*'] = {
+                   specifier: href,
+                   name: '*',
+@@ -378,11 +389,13 @@ export default class ReactFlightWebpackPlugin {
+             _this.clientManifestFilename,
+             new sources.RawSource(clientOutput, false),
+           );
+-          const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
+-          compilation.emitAsset(
+-            _this.serverConsumerManifestFilename,
+-            new sources.RawSource(ssrOutput, false),
+-          );
++          if (!_this.isServer) {
++            const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
++            compilation.emitAsset(
++              _this.serverConsumerManifestFilename,
++              new sources.RawSource(ssrOutput, false),
++            );
++          }
+         },
+       );
+     });
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.2.1/0002-RSC-PATCH-make-rsc-plugin-create-a-manifest-for-serv.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.2.1/0002-RSC-PATCH-make-rsc-plugin-create-a-manifest-for-serv.patch
@@ -1,0 +1,136 @@
+From 9d3d85d7ff8f04fe949387cf317d94ebbdb3a7dc Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sun, 8 Jun 2025 15:41:54 +0300
+Subject: [PATCH 2/3] [RSC-PATCH] make rsc plugin create a manifest for server
+ build
+
+---
+ .../src/ReactFlightWebpackPlugin.js           | 81 +++----------------
+ 1 file changed, 10 insertions(+), 71 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index 995cd63e1..dd11c4516 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -242,27 +242,23 @@ export default class ReactFlightWebpackPlugin {
+             (resolvedClientReferences || []).map(ref => ref.request),
+           );
+ 
+-          const clientManifest: {
++          type FilePathToModuleMetadata = {
+             [string]: ImportManifestEntry,
+-          } = {};
+-          type ServerConsumerModuleMap = {
+-            [string]: {
+-              [string]: {specifier: string, name: string},
+-            },
+           };
+-          const moduleMap: ServerConsumerModuleMap = {};
+-          const ssrBundleConfig: {
++          type BundleManifest = {
+             moduleLoading: {
+               prefix: string,
+               crossOrigin: string | null,
+             },
+-            moduleMap: ServerConsumerModuleMap,
+-          } = {
++            filePathToModuleMetadata: FilePathToModuleMetadata,
++          };
++          const filePathToModuleMetadata: FilePathToModuleMetadata = {};
++          const bundleManifest: BundleManifest = {
+             moduleLoading: {
+               prefix: compilation.outputOptions.publicPath || '',
+               crossOrigin: crossOriginMode,
+             },
+-            moduleMap,
++            filePathToModuleMetadata,
+           };
+ 
+           // We figure out which files are always loaded by any initial chunk (entrypoint).
+@@ -308,61 +304,11 @@ export default class ReactFlightWebpackPlugin {
+               const href = pathToFileURL(module.resource).href;
+ 
+               if (href !== undefined) {
+-                const ssrExports: {
+-                  [string]: {specifier: string, name: string},
+-                } = {};
+-
+-                clientManifest[href] = {
++                filePathToModuleMetadata[href] = {
+                   id,
+                   chunks,
+                   name: '*',
+                 };
+-
+-                if (_this.isServer) {
+-                  return;
+-                }
+-
+-                ssrExports['*'] = {
+-                  specifier: href,
+-                  name: '*',
+-                };
+-
+-                // TODO: If this module ends up split into multiple modules, then
+-                // we should encode each the chunks needed for the specific export.
+-                // When the module isn't split, it doesn't matter and we can just
+-                // encode the id of the whole module. This code doesn't currently
+-                // deal with module splitting so is likely broken from ESM anyway.
+-                /*
+-                clientManifest[href + '#'] = {
+-                  id,
+-                  chunks,
+-                  name: '',
+-                };
+-                ssrExports[''] = {
+-                  specifier: href,
+-                  name: '',
+-                };
+-
+-                const moduleProvidedExports = compilation.moduleGraph
+-                  .getExportsInfo(module)
+-                  .getProvidedExports();
+-
+-                if (Array.isArray(moduleProvidedExports)) {
+-                  moduleProvidedExports.forEach(function (name) {
+-                    clientManifest[href + '#' + name] = {
+-                      id,
+-                      chunks,
+-                      name: name,
+-                    };
+-                    ssrExports[name] = {
+-                      specifier: href,
+-                      name: name,
+-                    };
+-                  });
+-                }
+-                */
+-
+-                moduleMap[id] = ssrExports;
+               }
+             }
+ 
+@@ -384,18 +330,11 @@ export default class ReactFlightWebpackPlugin {
+             });
+           });
+ 
+-          const clientOutput = JSON.stringify(clientManifest, null, 2);
++          const bundleOutput = JSON.stringify(bundleManifest, null, 2);
+           compilation.emitAsset(
+             _this.clientManifestFilename,
+-            new sources.RawSource(clientOutput, false),
++            new sources.RawSource(bundleOutput, false),
+           );
+-          if (!_this.isServer) {
+-            const ssrOutput = JSON.stringify(ssrBundleConfig, null, 2);
+-            compilation.emitAsset(
+-              _this.serverConsumerManifestFilename,
+-              new sources.RawSource(ssrOutput, false),
+-            );
+-          }
+         },
+       );
+     });
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/rsc-patches-v19.2.1/0003-RSC-PATCH-Fix-chunk-merge-bug-in-ReactFlightWebpackP.patch
+++ b/patches/archive/abanoubghadban-react/rsc-patches-v19.2.1/0003-RSC-PATCH-Fix-chunk-merge-bug-in-ReactFlightWebpackP.patch
@@ -1,0 +1,59 @@
+From 4a646d8b129bf9c080f6654bdfd3c40c47a6bd0b Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Tue, 24 Feb 2026 18:12:01 +0200
+Subject: [PATCH 3/3] [RSC-PATCH] Fix chunk-merge bug in
+ ReactFlightWebpackPlugin recordModule
+
+When a 'use client' module appears in multiple webpack chunk groups,
+recordModule() was overwriting the manifest entry instead of merging
+chunk arrays. This caused missing chunk preloads during RSC hydration,
+leading to __webpack_require__ failures under slow networks.
+
+The fix merges chunk arrays from all chunk groups for each module,
+ensuring the flight client preloads all necessary chunks.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../src/ReactFlightWebpackPlugin.js           | 26 +++++++++++++++----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index dd11c4516..cff7a56ce 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -304,11 +304,27 @@ export default class ReactFlightWebpackPlugin {
+               const href = pathToFileURL(module.resource).href;
+ 
+               if (href !== undefined) {
+-                filePathToModuleMetadata[href] = {
+-                  id,
+-                  chunks,
+-                  name: '*',
+-                };
++                if (filePathToModuleMetadata[href]) {
++                  // Merge chunks from additional chunk groups instead of overwriting.
++                  // A module can appear in multiple chunk groups, and all chunks
++                  // need to be recorded so the flight client preloads them all.
++                  const existing = filePathToModuleMetadata[href];
++                  const existingChunkIds: Set<mixed> = new Set();
++                  for (let i = 0; i < existing.chunks.length; i += 2) {
++                    existingChunkIds.add(existing.chunks[i]);
++                  }
++                  for (let j = 0; j < chunks.length; j += 2) {
++                    if (!existingChunkIds.has(chunks[j])) {
++                      existing.chunks.push(chunks[j], chunks[j + 1]);
++                    }
++                  }
++                } else {
++                  filePathToModuleMetadata[href] = {
++                    id,
++                    chunks: chunks.slice(),
++                    name: '*',
++                  };
++                }
+               }
+             }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/topic-fix-3211-rsc-css-deferred-suspense/0001-RSC-PATCH-Fix-FOUC-for-use-client-CSS-in-deferred-Su.patch
+++ b/patches/archive/abanoubghadban-react/topic-fix-3211-rsc-css-deferred-suspense/0001-RSC-PATCH-Fix-FOUC-for-use-client-CSS-in-deferred-Su.patch
@@ -1,0 +1,395 @@
+From 980eda22244208a90b2a21e2e10847795a85b2be Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Wed, 29 Apr 2026 12:20:43 +0300
+Subject: [PATCH] [RSC-PATCH] Fix FOUC for use-client CSS in deferred Suspense
+ subtrees
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem
+-------
+
+When a `'use client'` component imports a CSS Module and lives inside a
+deferred Suspense subtree (an async server-component ancestor), the
+resolution chunk that streams in carries the client component's HTML
+but no in-tree stylesheet element. React DOM emits its `$RC` swap
+script (immediate swap), not `$RR` (gated swap). The browser swaps the
+styled <div> into view before its stylesheet has loaded, producing a
+flash of unstyled content. Empirically observed on Slow 3G; verified
+by reading React's resolution-chunk emission protocol — `$RR` is emitted
+exclusively when an in-tree `<link rel="stylesheet" precedence>` element
+is rendered as part of a streaming Suspense resolution. Hint-form
+`preinit` calls do NOT produce `$RR`.
+
+Fix
+---
+
+Three coordinated changes:
+
+1. Plugin (`ReactFlightWebpackPlugin.js`): for every chunkGroup, walk
+   `c.files` for `.css` siblings of the JS chunks. Record them as a
+   sibling `css: string[]` array on each client-reference manifest entry,
+   prefixed with `compilation.outputOptions.publicPath` so they are
+   usable URLs. The `css` field is merged across multiple chunkGroups
+   that resolve the same module, mirroring the existing `chunks` merge.
+
+2. Loader (`ReactFlightWebpackNodeLoader.js` -> `transformClientModule`):
+   instead of emitting raw `registerClientReference(...)` exports, emit
+   server-side wrapper functions per export. Each wrapper, when invoked
+   by React Flight during render, looks up its CSS hrefs from
+   `globalThis.__reactFlightClientManifest` and returns a Fragment
+   containing one `<link rel="stylesheet" precedence="rsc-css" href={css}/>`
+   per file plus the original client reference. React Flight encodes the
+   link as regular in-tree JSX and the client reference as `I[...]` as
+   before; the only thing that changes in the encoded RSC payload is
+   that the bare element `["$","$L<id>",null,props]` becomes a
+   2-element array `[<linkElement>, ["$","$L<id>",null,props]]` (a
+   key-less Fragment).
+
+   When the resolution chunk is a separate flush from the shell (the
+   normal deferred-Suspense case), React DOM sees the in-tree `<link>`
+   inside the resolved subtree, treats it as a precedence-managed
+   stylesheet resource, and emits `$RR(boundary, segment, [[href,
+   precedence]])` instead of `$RC(...)`. `$RR` creates a
+   `<link rel=stylesheet>` in `<head>` client-side, awaits its `load`
+   event, and only then runs the swap. The styled subtree never paints
+   unstyled.
+
+   When the resolution is fast enough to merge into the shell (no async
+   above the boundary), the link goes into the shell directly; the
+   browser's standard CSSOM render-blocking handles FOUC prevention.
+   Either way, no unstyled paint reaches the user.
+
+3. Server entry points (`ReactFlightDOMServerNode.js`,
+   `ReactFlightDOMServerEdge.js`, `ReactFlightDOMServerBrowser.js`):
+   publish the manifest to `globalThis.__reactFlightClientManifest` as
+   a side effect of `renderToPipeableStream`/`renderToReadableStream`/
+   `prerender*`. The loader-emitted wrappers find it without any
+   consumer-side wiring. Single assignment per render call; safe to
+   overwrite each time since the wrappers only read it during the same
+   render that just set it.
+
+Verification
+------------
+
+A standalone harness rendered an async-resolved Suspense subtree
+containing a `'use client'` boundary, with the CSS endpoint delayed by
+4 seconds. With this patch, the SSR HTML contains the wrapping pattern
+in the RSC payload and `$RR(...,[["/path/to.css","rsc-css"]])` in the
+resolution chunk; in the browser, the fallback stays visible until the
+stylesheet load event fires (~5s = 1s async + 4s CSS), then the styled
+subtree appears in a single frame. Without the patch, the styled card
+paints unstyled the moment the resolution chunk arrives — i.e., the
+flash this patch eliminates.
+---
+ .../src/ReactFlightWebpackNodeLoader.js       | 123 ++++++++++++++----
+ .../src/ReactFlightWebpackPlugin.js           |  42 +++++-
+ .../src/server/ReactFlightDOMServerBrowser.js |   5 +
+ .../src/server/ReactFlightDOMServerEdge.js    |   5 +
+ .../src/server/ReactFlightDOMServerNode.js    |   8 ++
+ .../src/shared/ReactFlightImportMetadata.js   |   6 +
+ 6 files changed, 161 insertions(+), 28 deletions(-)
+
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+index 9799acc3a..2cd07cf55 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+@@ -584,37 +584,110 @@ async function transformClientModule(
+     return '';
+   }
+ 
++  // FOUC fix: for component-shaped exports of a 'use client' file, emit a
++  // server-side wrapper that renders
++  //   <><link rel=stylesheet precedence=rsc-css href=…/>...<RealRef {...props}/></>
++  // so React DOM emits its $RR gating script for deferred Suspense subtrees,
++  // holding the swap until the stylesheet's load event fires — the only
++  // mechanism that fully prevents flash-of-unstyled-content for a styled
++  // client component that streams in via Suspense.
++  //
++  // Non-component exports (lowercase-named) keep the original client-
++  // reference shim so they can still be passed across the server/client
++  // boundary as tagged values (hooks, stores, constants, plain utilities,
++  // etc.). Wrapping non-components would turn passing them as values into a
++  // serialization failure.
++  //
++  // CSS hrefs are looked up at runtime from
++  // globalThis.__reactFlightClientManifest, which the public render entry
++  // points (renderToPipeableStream / renderToReadableStream / prerender)
++  // populate as a side effect on entry. The lookup runs on every wrapper
++  // invocation (no closure cache) so HMR rebuilds and multi-bundle setups
++  // always read the current manifest.
++  //
++  // The manifest published on globalThis is the flat ClientManifest the
++  // server APIs receive (a Record<filePath, ImportManifestEntry>). The
++  // lookup also handles the wrapped {filePathToModuleMetadata, ...} shape
++  // that the plugin emits to disk, in case a consumer publishes that shape.
++  //
++  // Children are spread variadic into createElement(Fragment, null, …) via
++  // .apply so React doesn't warn about missing keys for the inner element.
++  //
++  // Known limitations of this loader-level wrap:
++  // - Component-shape heuristic is name-based (PascalCase). False positives
++  //   for non-component PascalCase exports (e.g. `Store`, `ThemeContext`,
++  //   `URL`) and false negatives for lowercase-named components.
++  // - Wrapped exports are no longer client-reference-shaped, so passing a
++  //   client component as a value (`<Outer Component={Inner} />`) breaks.
++  //   Fully resolving these requires moving the wrap site into the React
++  //   Flight server's serializeClientReference, which is out of scope here.
+   let newSrc =
+-    'import {registerClientReference} from "react-server-dom-webpack/server";\n';
++    'import {registerClientReference} from "react-server-dom-webpack/server";\n' +
++    'import {createElement as __rfwn_h, Fragment as __rfwn_F} from "react";\n' +
++    'function __rfwn_css(refUrl){' +
++      'var m=globalThis.__reactFlightClientManifest;' +
++      'if(!m)return [];' +
++      'var entries=m.filePathToModuleMetadata||m;' +
++      'var e=entries[refUrl];' +
++      'return (e&&e.css)||[];' +
++    '}\n' +
++    'function __rfwn_wrap(ref,refUrl){' +
++      'return function __rfwn_wrapped(props){' +
++        'var __h=__rfwn_css(refUrl);' +
++        'if(__h.length===0)return __rfwn_h(ref,props);' +
++        'var c=[__rfwn_F,null];' +
++        'for(var i=0;i<__h.length;i++){' +
++          'c.push(__rfwn_h("link",{key:"__rfwn_link_"+__h[i],rel:"stylesheet",href:__h[i],precedence:"rsc-css"}));' +
++        '}' +
++        'c.push(__rfwn_h(ref,props));' +
++        'return __rfwn_h.apply(null,c);' +
++      '};' +
++    '}\n';
++  // Component-shape: default export OR named export starting with PascalCase
++  // (uppercase letter followed by lowercase). Lowercase, UPPER_SNAKE, and
++  // single-letter names get the bare shim.
++  const isComponentName = (n: string): boolean =>
++    n === 'default' || /^[A-Z][a-z]/.test(n);
++  // Keep the default-export's private variable name in a separate namespace
++  // so a named export literally called "_default" doesn't collide.
++  const refVarFor = (n: string): string =>
++    n === 'default' ? '__rfwn_default_ref__' : '__rfwn_named_ref_' + n;
+   for (let i = 0; i < names.length; i++) {
+     const name = names[i];
++    const errorMessage =
++      name === 'default'
++        ? `Attempted to call the default export of ${url} from the server ` +
++          `but it's on the client. It's not possible to invoke a client function from ` +
++          `the server, it can only be rendered as a Component or passed to props of a ` +
++          `Client Component.`
++        : `Attempted to call ${name}() from the server but ${name} is on the client. ` +
++          `It's not possible to invoke a client function from the server, it can ` +
++          `only be rendered as a Component or passed to props of a Client Component.`;
++    const shim =
++      'registerClientReference(function() { throw new Error(' +
++      JSON.stringify(errorMessage) +
++      '); }, ' +
++      JSON.stringify(url) +
++      ', ' +
++      JSON.stringify(name) +
++      ')';
++    if (!isComponentName(name)) {
++      // Non-component export: emit the bare shim, no wrapping.
++      if (name === 'default') {
++        newSrc += 'export default ' + shim + ';\n';
++      } else {
++        newSrc += 'export const ' + name + ' = ' + shim + ';\n';
++      }
++      continue;
++    }
++    // Component export: bind shim to a private name, then wrap.
++    const refVar = refVarFor(name);
++    newSrc += 'const ' + refVar + ' = ' + shim + ';\n';
+     if (name === 'default') {
+-      newSrc += 'export default ';
+-      newSrc += 'registerClientReference(function() {';
+-      newSrc +=
+-        'throw new Error(' +
+-        JSON.stringify(
+-          `Attempted to call the default export of ${url} from the server ` +
+-            `but it's on the client. It's not possible to invoke a client function from ` +
+-            `the server, it can only be rendered as a Component or passed to props of a ` +
+-            `Client Component.`,
+-        ) +
+-        ');';
++      newSrc += 'export default __rfwn_wrap(' + refVar + ', ' + JSON.stringify(url) + ');\n';
+     } else {
+-      newSrc += 'export const ' + name + ' = ';
+-      newSrc += 'registerClientReference(function() {';
+-      newSrc +=
+-        'throw new Error(' +
+-        JSON.stringify(
+-          `Attempted to call ${name}() from the server but ${name} is on the client. ` +
+-            `It's not possible to invoke a client function from the server, it can ` +
+-            `only be rendered as a Component or passed to props of a Client Component.`,
+-        ) +
+-        ');';
++      newSrc += 'export const ' + name + ' = __rfwn_wrap(' + refVar + ', ' + JSON.stringify(url) + ');\n';
+     }
+-    newSrc += '},';
+-    newSrc += JSON.stringify(url) + ',';
+-    newSrc += JSON.stringify(name) + ');\n';
+   }
+ 
+   // TODO: Generate source maps for Client Reference functions so they can point to their
+diff --git a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+index a574fd3eb..3b574adec 100644
+--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
++++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+@@ -274,15 +274,42 @@ export default class ReactFlightWebpackPlugin {
+             }
+           });
+ 
++          // FOUC fix: prefix used to turn bare CSS chunk filenames into full
++          // URLs the SSR pipeline can hand to the React DOM stylesheet
++          // resource graph.
++          const cssPrefix: string =
++            typeof compilation.outputOptions.publicPath === 'string'
++              ? compilation.outputOptions.publicPath
++              : '';
++
+           compilation.chunkGroups.forEach(function (chunkGroup) {
+             const chunks: Array<string> = [];
++            // FOUC fix: also collect every .css file emitted alongside the JS
++            // chunks reachable from this chunkGroup. They are recorded on each
++            // resolved client reference's manifest entry so the SSR pipeline
++            // can render <link rel="stylesheet" precedence> JSX siblings of
++            // each client-reference element. React DOM emits its $RR gating
++            // script for deferred Suspense subtrees, holding the swap until
++            // each stylesheet's load event fires.
++            const cssFiles: Array<string> = [];
+             chunkGroup.chunks.forEach(function (c) {
+               // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+               for (const file of c.files) {
+-                if (file.endsWith('.js') && !file.endsWith('.hot-update.js')) {
+-                  chunks.push(c.id, file);
+-                  break;
++                if (file.endsWith('.css')) {
++                  const cssUrl = cssPrefix + file;
++                  if (cssFiles.indexOf(cssUrl) === -1) {
++                    cssFiles.push(cssUrl);
++                  }
++                  continue;
++                }
++                if (!file.endsWith('.js')) {
++                  continue;
++                }
++                if (file.endsWith('.hot-update.js')) {
++                  continue;
+                 }
++                chunks.push(c.id, file);
++                break;
+               }
+             });
+ 
+@@ -312,10 +339,19 @@ export default class ReactFlightWebpackPlugin {
+                       existing.chunks.push(chunks[j], chunks[j + 1]);
+                     }
+                   }
++                  if (existing.css == null) {
++                    existing.css = [];
++                  }
++                  for (let k = 0; k < cssFiles.length; k++) {
++                    if (existing.css.indexOf(cssFiles[k]) === -1) {
++                      existing.css.push(cssFiles[k]);
++                    }
++                  }
+                 } else {
+                   filePathToModuleMetadata[href] = {
+                     id,
+                     chunks: chunks.slice(),
++                    css: cssFiles.slice(),
+                     name: '*',
+                   };
+                 }
+diff --git a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
+index 7954417b9..0ef4e48ff 100644
+--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
++++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerBrowser.js
+@@ -59,6 +59,9 @@ function renderToReadableStream(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): ReadableStream {
++  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
++  // can look up each client reference's CSS hrefs at render time.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   const request = createRequest(
+     model,
+     webpackMap,
+@@ -110,6 +113,8 @@ function prerender(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): Promise<StaticResult> {
++  // FOUC fix: see renderToReadableStream above.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   return new Promise((resolve, reject) => {
+     const onFatalError = reject;
+     function onAllReady() {
+diff --git a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+index 7954417b9..0ef4e48ff 100644
+--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
++++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerEdge.js
+@@ -59,6 +59,9 @@ function renderToReadableStream(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): ReadableStream {
++  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
++  // can look up each client reference's CSS hrefs at render time.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   const request = createRequest(
+     model,
+     webpackMap,
+@@ -110,6 +113,8 @@ function prerender(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): Promise<StaticResult> {
++  // FOUC fix: see renderToReadableStream above.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   return new Promise((resolve, reject) => {
+     const onFatalError = reject;
+     function onAllReady() {
+diff --git a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+index bf94c9e93..16d887e08 100644
+--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
++++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+@@ -87,6 +87,11 @@ function renderToPipeableStream(
+   webpackMap: ClientManifest,
+   options?: Options,
+ ): PipeableStream {
++  // FOUC fix: publish the manifest so the loader-emitted CSS wrappers
++  // (see ReactFlightWebpackNodeLoader transformClientModule) can look up
++  // each client reference's CSS hrefs at render time without consumers
++  // having to wire it manually.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   const request = createRequest(
+     model,
+     webpackMap,
+@@ -163,6 +168,9 @@ function prerenderToNodeStream(
+   webpackMap: ClientManifest,
+   options?: PrerenderOptions,
+ ): Promise<StaticResult> {
++  // FOUC fix: same as renderToPipeableStream — publish the manifest so
++  // loader-emitted CSS wrappers can find it via globalThis.
++  (globalThis: any).__reactFlightClientManifest = webpackMap;
+   return new Promise((resolve, reject) => {
+     const onFatalError = reject;
+     function onAllReady() {
+diff --git a/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js b/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
+index 29b012f60..769f9e81f 100644
+--- a/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
++++ b/packages/react-server-dom-webpack/src/shared/ReactFlightImportMetadata.js
+@@ -11,6 +11,12 @@ export type ImportManifestEntry = {
+   id: string,
+   // chunks is a double indexed array of chunkId / chunkFilename pairs
+   chunks: Array<string>,
++  // FOUC fix: list of CSS file URLs (publicPath-prefixed) emitted alongside
++  // this client reference's JS chunks. Read by the SSR pipeline so a
++  // <link rel="stylesheet" precedence> JSX sibling can be rendered next to
++  // the client reference, triggering React DOM's $RR gating script for
++  // deferred Suspense subtrees.
++  css?: Array<string>,
+   name: string,
+   async?: boolean,
+ };
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/archive/abanoubghadban-react/topic-perf-rsc-revive-model-walk/0001-RSC-PATCH-Walk-parsed-JSON-instead-of-using-reviver-.patch
+++ b/patches/archive/abanoubghadban-react/topic-perf-rsc-revive-model-walk/0001-RSC-PATCH-Walk-parsed-JSON-instead-of-using-reviver-.patch
@@ -1,0 +1,142 @@
+From 9dc1d7e63f4a3bd6f1154f66cf108d1132e0fc8a Mon Sep 17 00:00:00 2001
+From: Abanoub Ghadban <abanoub@shakacode.com>
+Date: Sat, 18 Apr 2026 16:55:33 +0200
+Subject: [PATCH] [RSC-PATCH] Walk parsed JSON instead of using reviver for
+ parsing RSC payload
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Backport of facebook/react#35776 to v19.0.3.
+
+Replace the JSON.parse reviver callback in parseModel with a two-step
+approach: plain JSON.parse() followed by a recursive reviveModel()
+post-process. This yields a ~75% speedup in RSC chunk deserialization
+by eliminating C++→JS boundary crossings for every key-value pair.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+---
+ .../react-client/src/ReactFlightClient.js     | 58 ++++++++++++++-----
+ .../src/ReactNoopFlightClient.js              |  3 -
+ 2 files changed, 45 insertions(+), 16 deletions(-)
+
+diff --git a/packages/react-client/src/ReactFlightClient.js b/packages/react-client/src/ReactFlightClient.js
+index 376f502a7..d28cfb1c3 100644
+--- a/packages/react-client/src/ReactFlightClient.js
++++ b/packages/react-client/src/ReactFlightClient.js
+@@ -276,7 +276,6 @@ export type Response = {
+   _encodeFormAction: void | EncodeFormActionCallback,
+   _nonce: ?string,
+   _chunks: Map<number, SomeChunk<any>>,
+-  _fromJSON: (key: string, value: JSONValue) => any,
+   _stringDecoder: StringDecoder,
+   _rowState: RowParserState,
+   _rowID: number, // parts of a row ID parsed so far
+@@ -1508,6 +1507,11 @@ function parseModelString(
+                 'or more specific objects.'
+               );
+             },
++            // no-op: the walk function may try to reassign this property after
++            // parseModelString returns. With the JSON.parse reviver, the engine's
++            // internal CreateDataProperty silently failed. We use a no-op setter
++            // to match that behavior in strict mode.
++            set: function () {},
+             enumerable: true,
+             configurable: false,
+           });
+@@ -1576,7 +1580,6 @@ function ResponseInstance(
+   this._nonce = nonce;
+   this._chunks = chunks;
+   this._stringDecoder = createStringDecoder();
+-  this._fromJSON = (null: any);
+   this._rowState = 0;
+   this._rowID = 0;
+   this._rowTag = 0;
+@@ -1618,8 +1621,6 @@ function ResponseInstance(
+     this._replayConsole = replayConsole;
+     this._rootEnvironmentName = rootEnv;
+   }
+-  // Don't inline this call because it causes closure to outline the call above.
+-  this._fromJSON = createFromJSONCallback(this);
+ }
+ 
+ export function createResponse(
+@@ -3138,21 +3139,52 @@ export function processStringChunk(response: Response, chunk: string): void {
+ }
+ 
+ function parseModel<T>(response: Response, json: UninitializedModel): T {
+-  return JSON.parse(json, response._fromJSON);
++  const rawModel = JSON.parse(json);
++  // Pass a wrapper object as parentObject to match the original JSON.parse
++  // reviver behavior, where the root value's reviver receives {"": rootValue}
++  // as `this`. This ensures parentObject is never null when accessed downstream.
++  return reviveModel(response, rawModel, {'': rawModel}, '');
+ }
+ 
+-function createFromJSONCallback(response: Response) {
+-  // $FlowFixMe[missing-this-annot]
+-  return function (key: string, value: JSONValue) {
+-    if (typeof value === 'string') {
+-      // We can't use .bind here because we need the "this" value.
+-      return parseModelString(response, this, key, value);
++function reviveModel(
++  response: Response,
++  value: JSONValue,
++  parentObject: Object,
++  key: string,
++): any {
++  if (typeof value === 'string') {
++    if (value[0] === '$') {
++      return parseModelString(response, parentObject, key, value);
++    }
++    return value;
++  }
++  if (typeof value !== 'object' || value === null) {
++    return value;
++  }
++  if (isArray(value)) {
++    for (let i = 0; i < value.length; i++) {
++      (value: any)[i] = reviveModel(response, value[i], value, '' + i);
+     }
+-    if (typeof value === 'object' && value !== null) {
++    if (value[0] === REACT_ELEMENT_TYPE) {
++      // React element tuple
+       return parseModelTuple(response, value);
+     }
+     return value;
+-  };
++  }
++  // Plain object
++  for (const k in value) {
++    if (k === '__proto__') {
++      delete (value: any)[k];
++    } else {
++      const walked = reviveModel(response, (value: any)[k], value, k);
++      if (walked !== undefined) {
++        (value: any)[k] = walked;
++      } else {
++        delete (value: any)[k];
++      }
++    }
++  }
++  return value;
+ }
+ 
+ export function close(response: Response): void {
+diff --git a/packages/react-noop-renderer/src/ReactNoopFlightClient.js b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+index 346433404..aa093fc42 100644
+--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
++++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+@@ -42,9 +42,6 @@ const {createResponse, processBinaryChunk, getRoot, close} = ReactFlightClient({
+   requireModule(idx: string) {
+     return readModule(idx);
+   },
+-  parseModel(response: Response, json) {
+-    return JSON.parse(json, response._fromJSON);
+-  },
+   bindToConsole(methodName, args, badgeName) {
+     return Function.prototype.bind.apply(
+       // eslint-disable-next-line react-internal/no-production-logging
+-- 
+2.50.1 (Apple Git-155)
+

--- a/scripts/react-upgrade/README.md
+++ b/scripts/react-upgrade/README.md
@@ -1,6 +1,16 @@
 # React Upgrade Scripts
 
-Automation scripts to upgrade `react-server-dom-webpack` from the React fork to `react-on-rails-rsc`.
+Legacy automation scripts for upgrading the vendored `react-server-dom-webpack` runtime from the
+React fork into `react-on-rails-rsc`.
+
+> [!WARNING]
+> This is legacy fork-cherry-pick tooling. The active strategy is the stock npm
+> runtime path documented in
+> [`docs/eliminate-react-fork.md`](../../docs/eliminate-react-fork.md). Use this
+> script only for emergency maintenance of the current vendored runtime. Do not
+> use it for the Option 4 patch-file fallback; seed that path from the in-repo
+> archive and rewrite the tooling first. Patch history from the fork is preserved in
+> [`patches/archive/abanoubghadban-react/`](../../patches/archive/abanoubghadban-react/).
 
 ## Prerequisites
 

--- a/scripts/react-upgrade/package.json
+++ b/scripts/react-upgrade/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-upgrade",
   "version": "1.0.0",
-  "description": "Scripts to upgrade react-server-dom-webpack from React fork",
+  "description": "Legacy scripts to upgrade the vendored react-server-dom-webpack runtime from the React fork",
   "type": "module",
   "main": "upgrade.js",
   "scripts": {

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -5,7 +5,7 @@
  * This is a faithful port of the previously vendored build of React's
  * reference `ReactFlightWebpackPlugin`
  * (`src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js`)
- * including every fork patch and in-repo edit that file accumulated:
+ * including every historical fork patch and in-repo edit that file accumulated:
  *
  *  - Server-build support: `isServer` option, server manifest emission
  *    (`react-server-client-manifest.json`), and server chunk-group scanning.

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -28,7 +28,7 @@
  *      zero console errors/warnings, zero recoverable hydration errors,
  *      client components interactive, stylesheet links present, and the
  *      runtime's devtools-embedded version string matches the intended
- *      React fork version (the rc.4 "runtime still reports 19.0.3" class
+ *      vendored runtime version (the rc.4 "runtime still reports 19.0.3" class
  *      of incident).
  *
  * Known divergences of the rspack leg (current main behavior, asserted
@@ -118,9 +118,9 @@ const runNode = <T>(args: string[]): T => {
 const readJson = <T>(...segments: string[]): T =>
   JSON.parse(fs.readFileSync(path.join(...segments), 'utf8')) as T;
 
-// The intended React fork version — the runtime everywhere in the packed
+// The intended vendored runtime version — the runtime everywhere in the packed
 // dist must report exactly this (devtools registration + embedded strings).
-const INTENDED_FORK_VERSION = readJson<{ version: string }>(
+const INTENDED_RUNTIME_VERSION = readJson<{ version: string }>(
   REPO_ROOT,
   'src',
   'react-server-dom-webpack',
@@ -369,13 +369,13 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
       expect([...result.stylesheetLinks].sort()).toEqual([...expectedLinks].sort());
 
       // The runtime's embedded version string (captured from the devtools
-      // hook registration) must match the intended fork version — catches
+      // hook registration) must match the intended vendored runtime version — catches
       // stale runtime builds like the rc.4 "still reports 19.0.3" incident.
       const flightRenderer = result.devtoolsRenderers.find(
         (renderer) => renderer.rendererPackageName === 'react-on-rails-rsc',
       );
       expect(flightRenderer).toBeDefined();
-      expect(flightRenderer!.version).toBe(INTENDED_FORK_VERSION);
+      expect(flightRenderer!.version).toBe(INTENDED_RUNTIME_VERSION);
 
       // And react-dom in the client bundle is the consumer-installed copy.
       const reactDomVersion = readJson<{ version: string }>(
@@ -394,7 +394,7 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
 });
 
 describe('installed tarball version integrity', () => {
-  it('ships the intended React fork version in the packed runtime', () => {
+  it('ships the intended vendored runtime version in the packed runtime', () => {
     // The runtime package.json inside the installed dist…
     const installedRuntimeVersion = readJson<{ version: string }>(
       INSTALLED_PKG,
@@ -402,7 +402,7 @@ describe('installed tarball version integrity', () => {
       'react-server-dom-webpack',
       'package.json',
     ).version;
-    expect(installedRuntimeVersion).toBe(INTENDED_FORK_VERSION);
+    expect(installedRuntimeVersion).toBe(INTENDED_RUNTIME_VERSION);
 
     // …and every version string embedded in the installed runtime sources.
     const cjsDir = path.join(INSTALLED_PKG, 'dist', 'react-server-dom-webpack', 'cjs');
@@ -420,7 +420,7 @@ describe('installed tarball version integrity', () => {
     expect(Object.keys(embedded).length).toBeGreaterThan(0);
     for (const [file, versions] of Object.entries(embedded)) {
       for (const version of versions) {
-        expect({ file, version }).toEqual({ file, version: INTENDED_FORK_VERSION });
+        expect({ file, version }).toEqual({ file, version: INTENDED_RUNTIME_VERSION });
       }
     }
 


### PR DESCRIPTION
## Summary

- Preserve the `AbanoubGhadban/react` patch history in-repo under `patches/archive/abanoubghadban-react/`.
- Record the upstream status for the two runtime topics from #58:
  - JSON-walk parsing is already upstreamed in facebook/react#35776.
  - The old deferred-Suspense CSS FOUC fork topic is not upstream, but its exact loader-wrapper/global-manifest shape is obsolete for this repo after #48/#49 and is unsafe to reapply verbatim.
- Retire active fork guidance by marking `scripts/react-upgrade/` and `$react-upgrade` as legacy emergency vendored-runtime maintenance only, not the Option 4 patch-file fallback.

Closes #58.
Refs #71.

## Codex Decision Log

- **Non-blocking:** Issue #60 is closed on GitHub, but live `main` still carries `src/react-server-dom-webpack/` and `scripts/react-upgrade/`.
  - **Decision:** Document that the stock-runtime replacement remains outstanding after #86's interim 19.0.7 CVE patch.
  - **Why:** PR #86 explicitly described itself as a stopgap, and current source still contains the vendored runtime.
  - **Review later:** Maintainer may want to reopen or replace #60 tracking.
- **Non-blocking:** Whether to delete `scripts/react-upgrade/` now.
  - **Decision:** Keep the script but mark it legacy/emergency-only; do not route Option 4 through it.
  - **Why:** The vendored runtime still exists in `main`, while Option 4 now starts from the in-repo archive and requires rewritten `git am` tooling.
  - **Review later:** Delete or replace the script when the stock-runtime replacement actually lands or maintainers explicitly choose the patch-file fallback.
- **Non-blocking:** Generated patch files contain historical whitespace that `git diff --check` flags.
  - **Decision:** Add a scoped `.gitattributes` rule for `patches/archive/**/*.patch -whitespace`.
  - **Why:** These are archival `git format-patch` outputs; preserving the patch text is more important than normal editable-file whitespace cleanup.

## Merge Readiness

- **Release mode:** No release. Documentation, agent guidance, comments/test naming, and historical patch archive only. No changelog entry required.
- **Current head SHA:** `1120b588effe3410141166254f54ccc2277e2b95`.
- **CI/check status:** Current-head checks passed as of `2026-06-13T12:03:00Z`: `unit-tests`, `e2e-tests`, `verify-artifacts`, `claude-review`, all four compatibility matrix jobs (`React 19.0.4`/`19.2.x` across webpack 5.59/latest and Node 20/22), CodeRabbit, and Cursor Bugbot. `React canary signal` and `claude` are skipped signal jobs.
- **Review-thread status:** 0 unresolved threads; `reviewDecision` is `APPROVED`; no pending review objects.
- **Review feedback triage:** Greptile readability nit fixed in `CLAUDE.md`. CodeRabbit FOUC global-manifest concern addressed in the archive README, with patch files preserved verbatim as provenance. Claude SHA/provenance and v19.2.1 patch-scope comments addressed. Late Claude callout/subdirectory-README suggestions were triaged as covered/optional after green current-head CI, with explicit thread replies.
- **Validation run:** `yarn`, `git diff --check`, `codex review --uncommitted`, `yarn build`, and full `yarn test` (18 suites / 169 tests) passed after the final review-response change. Archive count remains 15 patch files plus README.
- **Label/CI decision:** No CI-expansion labels or comment commands; this repo gates on the full `gh pr checks` list, which is pass/skipped for current head.
- **Known residual risk:** `AbanoubGhadban/react` is still public/unarchived and requires owner/admin action; current token has pull-only permission. Private `agent-coord` state is `UNKNOWN` because `agent-coord` is unavailable, so public claim comments are advisory fallback only. #71 may still need maintainer closure after accepting the owner/admin archive blocker and legacy-tooling decision.
- **Merge recommendation:** Merge now. This is low-risk repo documentation/archive work, not the actual fork archive operation.
