### PR TITLE
Scope per-client-reference CSS to its containing chunk(s) (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#108]) ([#110])
+- Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#110])
 
 ## [19.2.0-rc.2] - 2026-06-16
 
@@ -70,5 +70,4 @@ All notable changes to this package will be documented in this file.
 [#52]: https://github.com/shakacode/react_on_rails_rsc/pull/52
 [#54]: https://github.com/shakacode/react_on_rails_rsc/pull/54
 [#86]: https://github.com/shakacode/react_on_rails_rsc/pull/86
-[#108]: https://github.com/shakacode/react_on_rails_rsc/issues/108
 [#110]: https://github.com/shakacode/react_on_rails_rsc/pull/110

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#108]) ([#110])
+
 ## [19.2.0-rc.2] - 2026-06-16
 
 ### Fixed
@@ -65,3 +70,5 @@ All notable changes to this package will be documented in this file.
 [#52]: https://github.com/shakacode/react_on_rails_rsc/pull/52
 [#54]: https://github.com/shakacode/react_on_rails_rsc/pull/54
 [#86]: https://github.com/shakacode/react_on_rails_rsc/pull/86
+[#108]: https://github.com/shakacode/react_on_rails_rsc/issues/108
+[#110]: https://github.com/shakacode/react_on_rails_rsc/pull/110

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -190,9 +190,6 @@ type FlightBlock = {
 
 type FlightEntrypoint = {
   getRuntimeChunk(): { files: Iterable<string> } | null;
-  // An entrypoint's own chunks are exactly the chunks the page loads
-  // initially (vendor/common/styleguide splits + the entry chunk).
-  chunks: Iterable<FlightChunk>;
 };
 
 type FlightCompilation = {
@@ -478,25 +475,6 @@ export class RSCWebpackPlugin {
             }
           });
 
-          // Initial-chunk CSS filtering (#108, the follow-up to #52's
-          // runtime-chunk filtering): a client reference's chunk group pulls in
-          // the shared *initial* chunks it depends on (vendor/common/styleguide
-          // etc.). Those chunks' stylesheets are already loaded by the page's
-          // own entry as ordinary `<link>`s, so re-emitting them here — once per
-          // client reference, at `rsc-css` precedence (end of <head>) — is
-          // redundant render-blocking work and the dominant FCP/LCP regression
-          // when a real page is converted to RSC. Collect every initial chunk's
-          // files so the client build can exclude their CSS from per-module CSS
-          // lists; the server manifest is unaffected (`this.isServer`).
-          const initialChunkFiles = new Set<string>();
-          compilation.entrypoints.forEach((entrypoint) => {
-            for (const chunk of entrypoint.chunks ?? []) {
-              for (const file of chunk.files) {
-                initialChunkFiles.add(file);
-              }
-            }
-          });
-
           let cssPrefix =
             typeof compilation.outputOptions.publicPath === 'string' &&
             compilation.outputOptions.publicPath !== 'auto'
@@ -518,9 +496,12 @@ export class RSCWebpackPlugin {
             chunkResolvedClientFiles: Set<string>,
           ): void => {
             const chunks: (string | number | null)[] = [];
-            const cssFiles = new Set<string>();
 
-            const recordModule = (id: string | number | null, module: FlightModule): void => {
+            const recordModule = (
+              id: string | number | null,
+              module: FlightModule,
+              moduleCss: readonly string[],
+            ): void => {
               if (!module.resource || !chunkResolvedClientFiles.has(module.resource)) {
                 return;
               }
@@ -537,7 +518,7 @@ export class RSCWebpackPlugin {
                   }
                 }
                 if (existing.css == null) existing.css = [];
-                for (const cssFile of cssFiles) {
+                for (const cssFile of moduleCss) {
                   if (existing.css.indexOf(cssFile) === -1) {
                     existing.css.push(cssFile);
                   }
@@ -546,26 +527,21 @@ export class RSCWebpackPlugin {
                 filePathToModuleMetadata[href] = {
                   id,
                   chunks: chunks.slice(),
-                  css: Array.from(cssFiles),
+                  css: [...moduleCss],
                   name: '*',
                 };
               }
             };
 
-            // CSS-before-JS scan fix: record CSS files and the chunk's JS
-            // file independently of their order inside `chunk.files`.
+            // Record the loadable JS file of every chunk in the group: the
+            // chunk loader needs each dependency chunk to run the module, and
+            // it no-ops on chunks the page already installed. (CSS-before-JS
+            // scan fix: the JS file is found regardless of its position in
+            // `chunk.files`.)
             for (const chunk of chunkGroup.chunks) {
               let recordedJS = false;
               for (const file of chunk.files) {
                 if (
-                  file.endsWith('.css') &&
-                  !file.endsWith('.hot-update.css') &&
-                  cssPrefix !== null &&
-                  (this.isServer ||
-                    (!runtimeChunkFiles.has(file) && !initialChunkFiles.has(file)))
-                ) {
-                  cssFiles.add(cssPrefix + file);
-                } else if (
                   (file.endsWith('.js') || file.endsWith('.mjs')) &&
                   !file.endsWith('.hot-update.js') &&
                   !file.endsWith('.hot-update.mjs') &&
@@ -578,13 +554,38 @@ export class RSCWebpackPlugin {
               }
             }
 
+            // CSS is recorded PER CHUNK and attached only to the client
+            // references that chunk actually contains (#108). Collecting CSS
+            // group-wide (the previous behaviour) attached every shared
+            // dependency chunk's CSS — vendor/common/styleguide that the page
+            // entry already loaded — to every client reference in the group,
+            // which the node loader then re-emitted as a render-blocking
+            // `<link precedence="rsc-css">` per reference: the dominant FCP/LCP
+            // regression on real pages. Per-chunk scoping keeps a reference's
+            // own extracted CSS (incl. the entry chunk's CSS for an
+            // eagerly-imported component) while dropping the shared-dependency
+            // broadcast. The #52 runtime-chunk exclusion still applies.
             for (const chunk of chunkGroup.chunks) {
+              const chunkCss: string[] = [];
+              for (const file of chunk.files) {
+                if (
+                  file.endsWith('.css') &&
+                  !file.endsWith('.hot-update.css') &&
+                  cssPrefix !== null &&
+                  (this.isServer || !runtimeChunkFiles.has(file))
+                ) {
+                  const cssUrl = cssPrefix + file;
+                  if (!chunkCss.includes(cssUrl)) {
+                    chunkCss.push(cssUrl);
+                  }
+                }
+              }
               for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
                 const moduleId = compilation.chunkGraph.getModuleId(module);
-                recordModule(moduleId, module);
+                recordModule(moduleId, module, chunkCss);
                 if (module.modules) {
                   for (const concatenatedMod of module.modules) {
-                    recordModule(moduleId, concatenatedMod);
+                    recordModule(moduleId, concatenatedMod, chunkCss);
                   }
                 }
               }

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -190,6 +190,9 @@ type FlightBlock = {
 
 type FlightEntrypoint = {
   getRuntimeChunk(): { files: Iterable<string> } | null;
+  // An entrypoint's own chunks are exactly the chunks the page loads
+  // initially (vendor/common/styleguide splits + the entry chunk).
+  chunks: Iterable<FlightChunk>;
 };
 
 type FlightCompilation = {
@@ -475,6 +478,25 @@ export class RSCWebpackPlugin {
             }
           });
 
+          // Initial-chunk CSS filtering (#108, the follow-up to #52's
+          // runtime-chunk filtering): a client reference's chunk group pulls in
+          // the shared *initial* chunks it depends on (vendor/common/styleguide
+          // etc.). Those chunks' stylesheets are already loaded by the page's
+          // own entry as ordinary `<link>`s, so re-emitting them here — once per
+          // client reference, at `rsc-css` precedence (end of <head>) — is
+          // redundant render-blocking work and the dominant FCP/LCP regression
+          // when a real page is converted to RSC. Collect every initial chunk's
+          // files so the client build can exclude their CSS from per-module CSS
+          // lists; the server manifest is unaffected (`this.isServer`).
+          const initialChunkFiles = new Set<string>();
+          compilation.entrypoints.forEach((entrypoint) => {
+            for (const chunk of entrypoint.chunks ?? []) {
+              for (const file of chunk.files) {
+                initialChunkFiles.add(file);
+              }
+            }
+          });
+
           let cssPrefix =
             typeof compilation.outputOptions.publicPath === 'string' &&
             compilation.outputOptions.publicPath !== 'auto'
@@ -539,7 +561,8 @@ export class RSCWebpackPlugin {
                   file.endsWith('.css') &&
                   !file.endsWith('.hot-update.css') &&
                   cssPrefix !== null &&
-                  (this.isServer || !runtimeChunkFiles.has(file))
+                  (this.isServer ||
+                    (!runtimeChunkFiles.has(file) && !initialChunkFiles.has(file)))
                 ) {
                   cssFiles.add(cssPrefix + file);
                 } else if (


### PR DESCRIPTION
## Summary

Fixes #108. Scopes each client reference's CSS to the chunk(s) that actually contain that reference, instead of collecting CSS across the whole chunk group and attaching the union to every reference.

> **Note on history:** earlier revisions of this PR (and this description) explored an `initialChunkFiles` exclusion strategy — mirroring #52's runtime-chunk filter across all initial chunks. The **merged** implementation is **per-chunk CSS scoping**, a different algorithm; this description has been rewritten to match what shipped. See the trade-off discussion below and the follow-up in #111.

## The bug (#108)

`recordChunkGroup` collected CSS across a client reference's entire chunk group and attached that union to **every** reference in the group. Shared dependency chunks — vendor / common / styleguide that the page entry already loads — were therefore re-emitted as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` **per client reference**. On a real page converted to RSC this was the dominant FCP/LCP regression (hichee home: 12 of 14 stylesheet links were these re-broadcast shared chunks). #52 fixed only the runtime chunk; other shared initial chunks still broadcast.

## The fix

CSS is now recorded **per chunk** and attached only to the client references whose module that chunk contains:

- For each chunk in the group, collect its `.css` files (still honoring the #52 runtime-chunk exclusion and the `.hot-update.css` / `auto`-publicPath guards).
- Attach those files only to the client-reference modules found **in that chunk**.

A reference keeps its own extracted CSS; a shared dependency chunk whose only modules are non-client (vendor/common) no longer attaches its CSS to anyone. JS chunk lists are unchanged (still recorded group-wide), and the #52 runtime exclusion is preserved.

## Validation

Proven end-to-end on a real app (hichee), bumped to this branch via github refs:
- `filePathToModuleMetadata` CSS entries 609 → 82; vendor chunk references 103 → 0.
- Rendered page: home **14 → 8** stylesheet links (rsc-css **12 → 6**), faq **11 → 5** (rsc-css **9 → 3**). Only genuine per-client-reference chunks remain; shared vendor/splitChunks-commons no longer broadcast. Each client component keeps its own CSS.

## Follow-up — #111

A follow-up PR (#111) adds the regression coverage and tidy this PR's review threads asked for:
- A real-webpack per-chunk scoping test (the existing css-order unit tests mock `getChunkModulesIterable` to return the module for every chunk, so they cannot distinguish per-chunk from group-wide).
- Removes the dead `!chunkCss.includes(cssUrl)` dedup (`chunk.files` is a `Set`) and shortens the scoping comment.
- Fixes the stale `package-runtime-policy` version stamp (rc.1 → rc.2) that was red on `main`.

## Known limitation / open design question

Per-chunk scoping attaches a chunk's CSS by **module ownership**. If `SplitChunksPlugin` + `MiniCssExtractPlugin` place a client reference's *own* styles in a **sibling** chunk separate from the chunk holding its JS module (e.g. a shared `css/mini-extract` cache group), the reference's manifest entry can miss that CSS, because the sibling chunk's modules are CSS/shared modules rather than client references (raised by chatgpt-codex / claude on this PR). This does not occur in the real-world layouts validated above (each component's CSS stays with its module), but it is a real trade-off versus an initial-chunk-exclusion approach, which keys on initial-vs-async rather than module ownership. Tracking the decision in #111.