### PR TITLE
Fix downstream E2E Node runtime split

### DIFF
--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -59,11 +59,25 @@ jobs:
             echo "::error::Expected $rortv not found in the downstream checkout." >&2
             exit 1
           fi
-          # Ruby intentionally runs at the downstream minimum supported version;
-          # Node uses the downstream exact toolchain version for JS build parity.
+          # Ruby intentionally runs at the downstream minimum supported version.
+          # The RSC install/pack phase runs on the current Node 22 line, then
+          # the downstream app is restored to its selected Node runtime.
+          validate_tool_version() {
+            local name="$1"
+            local value="$2"
+            if [[ ! "$value" =~ ^[0-9]+([.][0-9]+){0,2}([-+.][0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::Unexpected $name version from downstream checkout: $value" >&2
+              exit 1
+            fi
+          }
+
+          ruby_version="$("$rortv" react_on_rails/.minimum.tool-versions ruby)"
+          downstream_node_version="$("$rortv" react_on_rails/.tool-versions nodejs)"
+          validate_tool_version "Ruby" "$ruby_version"
+          validate_tool_version "Node" "$downstream_node_version"
           {
-            echo "ruby-version=$("$rortv" react_on_rails/.minimum.tool-versions ruby)"
-            echo "node-version=$("$rortv" react_on_rails/.tool-versions nodejs)"
+            echo "ruby-version=$ruby_version"
+            echo "downstream-node-version=$downstream_node_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
@@ -74,29 +88,66 @@ jobs:
           working-directory: react_on_rails/react_on_rails_pro/spec/dummy
           bundler-cache: true
 
-      - name: Setup Node
+      - name: Setup RSC Node
         # Pinned immutable actions/setup-node@v4 release SHA verified via git ls-remote.
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: ${{ steps.downstream-versions.outputs.node-version }}
+          node-version: '22.x'
 
-      - name: Enable package managers
+      - name: Enable RSC package manager
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          echo "RSC Node: $(node --version)"
+          echo "Yarn: $(yarn --version)"
+          echo "Ruby: $(ruby --version)"
+          echo "Bundler: $(bundle --version)"
+
+      - name: Install react-on-rails-rsc dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Pack react-on-rails-rsc
+        run: |
+          set -euo pipefail
+          pack_dir="${RUNNER_TEMP}/react-on-rails-rsc-downstream/package"
+          npm_cache_dir="${RUNNER_TEMP}/react-on-rails-rsc-downstream/npm-cache"
+          mkdir -p "$pack_dir" "$npm_cache_dir"
+          yarn build
+          tarball_name="$(
+            npm_config_cache="$npm_cache_dir" npm pack --loglevel=error --pack-destination "$pack_dir" | tail -1
+          )"
+          if [[ -z "$tarball_name" || "$tarball_name" != *.tgz ]]; then
+            echo "::error::npm pack did not return a tarball filename: $tarball_name" >&2
+            exit 1
+          fi
+          tarball_path="$pack_dir/$tarball_name"
+          test -f "$tarball_path"
+          echo "Packed tarball: $tarball_path"
+          echo "RSC_DOWNSTREAM_TARBALL=$tarball_path" >> "$GITHUB_ENV"
+
+      - name: Setup downstream Node
+        # Pinned immutable actions/setup-node@v4 release SHA verified via git ls-remote.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: ${{ steps.downstream-versions.outputs.downstream-node-version }}
+
+      - name: Enable downstream package managers
+        env:
+          DOWNSTREAM_NODE_VERSION: ${{ steps.downstream-versions.outputs.downstream-node-version }}
         shell: bash
         run: |
           set -euo pipefail
           corepack enable
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
           corepack prepare "$(node -p "require('./react_on_rails/package.json').packageManager")" --activate
-          echo "Node: $(node --version)"
+          echo "Downstream Node: $(node --version)"
           echo "Yarn: $(yarn --version)"
           if command -v pnpm >/dev/null 2>&1; then
             echo "pnpm: $(pnpm --version)"
           fi
-          echo "Ruby: $(ruby --version)"
-          echo "Bundler: $(bundle --version)"
-
-      - name: Install react-on-rails-rsc dependencies
-        run: yarn --frozen-lockfile
+          echo "Downstream requested Node: $DOWNSTREAM_NODE_VERSION"
 
       - name: Run downstream RSC E2E
         env:

--- a/.github/workflows/downstream-e2e.yml
+++ b/.github/workflows/downstream-e2e.yml
@@ -123,7 +123,10 @@ jobs:
             exit 1
           fi
           tarball_path="$pack_dir/$tarball_name"
-          test -f "$tarball_path"
+          if [[ ! -f "$tarball_path" ]]; then
+            echo "::error::Packed tarball not found: $tarball_path" >&2
+            exit 1
+          fi
           echo "Packed tarball: $tarball_path"
           echo "RSC_DOWNSTREAM_TARBALL=$tarball_path" >> "$GITHUB_ENV"
 
@@ -140,7 +143,6 @@ jobs:
         run: |
           set -euo pipefail
           corepack enable
-          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
           corepack prepare "$(node -p "require('./react_on_rails/package.json').packageManager")" --activate
           echo "Downstream Node: $(node --version)"
           echo "Yarn: $(yarn --version)"

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -248,7 +248,7 @@ ensure_command() {
 
 configure_pnpm() {
   if command -v pnpm >/dev/null 2>&1; then
-    pnpm --version
+    (cd "$REACT_ON_RAILS_DIR" && pnpm --version)
     return
   fi
 
@@ -286,7 +286,7 @@ NODE
   )"
   corepack enable
   corepack prepare "$package_manager" --activate
-  pnpm --version
+  (cd "$REACT_ON_RAILS_DIR" && pnpm --version)
 }
 
 checkout_downstream() {

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -23,6 +23,7 @@ REACT_ON_RAILS_REF_EXPLICIT="0"
 if [[ -n "${RSC_DOWNSTREAM_REACT_ON_RAILS_REF:-}" ]]; then
   REACT_ON_RAILS_REF_EXPLICIT="1"
 fi
+PREBUILT_TARBALL="${RSC_DOWNSTREAM_TARBALL:-}"
 REACT_ON_RAILS_DIR="${RSC_DOWNSTREAM_REACT_ON_RAILS_DIR:-}"
 WORK_DIR="${RSC_DOWNSTREAM_WORK_DIR:-}"
 AUTO_WORK_DIR="0"
@@ -52,6 +53,8 @@ Options:
                              option or RSC_DOWNSTREAM_REACT_ON_RAILS_REF is set.
   --react-on-rails-repo URL  Downstream repository URL.
   --react-on-rails-dir PATH  Use an existing downstream checkout instead of cloning.
+  --tarball PATH             Use a prebuilt react-on-rails-rsc npm tarball instead
+                             of building and packing this checkout.
   --work-dir PATH            Directory for the packed tarball, logs, and clone.
                              User-supplied work dirs are preserved after exit.
   --keep                     Keep the generated work directory for debugging.
@@ -62,6 +65,7 @@ Environment:
   RSC_DOWNSTREAM_REACT_ON_RAILS_REPO      Downstream repository URL.
   RSC_DOWNSTREAM_REACT_ON_RAILS_REF       Downstream ref to test. Default: main for clones.
   RSC_DOWNSTREAM_REACT_ON_RAILS_DIR       Existing downstream checkout path.
+  RSC_DOWNSTREAM_TARBALL                  Prebuilt react-on-rails-rsc npm tarball.
   RSC_DOWNSTREAM_WORK_DIR                 Directory for packed tarball, logs, and clone.
   RSC_DOWNSTREAM_KEEP                     1 = preserve generated work dir.
   RSC_DOWNSTREAM_DUMMY_BUILD_SCRIPT       Dummy build script. Default: build:test:rspack.
@@ -93,6 +97,10 @@ while (($# > 0)); do
       ;;
     --react-on-rails-dir)
       REACT_ON_RAILS_DIR="${2:?--react-on-rails-dir requires a value}"
+      shift 2
+      ;;
+    --tarball)
+      PREBUILT_TARBALL="${2:?--tarball requires a value}"
       shift 2
       ;;
     --work-dir)
@@ -329,11 +337,31 @@ checkout_downstream() {
 }
 
 pack_local_package() {
+  if [[ -n "$PREBUILT_TARBALL" ]]; then
+    log_step "Using prebuilt react-on-rails-rsc tarball"
+    if [[ "$PREBUILT_TARBALL" != /* ]]; then
+      PREBUILT_TARBALL="$ROOT/$PREBUILT_TARBALL"
+    fi
+    if [[ ! -f "$PREBUILT_TARBALL" ]]; then
+      echo "Prebuilt tarball not found: $PREBUILT_TARBALL" >&2
+      return 1
+    fi
+    TARBALL="$PREBUILT_TARBALL"
+    echo "Using prebuilt tarball: $TARBALL"
+    return
+  fi
+
   log_step "Building and packing react-on-rails-rsc"
   yarn build
-  TARBALL="$PACKAGE_DIR/$(
+  local tarball_name
+  tarball_name="$(
     npm_config_cache="$NPM_CACHE_DIR" npm pack --loglevel=error --pack-destination "$PACKAGE_DIR" | tail -1
   )"
+  if [[ -z "$tarball_name" || "$tarball_name" != *.tgz ]]; then
+    echo "npm pack did not return a tarball filename: $tarball_name" >&2
+    return 1
+  fi
+  TARBALL="$PACKAGE_DIR/$tarball_name"
   test -f "$TARBALL"
   echo "Packed tarball: $TARBALL"
 }

--- a/scripts/e2e/downstream.sh
+++ b/scripts/e2e/downstream.sh
@@ -362,7 +362,10 @@ pack_local_package() {
     return 1
   fi
   TARBALL="$PACKAGE_DIR/$tarball_name"
-  test -f "$TARBALL"
+  if [[ ! -f "$TARBALL" ]]; then
+    echo "Packed tarball not found: $TARBALL" >&2
+    return 1
+  fi
   echo "Packed tarball: $TARBALL"
 }
 


### PR DESCRIPTION
## Summary

- Split the downstream E2E workflow into an RSC package phase on the current Node 22 line and a downstream app phase on the React on Rails app's declared Node version.
- Pack `react-on-rails-rsc` before switching to the downstream Node runtime, then pass that tarball into `scripts/e2e/downstream.sh`.
- Add `--tarball` / `RSC_DOWNSTREAM_TARBALL` support so the script can install a prebuilt tarball without rebuilding under the downstream runtime.
- Validate downstream tool-version outputs before using them in workflow outputs.

Refs #59.

## Why

The post-merge downstream dispatch for #98 failed because the workflow installed this package under the downstream app's Node 22.12.0 runtime, while `release-it@20.2.0` in this package requires `^20.19.0 || ^22.13.0 || >=24.0.0`. This keeps package install/build/pack on a compatible Node version while still running the Pro dummy app under its own selected runtime.

## Merge Criteria

- **Release mode:** release-gate fix for downstream verification; no package publish in this PR.
- **Current head SHA:** `d7ced176c4374163be38eb39fece06eba2d9f260`.
- **CI/check status:** full `gh pr checks 100` is pass or expected skip on current head: compatibility matrix rows pass, `claude-review` passes, `e2e-tests` passes, `unit-tests` passes, `verify-artifacts` passes, CodeRabbit passes/review-skipped, Cursor Bugbot passes, React canary signal is skipped, and the separate `claude` row is skipped.
- **Review-thread status:** GraphQL unresolved review-thread count is `0` after replying to and resolving all Claude review threads on current head.
- **Review feedback triage:** blocking feedback was fixed before current head, including the split Node runtime and downstream-root `pnpm` probe in `scripts/e2e/downstream.sh`. Remaining review comments were triaged as positive notes or optional diagnostic/log cleanup: `npm pack --json`, workflow-only `pnpm --version` cwd, Yarn log signal, and soft version-log guard. These are non-blocking because the harness path is correct and the current-head downstream dispatch succeeded.
- **Validation run:** coordinator reran `yarn`, `bash -n scripts/e2e/downstream.sh`, `bash scripts/e2e/downstream.sh --help | grep -E -- '--tarball PATH|RSC_DOWNSTREAM_TARBALL'`, `shellcheck scripts/e2e/downstream.sh`, `actionlint .github/workflows/downstream-e2e.yml`, `git diff --check -- .github/workflows/downstream-e2e.yml scripts/e2e/downstream.sh`, `yarn build`, `yarn test`, and `npm pack --dry-run --loglevel=error`. Worker-recorded validation before handoff also covered the same surfaces after the Greptile cleanup and downstream-CI pnpm-context fix.
- **Label/CI decision:** no label-driven CI expansion exists in this repo. The required live gate is the full PR checks list plus a fresh downstream workflow dispatch. Current-head dispatch https://github.com/shakacode/react_on_rails_rsc/actions/runs/27482765497 completed successfully against `d7ced176c4374163be38eb39fece06eba2d9f260`.
- **Workflow change audit:** posted at https://github.com/shakacode/react_on_rails_rsc/pull/100#issuecomment-4700126687; no new secret references, unchanged `permissions: contents: read`, unchanged `workflow_dispatch` and nightly schedule triggers, and no new third-party actions or action version changes.
- **Known residual risk:** `node-version: '22.x'` intentionally floats within the Node 22 line for the RSC package phase so the release tooling engine floor is satisfied; a future Node 22 patch regression would surface as workflow failure. Optional diagnostic cleanup remains deferred but does not affect the gate behavior.
- **Merge recommendation:** merge by squash now. Current-head checks are complete, review threads are resolved or explicitly triaged, downstream dispatch succeeded, merge state is clean, and the change is directly repairing the downstream gate introduced by #98.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local E2E harness changes only; no runtime product code, auth, or data paths affected.
>
> **Overview**
> Fixes downstream E2E failing when the React on Rails app pins an older Node (e.g. 22.12.0) that does not satisfy this repo’s release tooling engine requirements.
>
> **Workflow (`downstream-e2e.yml`):** Ruby still uses the downstream minimum; Node is split into two phases. **RSC phase** uses floating `22.x`, installs only this package’s Yarn toolchain, runs `yarn build`, and `npm pack`s into `RSC_DOWNSTREAM_TARBALL`. **Downstream phase** switches `setup-node` to the app’s declared Node from `.tool-versions`, enables the downstream `packageManager`, then runs `downstream.sh` (which consumes the prebuilt tarball via env). Tool versions read from the downstream checkout are validated with a regex before writing workflow outputs.
>
> **`scripts/e2e/downstream.sh`:** Adds `--tarball` / `RSC_DOWNSTREAM_TARBALL` so E2E can skip rebuild/pack when a tarball is already built. `pack_local_package` validates `npm pack` output and tarball existence; `configure_pnpm` runs `pnpm` from the downstream checkout directory.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ced176c4374163be38eb39fece06eba2d9f260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

