### PR TITLE
Update CHANGELOG.md for 19.2.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [19.2.0-rc.2] - 2026-06-16
 
 ### Fixed
 - Fixed the Rspack RSC build skipping the client-references module map on the 19.2 line when `react-server-dom-webpack` resolves to a different install path than the plugin's own copy (duplicate installs, pnpm/yarn symlink stores, hoisted-vs-nested layouts). The plugin now recognizes the Flight client runtime by file-name suffix confirmed through a `react-server-dom-webpack` `package.json` walk instead of strict resolved-path equality, matching the Webpack plugin's duplicate-install handling, so the module map is emitted and Rspack-rendered RSC client content works again. ([#105])
@@ -44,7 +44,8 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.1...HEAD
+[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.2...HEAD
+[19.2.0-rc.2]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.1...19.2.0-rc.2
 [19.2.0-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0-rc.1
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 


### PR DESCRIPTION
Stamps the `19.2.0-rc.2` prerelease version header in `CHANGELOG.md`.

This converts the existing `## [Unreleased]` section — which already holds the Fixed entry for the Rspack RSC client-runtime discovery fix ([#105], merged via [#106]) — into `## [19.2.0-rc.2]`, and adds the `19.2.0-rc.1...19.2.0-rc.2` compare link.

After this merges to `main`, the release runs from a clean `main` checkout: `yarn release:dry-run` → `yarn verify:artifacts` → `yarn release` (publishes `19.2.0-rc.2` to npm under the `next` dist-tag and creates the GitHub release from this section).

No code changes; changelog only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no effect on package behavior or consumers until a separate release publish.
> 
> **Overview**
> **Release bookkeeping only** — no runtime or build code changes.
> 
> Renames the top `CHANGELOG.md` section from `## [Unreleased]` to **`## [19.2.0-rc.2] - 2026-06-16`**, keeping the existing **Fixed** note for the Rspack client-references module map / duplicate `react-server-dom-webpack` install path ([#105]).
> 
> Updates footer links so **`[Unreleased]`** compares `19.2.0-rc.2...HEAD` and adds **`[19.2.0-rc.2]`** (`19.2.0-rc.1...19.2.0-rc.2`) for npm/GitHub release from this section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03056f4875be3107c90fcfb3cfe8de2e1aea9746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version 19.2.0-rc.2 release entry to changelog (dated 2026-06-16)
  * Updated version comparison links to reflect the new release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->