### PR TITLE
Recover a client reference's own CSS when SplitChunks splits it from its JS module (closes #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Fixed
 - Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#110])
+- Recovered a client reference's own extracted CSS when `SplitChunks` + `MiniCssExtractPlugin` place it in a chunk separate from the one holding the reference's JS module (e.g. a cache group that matches the JS file but not its `.css` sibling). The plugin now follows each reference's direct `.css` imports to the chunk(s) carrying them, intersected with the reference's chunk group, so the `rsc-css` hint is still emitted for those styles. Only direct imports are followed, so the per-chunk scoping from `#110` continues not to re-broadcast shared dependency CSS. ([#113])
 
 ## [19.2.0-rc.2] - 2026-06-16
 
@@ -71,3 +72,4 @@ All notable changes to this package will be documented in this file.
 [#54]: https://github.com/shakacode/react_on_rails_rsc/pull/54
 [#86]: https://github.com/shakacode/react_on_rails_rsc/pull/86
 [#110]: https://github.com/shakacode/react_on_rails_rsc/pull/110
+[#113]: https://github.com/shakacode/react_on_rails_rsc/pull/113

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -79,6 +79,12 @@ const clientFileNameOnServer = require.resolve('react-server-dom-webpack/client.
 
 const runtimeResourceDetectionCache = new Map<string, boolean>();
 
+// Style-import source extensions a client reference may import directly and
+// have extracted into a sibling chunk (#112): plain CSS plus the common
+// preprocessors. MiniCssExtract preserves the authored resource extension on
+// the importing module even though the emitted chunk file is `.css`.
+const STYLE_SOURCE_RE = /\.(css|scss|sass|less|styl|pcss)$/i;
+
 /**
  * Detects whether `resource` is the react-on-rails-rsc Flight client runtime
  * the plugin keys its client-reference injection on. Results are memoized
@@ -599,23 +605,26 @@ export class RSCWebpackPlugin {
               compilation.chunkGraph.getModuleChunksIterable?.bind(compilation.chunkGraph);
             const directCssDepFiles = (module: FlightModule): string[] => {
               if (!moduleGraph || !getModuleChunksIterable || cssPrefix === null) return [];
-              const files: string[] = [];
+              const files = new Set<string>();
               for (const connection of moduleGraph.getOutgoingConnections(module)) {
                 const depModule = connection.module ?? connection.resolvedModule;
-                if (!depModule || !depModule.resource || !depModule.resource.endsWith('.css')) {
+                // Match the style-import source (`.css` and the common
+                // preprocessor extensions); MiniCssExtract keeps the importing
+                // module's resource as the authored file even though the
+                // emitted chunk file is always `.css`.
+                if (!depModule || !depModule.resource || !STYLE_SOURCE_RE.test(depModule.resource)) {
                   continue;
                 }
                 for (const cssChunk of getModuleChunksIterable(depModule)) {
                   if (!groupChunks.has(cssChunk)) continue;
                   for (const file of cssChunk.files) {
                     if (isRecordableCss(file)) {
-                      const cssUrl = cssPrefix + file;
-                      if (!files.includes(cssUrl)) files.push(cssUrl);
+                      files.add(cssPrefix + file);
                     }
                   }
                 }
               }
-              return files;
+              return [...files];
             };
 
             for (const chunk of chunkGroup.chunks) {

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -636,12 +636,19 @@ export class RSCWebpackPlugin {
               }
               for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
                 const moduleId = compilation.chunkGraph.getModuleId(module);
-                // Only client references (or concatenation roots that may wrap
-                // one) need sibling-CSS recovery; skip the graph walk for the
-                // many plain dependency modules `recordModule` would drop anyway.
+                // Only client references need sibling-CSS recovery; skip the
+                // graph walk for the many plain dependency modules
+                // `recordModule` would drop anyway. A client reference can also
+                // be the root of a ConcatenationModule — its external `.css`
+                // imports live on the root, so walking the root recovers them.
+                // (A client reference is an async boundary, so webpack does not
+                // fold it in as a concatenated *inner* module; inner-module CSS
+                // imports therefore aren't a case that arises here.)
+                const isResolvedClientRef = (m: FlightModule): boolean =>
+                  !!m.resource && chunkResolvedClientFiles.has(m.resource);
                 const mayBeClientRef =
-                  (!!module.resource && chunkResolvedClientFiles.has(module.resource)) ||
-                  !!module.modules;
+                  isResolvedClientRef(module) ||
+                  (!!module.modules && module.modules.some(isResolvedClientRef));
                 const siblingCss = mayBeClientRef ? directCssDepFiles(module) : [];
                 const moduleCss = siblingCss.length
                   ? [...new Set([...chunkCss, ...siblingCss])]

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -205,6 +205,16 @@ type FlightCompilation = {
   chunkGraph: {
     getChunkModulesIterable(chunk: FlightChunk): Iterable<FlightModule>;
     getModuleId(module: FlightModule): string | number | null;
+    // Real webpack only; absent in the unit-test mocks, which gate the
+    // sibling-chunk CSS recovery pass off this method's presence.
+    getModuleChunksIterable?(module: FlightModule): Iterable<FlightChunk>;
+  };
+  // Real webpack only; the unit-test mocks omit it, which disables the
+  // sibling-chunk CSS recovery pass (see #112).
+  moduleGraph?: {
+    getOutgoingConnections(
+      module: FlightModule,
+    ): Iterable<{ module?: FlightModule | null; resolvedModule?: FlightModule | null }>;
   };
   hooks: {
     processAssets: {
@@ -564,24 +574,73 @@ export class RSCWebpackPlugin {
             // reference as a render-blocking `<link precedence="rsc-css">` —
             // the dominant FCP/LCP regression on real pages. A reference's own
             // extracted CSS and the #52 runtime-chunk exclusion are preserved.
+            const groupChunks = new Set<FlightChunk>(chunkGroup.chunks);
+
+            const isRecordableCss = (file: string): boolean =>
+              file.endsWith('.css') &&
+              !file.endsWith('.hot-update.css') &&
+              cssPrefix !== null &&
+              (this.isServer || !runtimeChunkFiles.has(file));
+
+            // Sibling-chunk CSS recovery (#112): SplitChunks + MiniCssExtract
+            // can place a reference's *own* extracted CSS in a chunk separate
+            // from the one holding its JS module (e.g. a cache group that
+            // matches the JS file but not its `.css` sibling). That CSS chunk's
+            // only modules are CSS/shared modules, so the per-chunk pass alone
+            // would drop it. Follow the module's DIRECT `.css` imports to the
+            // chunk(s) that carry them, intersected with this chunk group, and
+            // merge that CSS. Only direct imports are followed, so CSS reached
+            // through a shared dependency (imported by another module, not the
+            // reference) is NOT picked up — the #108 broadcast stays fixed.
+            // Guarded on `moduleGraph`/`getModuleChunksIterable`, which the
+            // unit-test mocks omit (they exercise the per-chunk pass only).
+            const moduleGraph = compilation.moduleGraph;
+            const getModuleChunksIterable =
+              compilation.chunkGraph.getModuleChunksIterable?.bind(compilation.chunkGraph);
+            const directCssDepFiles = (module: FlightModule): string[] => {
+              if (!moduleGraph || !getModuleChunksIterable || cssPrefix === null) return [];
+              const files: string[] = [];
+              for (const connection of moduleGraph.getOutgoingConnections(module)) {
+                const depModule = connection.module ?? connection.resolvedModule;
+                if (!depModule || !depModule.resource || !depModule.resource.endsWith('.css')) {
+                  continue;
+                }
+                for (const cssChunk of getModuleChunksIterable(depModule)) {
+                  if (!groupChunks.has(cssChunk)) continue;
+                  for (const file of cssChunk.files) {
+                    if (isRecordableCss(file)) {
+                      const cssUrl = cssPrefix + file;
+                      if (!files.includes(cssUrl)) files.push(cssUrl);
+                    }
+                  }
+                }
+              }
+              return files;
+            };
+
             for (const chunk of chunkGroup.chunks) {
               const chunkCss: string[] = [];
               for (const file of chunk.files) {
-                if (
-                  file.endsWith('.css') &&
-                  !file.endsWith('.hot-update.css') &&
-                  cssPrefix !== null &&
-                  (this.isServer || !runtimeChunkFiles.has(file))
-                ) {
+                if (isRecordableCss(file)) {
                   chunkCss.push(cssPrefix + file);
                 }
               }
               for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
                 const moduleId = compilation.chunkGraph.getModuleId(module);
-                recordModule(moduleId, module, chunkCss);
+                // Only client references (or concatenation roots that may wrap
+                // one) need sibling-CSS recovery; skip the graph walk for the
+                // many plain dependency modules `recordModule` would drop anyway.
+                const mayBeClientRef =
+                  (!!module.resource && chunkResolvedClientFiles.has(module.resource)) ||
+                  !!module.modules;
+                const siblingCss = mayBeClientRef ? directCssDepFiles(module) : [];
+                const moduleCss = siblingCss.length
+                  ? [...new Set([...chunkCss, ...siblingCss])]
+                  : chunkCss;
+                recordModule(moduleId, module, moduleCss);
                 if (module.modules) {
                   for (const concatenatedMod of module.modules) {
-                    recordModule(moduleId, concatenatedMod, chunkCss);
+                    recordModule(moduleId, concatenatedMod, moduleCss);
                   }
                 }
               }

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -513,6 +513,15 @@ export class RSCWebpackPlugin {
           ): void => {
             const chunks: (string | number | null)[] = [];
 
+            // `chunkGroup.chunks` is typed as `Iterable<FlightChunk>` and is
+            // walked several times below; materialize it once so a one-shot
+            // iterator (a non-webpack bundler) cannot silently yield nothing on
+            // the later passes.
+            const groupChunkList = [...chunkGroup.chunks];
+
+            const isResolvedClientRef = (module: FlightModule): boolean =>
+              !!module.resource && chunkResolvedClientFiles.has(module.resource);
+
             const recordModule = (
               id: string | number | null,
               module: FlightModule,
@@ -557,7 +566,7 @@ export class RSCWebpackPlugin {
             // per-chunk: every chunk must load before any module in the group
             // runs, but a module only needs the CSS extracted from its own
             // chunk. If that contract changes, both loops move together.
-            for (const chunk of chunkGroup.chunks) {
+            for (const chunk of groupChunkList) {
               let recordedJS = false;
               for (const file of chunk.files) {
                 if (
@@ -580,7 +589,7 @@ export class RSCWebpackPlugin {
             // reference as a render-blocking `<link precedence="rsc-css">` —
             // the dominant FCP/LCP regression on real pages. A reference's own
             // extracted CSS and the #52 runtime-chunk exclusion are preserved.
-            const groupChunks = new Set<FlightChunk>(chunkGroup.chunks);
+            const groupChunks = new Set<FlightChunk>(groupChunkList);
 
             const isRecordableCss = (file: string): boolean =>
               file.endsWith('.css') &&
@@ -627,7 +636,7 @@ export class RSCWebpackPlugin {
               return [...files];
             };
 
-            for (const chunk of chunkGroup.chunks) {
+            for (const chunk of groupChunkList) {
               const chunkCss: string[] = [];
               for (const file of chunk.files) {
                 if (isRecordableCss(file)) {
@@ -644,8 +653,6 @@ export class RSCWebpackPlugin {
                 // (A client reference is an async boundary, so webpack does not
                 // fold it in as a concatenated *inner* module; inner-module CSS
                 // imports therefore aren't a case that arises here.)
-                const isResolvedClientRef = (m: FlightModule): boolean =>
-                  !!m.resource && chunkResolvedClientFiles.has(m.resource);
                 const mayBeClientRef =
                   isResolvedClientRef(module) ||
                   (!!module.modules && module.modules.some(isResolvedClientRef));

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -616,12 +616,17 @@ export class RSCWebpackPlugin {
               if (!moduleGraph || !getModuleChunksIterable || cssPrefix === null) return [];
               const files = new Set<string>();
               for (const connection of moduleGraph.getOutgoingConnections(module)) {
+                // `module` is the resolved destination for most connections;
+                // some dependency types leave it null with the target on
+                // `resolvedModule`, so fall back to it.
                 const depModule = connection.module ?? connection.resolvedModule;
                 // Match the style-import source (`.css` and the common
                 // preprocessor extensions); MiniCssExtract keeps the importing
                 // module's resource as the authored file even though the
-                // emitted chunk file is always `.css`.
-                if (!depModule || !depModule.resource || !STYLE_SOURCE_RE.test(depModule.resource)) {
+                // emitted chunk file is always `.css`. Strip any webpack
+                // resource query/fragment (`./Button.css?inline`) first.
+                const depResource = depModule?.resource?.replace(/[?#].*$/, '');
+                if (!depResource || !STYLE_SOURCE_RE.test(depResource)) {
                   continue;
                 }
                 for (const cssChunk of getModuleChunksIterable(depModule)) {

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -620,15 +620,14 @@ export class RSCWebpackPlugin {
                 // some dependency types leave it null with the target on
                 // `resolvedModule`, so fall back to it.
                 const depModule = connection.module ?? connection.resolvedModule;
+                if (!depModule || !depModule.resource) continue;
                 // Match the style-import source (`.css` and the common
                 // preprocessor extensions); MiniCssExtract keeps the importing
                 // module's resource as the authored file even though the
                 // emitted chunk file is always `.css`. Strip any webpack
                 // resource query/fragment (`./Button.css?inline`) first.
-                const depResource = depModule?.resource?.replace(/[?#].*$/, '');
-                if (!depResource || !STYLE_SOURCE_RE.test(depResource)) {
-                  continue;
-                }
+                const depResource = depModule.resource.replace(/[?#].*$/, '');
+                if (!STYLE_SOURCE_RE.test(depResource)) continue;
                 for (const cssChunk of getModuleChunksIterable(depModule)) {
                   if (!groupChunks.has(cssChunk)) continue;
                   for (const file of cssChunk.files) {

--- a/tests/webpack-plugin/fixtures/split-js-css/Button.css
+++ b/tests/webpack-plugin/fixtures/split-js-css/Button.css
@@ -1,0 +1,3 @@
+.button {
+  color: red;
+}

--- a/tests/webpack-plugin/fixtures/split-js-css/Button.js
+++ b/tests/webpack-plugin/fixtures/split-js-css/Button.js
@@ -1,0 +1,7 @@
+'use client';
+
+import './Button.css';
+
+export default function Button() {
+  return 'button';
+}

--- a/tests/webpack-plugin/fixtures/split-js-css/Other.js
+++ b/tests/webpack-plugin/fixtures/split-js-css/Other.js
@@ -1,0 +1,7 @@
+'use client';
+
+import Button from './Button';
+
+export default function Other() {
+  return 'other:' + Button();
+}

--- a/tests/webpack-plugin/fixtures/split-js-css/entryOnly.js
+++ b/tests/webpack-plugin/fixtures/split-js-css/entryOnly.js
@@ -1,0 +1,1 @@
+export const entryOnly = 'entry-only';

--- a/tests/webpack-plugin/fixtures/split-js-css/index.js
+++ b/tests/webpack-plugin/fixtures/split-js-css/index.js
@@ -1,0 +1,9 @@
+// Button and Other are both 'use client'. Other imports Button, so Button's
+// JS module is shared between two client-reference chunk groups; splitChunks
+// (matching only `Button.js`) moves that JS into a shared chunk while
+// MiniCssExtract leaves Button.css in the per-reference sibling chunk. Button's
+// own CSS thus lands in a chunk that does NOT contain Button's module — the
+// #112 sibling-chunk case.
+import { entryOnly } from './entryOnly';
+
+export const app = [entryOnly];

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -248,6 +248,14 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
       expect(button.css ?? []).not.toContain('/assets/client-Other-js.chunk.css');
     });
 
+    it("attaches Other's own copy of the CSS to Other, not Button's", () => {
+      const other = entryEndingWith(result.manifest, '/Other.js');
+      // Other renders Button, so its chunk carries its own extracted copy of
+      // the styles; it must be hinted Other's copy and not Button's.
+      expect(other.css).toContain('/assets/client-Other-js.chunk.css');
+      expect(other.css ?? []).not.toContain('/assets/client-Button-js.chunk.css');
+    });
+
     it('produces no fallback warning', () => {
       expectNoWarnings(result);
     });

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -192,6 +192,67 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
     });
   });
 
+  describe('sibling-chunk CSS recovery: own CSS split from its JS module (#112)', () => {
+    // Button ('use client') imports Button.css; Other ('use client') imports
+    // Button, so Button's JS is shared across two client-reference chunk
+    // groups. splitChunks (matching only Button.js) moves that JS into a shared
+    // chunk, while MiniCssExtract leaves Button.css in the per-reference
+    // sibling chunk — so Button's own CSS lives in a chunk that does not
+    // contain Button's module. The per-chunk pass alone would leave Button's
+    // entry with no CSS; the #112 recovery pass follows Button's direct
+    // Button.css import to its chunk (intersected with Button's group) and
+    // restores it.
+    let result: CompileResult;
+
+    beforeAll(() => {
+      result = run('split-js-css', {
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              sharedButtonJs: {
+                test: /Button\.js$/,
+                name: 'shared-button',
+                minChunks: 2,
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("splits Button's JS into the shared chunk while its CSS stays in the sibling chunk (precondition)", () => {
+      expect(result.assets).toContain('shared-button.chunk.js');
+      expect(result.assets).toContain('client-Button-js.chunk.css');
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      // Button's JS module is in the shared chunk, which carries no CSS.
+      expect(chunkFiles(button)).toContain('shared-button.chunk.js');
+    });
+
+    it("recovers Button's own CSS from its sibling chunk", () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(button.css).toContain('/assets/client-Button-js.chunk.css');
+    });
+
+    it("does not attach another group's copy of Button's CSS to Button", () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      // Button.css is also extracted into Other's chunk, but that chunk is not
+      // in Button's chunk group, so its copy must not be hinted for Button.
+      expect(button.css ?? []).not.toContain('/assets/client-Other-js.chunk.css');
+    });
+
+    it('produces no fallback warning', () => {
+      expectNoWarnings(result);
+    });
+  });
+
   describe('duplicated module across chunk groups (issue #19 class, no splitChunks)', () => {
     // SettingsPage imports Button; with no splitChunks, Button's module is
     // duplicated into SettingsPage's chunk, so it appears in two chunk


### PR DESCRIPTION
Closes #112. Follow-up to #108 / #110 / #111.

## Problem

Per-chunk CSS scoping (#108, #110) attaches a chunk's CSS to the client references whose **module** that chunk contains. When `SplitChunksPlugin` + `MiniCssExtractPlugin` place a reference's *own* extracted CSS in a chunk **separate** from the one holding its JS module — e.g. a cache group that matches the JS file but not its `.css` sibling — that CSS chunk's only modules are CSS/shared modules, so `recordModule` skips them and the reference's manifest entry ends up with `css: []`. The Flight server then emits no `rsc-css` hint for styles that are needed and not necessarily initial-loaded.

Raised by `chatgpt-codex-connector` (P2) and `claude` on #110.

## Why `getModuleChunksIterable(jsModule)` alone doesn't fix it

`mini-css-extract` represents the extracted styles as a *separate* module that is a dependency of the JS module, so `getModuleChunksIterable(jsModule)` returns only the chunks containing the **JS** module — never the sibling chunk holding the CSS module. You have to go through the dependency edge.

## Fix

A guarded **recovery pass** in `recordChunkGroup`: for each client-reference module, follow its **direct** `.css` import connections (`moduleGraph.getOutgoingConnections`) to the CSS module, locate that module's chunks (`chunkGraph.getModuleChunksIterable`), **intersect with the current chunk group**, and merge those chunks' CSS into the reference's entry.

Key properties:

- **Closes the gap** — a reference's own CSS is restored even when its JS and CSS land in different chunks of its group.
- **#108 broadcast stays fixed (by construction)** — only *direct* `.css` imports are followed, so CSS reached through a shared dependency (imported by another module, not the reference) is never picked up. Verified against the `split-shared-css` fixture from #111.
- **Group-scoped** — the same CSS module can be extracted into several groups' chunks; intersecting with the current group ensures a reference is only hinted CSS that will actually load with it (asserted: Other's copy of `Button.css` is not attached to Button).
- **No-op for normal layouts** — when JS and CSS are co-located (the common case, including hichee), the recovered set equals the per-chunk set and the deduped union is byte-identical. The `css-import` test confirms unchanged output.
- **Mock-safe** — gated on `moduleGraph` / `getModuleChunksIterable`, which the unit-test mocks omit; the per-chunk pass is unchanged for them.

## Tests

New `split-js-css` integration fixture (Button's JS forced into a shared chunk via a `Button.js`-only cache group, its CSS left in the sibling chunk):

- recovers `client-Button-js.chunk.css` onto Button's entry (verified to fail — `css: []` — with the recovery pass disabled),
- does **not** attach Other's copy (`client-Other-js.chunk.css`) to Button,
- no fallback warning.

All existing suites green (`yarn test`: 192 tests across the three jest projects), including the #111 no-broadcast invariant and the eager-import / css-order coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manifest CSS assembly on the RSC critical path; behavior is guarded and covered by integration tests, but wrong graph scoping could mis-hint styles or regress #110 performance fixes.
> 
> **Overview**
> **Extends per-chunk client-reference CSS scoping** so a component’s own extracted styles are still listed in the Flight client manifest when `splitChunks` puts its JS in one chunk and `MiniCssExtractPlugin` leaves the matching CSS in a sibling chunk (e.g. a cache group that matches only `Button.js`).
> 
> In `recordChunkGroup`, the plugin now materializes chunk-group chunks once, then for client-reference modules (including concatenation roots) walks **direct** style imports via `moduleGraph` / `getModuleChunksIterable`, merges those CSS URLs with the per-chunk list (group-scoped, deduped), and skips the pass when those APIs are absent (unit mocks). Shared-dependency CSS is still not re-broadcast because only direct imports are followed.
> 
> Adds a `split-js-css` integration fixture and tests; documents the fix in **CHANGELOG** ([#113]).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8bc9fb9c9b621f44a023c35bfbdf5f462d7f57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Merge criteria (met)

Documenting the bar this PR was merged against, per maintainer authorization:

1. **All required CI green** — `unit-tests`, `e2e-tests`, `verify-artifacts`, and the full React 19.0.4/19.2.x × webpack 5.59/latest × Node 20/22 compatibility matrix all pass on the head commit; `claude-review` passed.
2. **`yarn test` green locally** — 192 → 193 tests across the three jest projects after the added coverage.
3. **Closes the gap, proven non-vacuously** — the `split-js-css` recovery assertion fails (`css: []`) with the recovery pass disabled and passes with it enabled.
4. **#108 / #110 no-broadcast invariant preserved by construction** — only *direct* `.css` imports are followed; the `split-shared-css` fixture (shared dependency CSS) still asserts no broadcast.
5. **No-op for normal/co-located layouts** — the `css-import` fixture output is byte-identical, so real apps (e.g. hichee, whose client components co-locate JS+CSS) are unaffected; the full hichee ShakaPerf rebuild was intentionally not re-run because the change provably cannot alter its rendered output.
6. **Mock-safe** — gated on `moduleGraph` / `getModuleChunksIterable`, which the unit mocks omit, so the per-chunk path is unchanged for them.
7. **All review threads addressed** — preprocessor extensions (`.scss`/`.less`/…), `Set` dedup, tightened concatenation guard + documented assumption, Other-side positive coverage, and the changelog entry; every CodeRabbit/Codex/Greptile/claude thread resolved.
