### PR TITLE
Fix release-blocking version stamp test (unblocks 19.2.0-rc.3)

### DIFF
--- a/tests/package-runtime-policy.test.ts
+++ b/tests/package-runtime-policy.test.ts
@@ -34,8 +34,13 @@ describe('19.2 runtime release policy', () => {
     const pkg = readJson<PackageJson>('package.json');
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
 
-    expect(pkg.version).toBe('19.2.0-rc.2');
-    expect(changelog).toMatch(/^## \[19\.2\.0-rc\.2\] - \d{4}-\d{2}-\d{2}$/m);
+    // Derive the expected version from package.json so a version bump doesn't
+    // require editing this test (a hard-coded version here previously blocked
+    // the rc.3 release). Still pins the 19.2.0-rc line and requires the
+    // CHANGELOG's top entry to match the package version exactly.
+    expect(pkg.version).toMatch(/^19\.2\.0-rc\.\d+$/);
+    const topChangelogVersion = changelog.match(/^## \[([^\]]+)\] - \d{4}-\d{2}-\d{2}$/m)?.[1];
+    expect(topChangelogVersion).toBe(pkg.version);
   });
 
   it('depends on the stock React 19.2 Flight runtime and raises React peers to the runtime floor', () => {


### PR DESCRIPTION
## Problem

The `19.2 runtime release policy` test (`tests/package-runtime-policy.test.ts`) hard-coded the expected version:

```ts
expect(pkg.version).toBe('19.2.0-rc.2');
expect(changelog).toMatch(/^## \[19\.2\.0-rc\.2\] - \d{4}-\d{2}-\d{2}$/m);
```

The `Bump version to 19.2.0-rc.3` commit (63b3ae3) updated `package.json` + `CHANGELOG.md` to `19.2.0-rc.3` but not this assertion. The Release workflow runs the test suite as validation, so **the rc.3 release failed twice** (runs on 2026-06-20 and 2026-06-21) at "Run release validation":

```
FAIL tests/package-runtime-policy.test.ts
> 37 |     expect(pkg.version).toBe('19.2.0-rc.2');
```

`npm dist-tag next` is still stuck at `19.2.0-rc.2` as a result.

## Fix

Derive the expected version from `package.json` and require the CHANGELOG's top entry to match it, still pinned to the `19.2.0-rc` line. Future version bumps no longer need to edit this test.

```ts
expect(pkg.version).toMatch(/^19\.2\.0-rc\.\d+$/);
const topChangelogVersion = changelog.match(/^## \[([^\]]+)\] - \d{4}-\d{2}-\d{2}$/m)?.[1];
expect(topChangelogVersion).toBe(pkg.version);
```

`yarn jest tests/package-runtime-policy.test.ts` → 4/4 pass on current `main` (rc.3).

Once merged, re-run **Release package** (`version=19.2.0-rc.3`, `confirm_publish=publish`) to publish rc.3 to the `next` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to release validation; no runtime or publish behavior is modified.
> 
> **Overview**
> Fixes a **release-blocking** failure in `tests/package-runtime-policy.test.ts` where the version/changelog stamp test still expected `19.2.0-rc.2` after `package.json` and `CHANGELOG.md` were bumped to `19.2.0-rc.3`.
> 
> The test now **reads `package.json` as source of truth**: it asserts the version matches the `19.2.0-rc.N` line and that the **top CHANGELOG heading** uses the same version. Future rc bumps no longer require editing this test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa96ef72cd6f2a0d633a814e27def5207328f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release policy validation to dynamically extract and verify version information from package metadata and release notes instead of using hard-coded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->