### PR TITLE
Make main CI green and add a per-chunk CSS scoping regression test (follow-up to #108/#110)

### DIFF
--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -537,7 +537,10 @@ export class RSCWebpackPlugin {
             // chunk loader needs each dependency chunk to run the module, and
             // it no-ops on chunks the page already installed. (CSS-before-JS
             // scan fix: the JS file is found regardless of its position in
-            // `chunk.files`.)
+            // `chunk.files`.) JS is intentionally group-wide while CSS below is
+            // per-chunk: every chunk must load before any module in the group
+            // runs, but a module only needs the CSS extracted from its own
+            // chunk. If that contract changes, both loops move together.
             for (const chunk of chunkGroup.chunks) {
               let recordedJS = false;
               for (const file of chunk.files) {

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -555,16 +555,12 @@ export class RSCWebpackPlugin {
             }
 
             // CSS is recorded PER CHUNK and attached only to the client
-            // references that chunk actually contains (#108). Collecting CSS
-            // group-wide (the previous behaviour) attached every shared
-            // dependency chunk's CSS — vendor/common/styleguide that the page
-            // entry already loaded — to every client reference in the group,
-            // which the node loader then re-emitted as a render-blocking
-            // `<link precedence="rsc-css">` per reference: the dominant FCP/LCP
-            // regression on real pages. Per-chunk scoping keeps a reference's
-            // own extracted CSS (incl. the entry chunk's CSS for an
-            // eagerly-imported component) while dropping the shared-dependency
-            // broadcast. The #52 runtime-chunk exclusion still applies.
+            // references that chunk contains (#108), instead of group-wide,
+            // which re-broadcast every shared dependency chunk's CSS
+            // (vendor/common already loaded by the page entry) onto every
+            // reference as a render-blocking `<link precedence="rsc-css">` —
+            // the dominant FCP/LCP regression on real pages. A reference's own
+            // extracted CSS and the #52 runtime-chunk exclusion are preserved.
             for (const chunk of chunkGroup.chunks) {
               const chunkCss: string[] = [];
               for (const file of chunk.files) {
@@ -574,10 +570,7 @@ export class RSCWebpackPlugin {
                   cssPrefix !== null &&
                   (this.isServer || !runtimeChunkFiles.has(file))
                 ) {
-                  const cssUrl = cssPrefix + file;
-                  if (!chunkCss.includes(cssUrl)) {
-                    chunkCss.push(cssUrl);
-                  }
+                  chunkCss.push(cssPrefix + file);
                 }
               }
               for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {

--- a/tests/package-runtime-policy.test.ts
+++ b/tests/package-runtime-policy.test.ts
@@ -34,8 +34,8 @@ describe('19.2 runtime release policy', () => {
     const pkg = readJson<PackageJson>('package.json');
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
 
-    expect(pkg.version).toBe('19.2.0-rc.1');
-    expect(changelog).toMatch(/^## \[19\.2\.0-rc\.1\] - \d{4}-\d{2}-\d{2}$/m);
+    expect(pkg.version).toBe('19.2.0-rc.2');
+    expect(changelog).toMatch(/^## \[19\.2\.0-rc\.2\] - \d{4}-\d{2}-\d{2}$/m);
   });
 
   it('depends on the stock React 19.2 Flight runtime and raises React peers to the runtime floor', () => {

--- a/tests/webpack-plugin/fixtures/split-shared-css/Button.css
+++ b/tests/webpack-plugin/fixtures/split-shared-css/Button.css
@@ -1,0 +1,3 @@
+.button {
+  color: red;
+}

--- a/tests/webpack-plugin/fixtures/split-shared-css/Button.js
+++ b/tests/webpack-plugin/fixtures/split-shared-css/Button.js
@@ -1,0 +1,8 @@
+'use client';
+
+import './Button.css';
+import { shared } from './shared';
+
+export default function Button() {
+  return 'button:' + shared;
+}

--- a/tests/webpack-plugin/fixtures/split-shared-css/SettingsPage.css
+++ b/tests/webpack-plugin/fixtures/split-shared-css/SettingsPage.css
@@ -1,0 +1,3 @@
+.settings {
+  color: green;
+}

--- a/tests/webpack-plugin/fixtures/split-shared-css/SettingsPage.js
+++ b/tests/webpack-plugin/fixtures/split-shared-css/SettingsPage.js
@@ -1,0 +1,9 @@
+'use client';
+
+import './SettingsPage.css';
+import { shared } from './shared';
+import { settingsOnly } from './settingsOnly';
+
+export default function SettingsPage() {
+  return 'settings:' + shared + settingsOnly;
+}

--- a/tests/webpack-plugin/fixtures/split-shared-css/entryOnly.js
+++ b/tests/webpack-plugin/fixtures/split-shared-css/entryOnly.js
@@ -1,0 +1,1 @@
+export const entryOnly = 'entry-only-module';

--- a/tests/webpack-plugin/fixtures/split-shared-css/index.js
+++ b/tests/webpack-plugin/fixtures/split-shared-css/index.js
@@ -1,0 +1,8 @@
+// Button and SettingsPage are independent 'use client' components that both
+// import a shared non-client module (`shared`) carrying its own CSS. The entry
+// reaches them only through the plugin's injected async blocks, and splitChunks
+// forces `shared` into a chunk shared by both client-reference chunk groups —
+// so the shared chunk's CSS is the broadcast vector the per-chunk fix scopes.
+import { entryOnly } from './entryOnly';
+
+export const app = [entryOnly];

--- a/tests/webpack-plugin/fixtures/split-shared-css/settingsOnly.js
+++ b/tests/webpack-plugin/fixtures/split-shared-css/settingsOnly.js
@@ -1,0 +1,1 @@
+export const settingsOnly = 'settings-only-module';

--- a/tests/webpack-plugin/fixtures/split-shared-css/shared.css
+++ b/tests/webpack-plugin/fixtures/split-shared-css/shared.css
@@ -1,0 +1,3 @@
+.shared {
+  color: blue;
+}

--- a/tests/webpack-plugin/fixtures/split-shared-css/shared.js
+++ b/tests/webpack-plugin/fixtures/split-shared-css/shared.js
@@ -1,0 +1,3 @@
+import './shared.css';
+
+export const shared = 'shared-module';

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -134,6 +134,64 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
     });
   });
 
+  describe('per-chunk CSS scoping: a shared dependency chunk does not broadcast its CSS', () => {
+    // Button and SettingsPage are independent 'use client' components, each
+    // with its own CSS, that both import a non-client `shared` module carrying
+    // shared.css. splitChunks forces `shared` into a chunk present in both
+    // client-reference chunk groups. Per-chunk scoping attaches a chunk's CSS
+    // only to the client references that chunk contains: shared.css lives in
+    // the shared chunk (whose only module is the non-client `shared`), so it is
+    // attached to neither reference, while each component keeps its own CSS.
+    // The pre-fix group-wide collection attached shared.css to both references.
+    let result: CompileResult;
+
+    beforeAll(() => {
+      result = run('split-shared-css', {
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              shared: {
+                test: /shared\.(js|css)$/,
+                name: 'shared',
+                minChunks: 2,
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('extracts the shared chunk CSS as its own asset (precondition)', () => {
+      expect(result.assets).toContain('shared.chunk.css');
+    });
+
+    it("keeps each client reference's own CSS", () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      const settings = entryEndingWith(result.manifest, '/SettingsPage.js');
+      expect(button.css).toContain('/assets/client-Button-js.chunk.css');
+      expect(settings.css).toContain('/assets/client-SettingsPage-js.chunk.css');
+    });
+
+    it("does not broadcast the shared chunk's CSS onto either reference", () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      const settings = entryEndingWith(result.manifest, '/SettingsPage.js');
+      expect(button.css ?? []).not.toContain('/assets/shared.chunk.css');
+      expect(settings.css ?? []).not.toContain('/assets/shared.chunk.css');
+    });
+
+    it('produces no fallback warning', () => {
+      expectNoWarnings(result);
+    });
+  });
+
   describe('duplicated module across chunk groups (issue #19 class, no splitChunks)', () => {
     // SettingsPage imports Button; with no splitChunks, Button's module is
     // duplicated into SettingsPage's chunk, so it appears in two chunk


### PR DESCRIPTION
Follow-up to #110 (per-chunk CSS scoping for #108). Addresses the remaining review feedback and a red `main`.

## Why

#110 merged with one pre-existing red test on `main` and two outstanding review threads. This PR closes both out.

## Changes

### 1. Unblock CI (`tests/package-runtime-policy.test.ts`)
The 19.2 release-policy test still asserted `19.2.0-rc.1`, but the package and CHANGELOG advanced to `19.2.0-rc.2` in `cb34e76` (Release 19.2.0-rc.2), so the test failed on `main`. Both assertions are bumped to `rc.2`.

### 2. Per-chunk CSS scoping regression test (review thread on coverage)
The existing `react-flight-webpack-plugin-css-order` unit tests cannot catch the #108 broadcast bug: their `getChunkModulesIterable` mock returns the same module for *every* chunk, so per-chunk vs group-wide attribution is indistinguishable.

This adds a **real-webpack** integration test (`plugin-integration.test.ts` + new `split-shared-css` fixture): two independent `'use client'` components, each with its own CSS, both importing a shared **non-client** module that carries its own CSS. `splitChunks` forces the shared module + its CSS into a standalone `shared` chunk that lives in *both* client-reference chunk groups. The test asserts:

- each component keeps its own extracted CSS, and
- the shared chunk's CSS (`shared.chunk.css`) is broadcast onto **neither** reference.

Verified this test **fails under the pre-fix group-wide collection** and **passes with per-chunk scoping** — i.e. it is a genuine regression guard, not a vacuous pass.

### 3. Plugin tidy (review thread on `recordChunkGroup`)
- Remove the dead `!chunkCss.includes(cssUrl)` dedup — `chunk.files` is a `Set`, so the URLs are already unique.
- Tighten the scoping comment.

No behavior change from (3); JS chunk lists and the #52 runtime-chunk exclusion are untouched.

## Verification

- `yarn build` ✅
- `yarn test` ✅ — all 188 tests across the three jest projects pass (was 1 red on `main`).
- Pre-fix simulation: reverting `recordChunkGroup` to group-wide collection makes the new "does not broadcast" assertion fail, confirming the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test and comment changes; the plugin edit is dedup removal with no intended behavior change, and CI version assertions are non-runtime.
> 
> **Overview**
> Unblocks **main CI** by aligning `package-runtime-policy` expectations with **`19.2.0-rc.2`** in `package.json` and `CHANGELOG.md` (was still asserting `rc.1`).
> 
> Adds a **real-webpack** regression for **#108** per-chunk CSS scoping: a `split-shared-css` fixture where two `'use client'` components share a non-client module forced into a common chunk with its own CSS. Integration tests assert each reference keeps its component CSS and **does not** get `shared.chunk.css` on the manifest—behavior that failed under group-wide CSS collection.
> 
> In `RSCWebpackPlugin.recordChunkGroup`, only **comments** are tightened (JS group-wide vs CSS per-chunk contract) and the redundant `chunkCss.includes` dedup is removed because `chunk.files` is already unique—**no manifest behavior change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9fe470c4c9b282e8dd22903fdcaa6f2cb96c10b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->