### PR TITLE
Update CHANGELOG.md for 19.2.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [19.2.0-rc.3] - 2026-06-19
 
 ### Fixed
 - Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#110])
@@ -50,7 +50,7 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.2...HEAD
+[19.2.0-rc.3]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.2...19.2.0-rc.3
 [19.2.0-rc.2]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.1...19.2.0-rc.2
 [19.2.0-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0-rc.1
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5


### PR DESCRIPTION
## Summary

Stamps the **`19.2.0-rc.3`** prerelease version header in `CHANGELOG.md`. This is the changelog-driven prep step before running `yarn release` from `main`.

No new entries were written — the two `### Fixed` entries had already accumulated under `## [Unreleased]`. This PR just renames that section to `## [19.2.0-rc.3] - 2026-06-19` and adds the `19.2.0-rc.2...19.2.0-rc.3` compare link.

## Classification sweep (`19.2.0-rc.2..origin/main`)

| PR | Result | Category | Notes |
| ---- | ---- | ---- | ---- |
| #110 | entry-needed | product code | Per-client-reference CSS scoping (FCP/LCP fix). Already in changelog. |
| #111 | no-entry | internal | CI fix (release-policy test rc.1→rc.2), per-chunk regression test, comment/dedup cleanup. No user-visible behavior change. |
| #113 | entry-needed | product code | Recovers a reference's own extracted CSS when SplitChunks separates it from its JS module. Already in changelog. |

> Note: `#108` and `#112` in the merge-commit subjects are **issue** references; the merged PRs are `#110`/`#113`.

## Next step

After this merges to `main`, run `yarn release:dry-run` then `yarn release` from a clean `main` checkout. `scripts/release.sh` reads `19.2.0-rc.3` from the top-most version header, publishes to npm under the `next` dist-tag, and creates the GitHub release from this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release bookkeeping with no runtime or build behavior changes.
> 
> **Overview**
> Prepares the **19.2.0-rc.3** prerelease in `CHANGELOG.md` only: the former `## [Unreleased]` block becomes `## [19.2.0-rc.3] - 2026-06-19` with the same two **Fixed** bullets (per-client-reference CSS scoping [#110] and SplitChunks CSS recovery [#113]), and the footer gains `[19.2.0-rc.3]` compare URL while `[Unreleased]` is removed.
> 
> No new changelog text or product code—this unblocks changelog-driven `yarn release` on `main`, which reads the top version header for npm/GitHub tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c60a73a0f95759c9ee2eeb81945334c3fca383a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version documentation to reflect release candidate 19.2.0-rc.3 (June 19, 2026).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->