### PR TITLE
Add npm badges and package link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # react-on-rails-rsc
 
+[![npm version](https://img.shields.io/npm/v/react-on-rails-rsc.svg)](https://www.npmjs.com/package/react-on-rails-rsc)
+[![npm next](https://img.shields.io/npm/v/react-on-rails-rsc/next.svg?label=next)](https://www.npmjs.com/package/react-on-rails-rsc?activeTab=versions)
+[![license](https://img.shields.io/npm/l/react-on-rails-rsc.svg)](https://www.npmjs.com/package/react-on-rails-rsc)
+
+[**npm: react-on-rails-rsc**](https://www.npmjs.com/package/react-on-rails-rsc)
+
 This package provides React Server Components (RSC) support for the [`react-on-rails-pro`](https://github.com/shakacode/react_on_rails_pro) Ruby gem. 
 
 ⚠️ **IMPORTANT: This package is for internal use only** ⚠️


### PR DESCRIPTION
Adds npm version, npm `next`-tag, and license badges plus a direct npm package link to the top of the README so the published package is discoverable from the repo landing page. Documentation only — no code, build, or version/changelog changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no code or release behavior changes.
> 
> **Overview**
> Adds **npm discoverability** at the top of `README.md`: shields for **latest version**, **`next` tag**, and **license**, plus a prominent link to the [npm package page](https://www.npmjs.com/package/react-on-rails-rsc).
> 
> No runtime, build, or release workflow changes—landing-page documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcf33c2a33bbb63d7c26277683897ff3e389d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added npm-related status badges (version, next tag, and license) to the project overview, with links to the corresponding npm package pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->