### PR TITLE
Docs: explain consuming unreleased RSC builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ This package is not intended to be used directly by end users. It is designed to
 
 Do not use this package's APIs directly in your application code. Instead use [`react_on_rails`](https://github.com/shakacode/react_on_rails) and [`react-on-rails-pro`](https://github.com/shakacode/react_on_rails_pro) gems and npm packages APIs to render or stream React Server Components.
 
+## Testing Unreleased Builds
+
+If a downstream app needs to test a `react-on-rails-rsc` fix before an npm
+release, see [`docs/consuming-unreleased-builds.md`](docs/consuming-unreleased-builds.md)
+for the yalc, canary publish, throwaway dist branch, and version-pairing
+workflows.
+
 ## Package Contents
 
 This package provides internal tooling for React Server Components integration:

--- a/docs/consuming-unreleased-builds.md
+++ b/docs/consuming-unreleased-builds.md
@@ -194,12 +194,30 @@ package in isolation.
 ## Downstream Verification Checklist
 
 Before reporting that the unreleased build works, verify the app is actually
-using the intended package and that the package has built files:
+using the intended package and that the package has the required built entry
+points and exported plugin/server files:
 
 ```bash
 node -p "require('react-on-rails-rsc/package.json').version"
 test -f node_modules/react-on-rails-rsc/dist/client.browser.js
+test -f node_modules/react-on-rails-rsc/dist/client.node.js
 test -f node_modules/react-on-rails-rsc/dist/server.node.js
+test -f node_modules/react-on-rails-rsc/dist/types.js
+test -f node_modules/react-on-rails-rsc/dist/types.d.ts
+test -f node_modules/react-on-rails-rsc/dist/WebpackPlugin.js
+test -f node_modules/react-on-rails-rsc/dist/WebpackPlugin.d.ts
+test -f node_modules/react-on-rails-rsc/dist/WebpackLoader.js
+test -f node_modules/react-on-rails-rsc/dist/WebpackLoader.d.ts
+test -f node_modules/react-on-rails-rsc/dist/flight-server.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.browser.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.edge.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.node.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.js
+test -f node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.js
+test -f node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.d.ts
+test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.js
+test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.js
+test -f node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.js
 ```
 
 Then run the downstream app's normal RSC build and test path. A package install

--- a/docs/consuming-unreleased-builds.md
+++ b/docs/consuming-unreleased-builds.md
@@ -1,0 +1,207 @@
+# Consuming Unreleased Builds
+
+Use this guide when a downstream React on Rails app needs to test a
+`react-on-rails-rsc` fix before the fix is published in an official npm
+release. This package is still normally consumed through `react_on_rails` and
+`react_on_rails_pro`; do not import its low-level APIs directly from
+application code.
+
+Prefer a released `react-on-rails-rsc` version when possible. For temporary
+testing, choose one of these workflows:
+
+| Workflow | Use when | Tradeoff |
+| --- | --- | --- |
+| yalc | You are iterating locally in one downstream app. | Fastest loop, but not useful for CI or sharing. |
+| Canary npm publish | Teammates or CI need the same temporary build. | Requires maintainer npm publish rights and a unique prerelease version. |
+| Throwaway dist branch | A Yarn Classic app needs a Git ref and npm publishing is not appropriate. | Commits generated `dist/` output to a branch that must never be merged. |
+
+## Why Direct Git Dependencies Break In Yarn Classic
+
+This repository does not commit `dist/`; `.gitignore` excludes it. Published npm
+tarballs include `dist/`, and this package's `prepare` and `prepack` scripts run
+`yarn run build-if-needed` to create it when the package is built for publishing.
+
+That means a plain source branch is not enough for Yarn Classic consumers. A
+dependency such as this can install without the built files that this package's
+exports point at:
+
+```bash
+yarn add react-on-rails-rsc@git+https://github.com/shakacode/react_on_rails_rsc.git#main
+```
+
+If `node_modules/react-on-rails-rsc/dist/client.browser.js` and the other `dist`
+entry points are missing, the downstream app will fail later during bundling or
+server startup. Use one of the workflows below instead of relying on Yarn
+Classic to build this package from a Git dependency.
+
+## yalc Workflow
+
+Use yalc for a local fix/test loop when one developer controls both this checkout
+and the downstream app checkout.
+
+From this repository:
+
+```bash
+yarn
+yarn build
+yalc publish
+```
+
+From the downstream app:
+
+```bash
+yalc add react-on-rails-rsc
+yarn install
+```
+
+After each change in this repository, rebuild and update the yalc package:
+
+```bash
+yarn build
+yalc publish
+```
+
+Then refresh the app copy:
+
+```bash
+yalc update react-on-rails-rsc
+yarn install
+```
+
+Do not commit yalc artifacts such as `.yalc/`, `yalc.lock`, or temporary
+`package.json` dependency rewrites unless the downstream project deliberately
+tracks them for its own testing workflow.
+
+## Canary npm Publish Workflow
+
+Use a canary publish only when a maintainer needs to share the same temporary
+build with another developer or CI. This is not the official release process;
+official releases still follow `docs/releasing.md` and the dist-tag policy in
+`docs/versioning.md`.
+
+Choose an unpublished prerelease version in the same package runtime line as the
+branch being tested. For example, a temporary build from the `19.2.x` line might
+use a version like `19.2.0-canary.20260621.<short-sha>`. Do not publish
+temporary test builds to `latest`, `next`, or `rc`; `next` is reserved for the
+official prerelease lane and `rc` is not an allowed npm dist-tag under this
+package's release policy.
+
+From this repository:
+
+```bash
+git switch <fix-branch>
+yarn
+yarn build
+yarn version --new-version X.Y.Z-canary.<date>.<short-sha> --no-git-tag-version
+npm publish --tag canary --access public
+```
+
+Record the exact published version. Then restore the local version edit unless
+the branch is intentionally carrying that version change:
+
+```bash
+git restore package.json
+```
+
+From the downstream app, pin the exact canary version rather than the dist-tag:
+
+```bash
+yarn add react-on-rails-rsc@X.Y.Z-canary.<date>.<short-sha>
+```
+
+If `react-on-rails-rsc` is pulled in transitively through
+`react-on-rails-pro`, use the downstream app's normal override mechanism. For a
+Yarn Classic app, that is usually a `resolutions` entry:
+
+```json
+{
+  "resolutions": {
+    "react-on-rails-rsc": "X.Y.Z-canary.<date>.<short-sha>"
+  }
+}
+```
+
+Verify the resolved package before testing:
+
+```bash
+yarn why react-on-rails-rsc
+node -p "require('react-on-rails-rsc/package.json').version"
+```
+
+## Throwaway Dist Branch Workflow
+
+Use a throwaway dist branch when a Yarn Classic consumer must install from Git
+and npm publishing is not appropriate. The branch exists only to carry generated
+`dist/` files for testing.
+
+From this repository:
+
+```bash
+git fetch origin
+git switch -c throwaway/rsc-dist-<short-sha> <target-ref>
+yarn
+yarn build
+git add -f dist
+git commit -m "Build dist for <target-ref>"
+git push origin HEAD
+```
+
+From the downstream app:
+
+```bash
+yarn add react-on-rails-rsc@git+https://github.com/shakacode/react_on_rails_rsc.git#throwaway/rsc-dist-<short-sha>
+```
+
+Keep this branch out of pull requests and merge queues. If the source branch
+changes, rebuild `dist/` and push a new throwaway branch or commit. Delete the
+branch after downstream testing no longer needs it.
+
+## Version Pairing
+
+`react-on-rails-rsc` is only one part of the downstream RSC stack. The package
+`major.minor` tracks the React runtime line, as described in
+[`versioning.md`](versioning.md). When testing an unreleased build, keep these
+pieces paired from the same rollout or compatibility target:
+
+- `react_on_rails` / `react-on-rails`
+- `react_on_rails_pro` / `react-on-rails-pro`
+- `react-on-rails-rsc`
+- The React runtime packages expected by that RSC line, including `react`,
+  `react-dom`, and the `react-server-dom-webpack` dependency resolved through
+  this package
+
+Do not move only `react-on-rails-rsc` to a different package runtime line, such
+as `19.0.x` to `19.2.x`, unless the matching `react_on_rails` and
+`react_on_rails_pro` branches or releases are also part of the test plan.
+Version skew can show up as missing package exports, missing
+`react-server-dom-webpack` subpaths, or bundler failures before the app reaches
+runtime.
+
+For a downstream Yarn Classic app, confirm the resolved package set before
+calling the test successful:
+
+```bash
+yarn why react-on-rails-rsc
+yarn why react-on-rails
+yarn why react-on-rails-pro
+```
+
+For Ruby gems, check the app's `Gemfile.lock` or the exact Git refs in the
+rollout branch. If the tested branch includes a coordinated React on Rails or
+React on Rails Pro update, use that branch instead of overriding only this
+package in isolation.
+
+## Downstream Verification Checklist
+
+Before reporting that the unreleased build works, verify the app is actually
+using the intended package and that the package has built files:
+
+```bash
+node -p "require('react-on-rails-rsc/package.json').version"
+test -f node_modules/react-on-rails-rsc/dist/client.browser.js
+test -f node_modules/react-on-rails-rsc/dist/server.node.js
+```
+
+Then run the downstream app's normal RSC build and test path. A package install
+that succeeds is not enough evidence; the RSC bundler and server-rendering paths
+must also pass in the consumer app.

--- a/docs/consuming-unreleased-builds.md
+++ b/docs/consuming-unreleased-builds.md
@@ -15,15 +15,16 @@ testing, choose one of these workflows:
 | Canary npm publish | Teammates or CI need the same temporary build. | Requires maintainer npm publish rights and a unique prerelease version. |
 | Throwaway dist branch | A Yarn Classic app needs a Git ref and npm publishing is not appropriate. | Commits generated `dist/` output to a branch that must never be merged. |
 
-## Why Direct Git Dependencies Break In Yarn Classic
+## Why Direct Git Dependencies Are Fragile In Yarn Classic
 
 This repository does not commit `dist/`; `.gitignore` excludes it. Published npm
 tarballs include `dist/`, and this package's `prepare` and `prepack` scripts run
 `yarn run build-if-needed` to create it when the package is built for publishing.
 
-That means a plain source branch is not enough for Yarn Classic consumers. A
-dependency such as this can install without the built files that this package's
-exports point at:
+That means a plain source branch is risky for Yarn Classic consumers. Depending
+on install flags, cache state, and the package manager environment, a Git
+dependency can install without the built files that this package's exports point
+at, or spend the app install trying to build this package from source:
 
 ```bash
 yarn add react-on-rails-rsc@git+https://github.com/shakacode/react_on_rails_rsc.git#main
@@ -31,8 +32,9 @@ yarn add react-on-rails-rsc@git+https://github.com/shakacode/react_on_rails_rsc.
 
 If `node_modules/react-on-rails-rsc/dist/client.browser.js` and the other `dist`
 entry points are missing, the downstream app will fail later during bundling or
-server startup. Use one of the workflows below instead of relying on Yarn
-Classic to build this package from a Git dependency.
+server startup. Use one of the workflows below instead of relying on a Yarn
+Classic Git dependency to build this package reproducibly inside the consumer
+install.
 
 ## yalc Workflow
 
@@ -68,6 +70,10 @@ yalc update react-on-rails-rsc
 yarn install
 ```
 
+For a faster loop, yalc also supports `yalc push` after `yalc publish` has
+linked the package into the app. Use `yalc push --watch` when you want yalc to
+refresh the app copy automatically after each local rebuild.
+
 Do not commit yalc artifacts such as `.yalc/`, `yalc.lock`, or temporary
 `package.json` dependency rewrites unless the downstream project deliberately
 tracks them for its own testing workflow.
@@ -93,8 +99,14 @@ git switch <fix-branch>
 yarn
 yarn build
 yarn version --new-version X.Y.Z-canary.<date>.<short-sha> --no-git-tag-version
-npm publish --tag canary --access public
+npm publish --ignore-scripts --tag canary --access public
 ```
+
+The publish command intentionally uses `npm publish`: npm owns the registry
+publish flow, while `yarn publish` prompts for versioning and can create git
+metadata. The explicit `yarn build` above prepares `dist/`, and
+`--ignore-scripts` prevents the `prepublishOnly` hook from rebuilding the same
+files a second time.
 
 Record the exact published version. Then restore the local version edit unless
 the branch is intentionally carrying that version change:

--- a/docs/consuming-unreleased-builds.md
+++ b/docs/consuming-unreleased-builds.md
@@ -56,23 +56,17 @@ yalc add react-on-rails-rsc
 yarn install
 ```
 
-After each change in this repository, rebuild and update the yalc package:
+After each change in this repository, rebuild and push the updated yalc package
+to linked downstream apps:
 
 ```bash
 yarn build
-yalc publish
+yalc push
 ```
 
-Then refresh the app copy:
-
-```bash
-yalc update react-on-rails-rsc
-yarn install
-```
-
-For a faster loop, yalc also supports `yalc push` after `yalc publish` has
-linked the package into the app. Use `yalc push --watch` when you want yalc to
-refresh the app copy automatically after each local rebuild.
+Use `yalc push --watch` when you want yalc to refresh the app copy
+automatically after each local rebuild. Rerun `yarn install` in the downstream
+app only when dependency metadata changes.
 
 Do not commit yalc artifacts such as `.yalc/`, `yalc.lock`, or temporary
 `package.json` dependency rewrites unless the downstream project deliberately
@@ -98,8 +92,8 @@ From this repository:
 git switch <fix-branch>
 yarn
 yarn build
-yarn version --new-version X.Y.Z-canary.<date>.<short-sha> --no-git-tag-version
 npm whoami
+yarn version --new-version X.Y.Z-canary.<date>.<short-sha> --no-git-tag-version
 npm publish --ignore-scripts --tag canary
 ```
 
@@ -213,35 +207,44 @@ points and exported plugin/server files:
 
 ```bash
 node -p "require('react-on-rails-rsc/package.json').version"
-test -f node_modules/react-on-rails-rsc/dist/client.browser.js
-test -f node_modules/react-on-rails-rsc/dist/client.browser.d.ts
-test -f node_modules/react-on-rails-rsc/dist/client.node.js
-test -f node_modules/react-on-rails-rsc/dist/client.node.d.ts
-test -f node_modules/react-on-rails-rsc/dist/server.node.js
-test -f node_modules/react-on-rails-rsc/dist/server.node.d.ts
-test -f node_modules/react-on-rails-rsc/dist/types.js
-test -f node_modules/react-on-rails-rsc/dist/types.d.ts
-test -f node_modules/react-on-rails-rsc/dist/WebpackPlugin.js
-test -f node_modules/react-on-rails-rsc/dist/WebpackPlugin.d.ts
-test -f node_modules/react-on-rails-rsc/dist/WebpackLoader.js
-test -f node_modules/react-on-rails-rsc/dist/WebpackLoader.d.ts
-test -f node_modules/react-on-rails-rsc/dist/flight-server.js
-test -f node_modules/react-on-rails-rsc/dist/flight-server.d.ts
-test -f node_modules/react-on-rails-rsc/dist/flight-server.browser.js
-test -f node_modules/react-on-rails-rsc/dist/flight-server.browser.d.ts
-test -f node_modules/react-on-rails-rsc/dist/flight-server.edge.js
-test -f node_modules/react-on-rails-rsc/dist/flight-server.edge.d.ts
-test -f node_modules/react-on-rails-rsc/dist/flight-server.node.js
-test -f node_modules/react-on-rails-rsc/dist/flight-server.node.d.ts
-test -f node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.js
-test -f node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.d.ts
-test -f node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.js
-test -f node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.d.ts
-test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.js
-test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.d.ts
-test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.js
-test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.d.ts
-test -f node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.js
+for path in \
+  node_modules/react-on-rails-rsc/dist/client.browser.js \
+  node_modules/react-on-rails-rsc/dist/client.browser.d.ts \
+  node_modules/react-on-rails-rsc/dist/client.node.js \
+  node_modules/react-on-rails-rsc/dist/client.node.d.ts \
+  node_modules/react-on-rails-rsc/dist/server.node.js \
+  node_modules/react-on-rails-rsc/dist/server.node.d.ts \
+  node_modules/react-on-rails-rsc/dist/types.js \
+  node_modules/react-on-rails-rsc/dist/types.d.ts \
+  node_modules/react-on-rails-rsc/dist/WebpackPlugin.js \
+  node_modules/react-on-rails-rsc/dist/WebpackPlugin.d.ts \
+  node_modules/react-on-rails-rsc/dist/WebpackLoader.js \
+  node_modules/react-on-rails-rsc/dist/WebpackLoader.d.ts \
+  node_modules/react-on-rails-rsc/dist/flight-server.js \
+  node_modules/react-on-rails-rsc/dist/flight-server.d.ts \
+  node_modules/react-on-rails-rsc/dist/flight-server.browser.js \
+  node_modules/react-on-rails-rsc/dist/flight-server.browser.d.ts \
+  node_modules/react-on-rails-rsc/dist/flight-server.edge.js \
+  node_modules/react-on-rails-rsc/dist/flight-server.edge.d.ts \
+  node_modules/react-on-rails-rsc/dist/flight-server.node.js \
+  node_modules/react-on-rails-rsc/dist/flight-server.node.d.ts \
+  node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.js \
+  node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.d.ts \
+  node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.js \
+  node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.d.ts \
+  node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.js \
+  node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.d.ts \
+  node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.js \
+  node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.d.ts \
+  node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.js
+do
+  if test -f "$path"; then
+    printf 'ok %s\n' "$path"
+  else
+    printf 'missing %s\n' "$path" >&2
+    exit 1
+  fi
+done
 ```
 
 Then run the downstream app's normal RSC build and test path. A package install

--- a/docs/consuming-unreleased-builds.md
+++ b/docs/consuming-unreleased-builds.md
@@ -99,14 +99,16 @@ git switch <fix-branch>
 yarn
 yarn build
 yarn version --new-version X.Y.Z-canary.<date>.<short-sha> --no-git-tag-version
-npm publish --ignore-scripts --tag canary --access public
+npm whoami
+npm publish --ignore-scripts --tag canary
 ```
 
 The publish command intentionally uses `npm publish`: npm owns the registry
 publish flow, while `yarn publish` prompts for versioning and can create git
 metadata. The explicit `yarn build` above prepares `dist/`, and
 `--ignore-scripts` prevents the `prepublishOnly` hook from rebuilding the same
-files a second time.
+files a second time. The `npm whoami` preflight makes missing npm publish auth
+fail before the version is changed or the publish step starts.
 
 Record the exact published version. Then restore the local version edit unless
 the branch is intentionally carrying that version change:
@@ -212,8 +214,11 @@ points and exported plugin/server files:
 ```bash
 node -p "require('react-on-rails-rsc/package.json').version"
 test -f node_modules/react-on-rails-rsc/dist/client.browser.js
+test -f node_modules/react-on-rails-rsc/dist/client.browser.d.ts
 test -f node_modules/react-on-rails-rsc/dist/client.node.js
+test -f node_modules/react-on-rails-rsc/dist/client.node.d.ts
 test -f node_modules/react-on-rails-rsc/dist/server.node.js
+test -f node_modules/react-on-rails-rsc/dist/server.node.d.ts
 test -f node_modules/react-on-rails-rsc/dist/types.js
 test -f node_modules/react-on-rails-rsc/dist/types.d.ts
 test -f node_modules/react-on-rails-rsc/dist/WebpackPlugin.js
@@ -221,14 +226,21 @@ test -f node_modules/react-on-rails-rsc/dist/WebpackPlugin.d.ts
 test -f node_modules/react-on-rails-rsc/dist/WebpackLoader.js
 test -f node_modules/react-on-rails-rsc/dist/WebpackLoader.d.ts
 test -f node_modules/react-on-rails-rsc/dist/flight-server.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.d.ts
 test -f node_modules/react-on-rails-rsc/dist/flight-server.browser.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.browser.d.ts
 test -f node_modules/react-on-rails-rsc/dist/flight-server.edge.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.edge.d.ts
 test -f node_modules/react-on-rails-rsc/dist/flight-server.node.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.node.d.ts
 test -f node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.js
+test -f node_modules/react-on-rails-rsc/dist/flight-server.node.unbundled.d.ts
 test -f node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.js
 test -f node_modules/react-on-rails-rsc/dist/RSCReferenceDiscoveryPlugin.d.ts
 test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.js
+test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.d.ts
 test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.js
+test -f node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.d.ts
 test -f node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.js
 ```
 

--- a/docs/consuming-unreleased-builds.md
+++ b/docs/consuming-unreleased-builds.md
@@ -111,6 +111,15 @@ the branch is intentionally carrying that version change:
 git restore package.json
 ```
 
+When testing is complete, remove the moving canary tag and deprecate the
+temporary version so future consumers do not discover it accidentally:
+
+```bash
+npm dist-tag rm react-on-rails-rsc canary
+npm deprecate react-on-rails-rsc@X.Y.Z-canary.<date>.<short-sha> \
+  "Temporary canary build; use a supported release instead."
+```
+
 From the downstream app, pin the exact canary version rather than the dist-tag:
 
 ```bash
@@ -236,15 +245,17 @@ for path in \
   node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/plugin.d.ts \
   node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.js \
   node_modules/react-on-rails-rsc/dist/react-server-dom-rspack/loader.d.ts \
-  node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.js
+  node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.js \
+  node_modules/react-on-rails-rsc/dist/webpack/RSCWebpackPlugin.d.ts
 do
   if test -f "$path"; then
     printf 'ok %s\n' "$path"
   else
     printf 'missing %s\n' "$path" >&2
-    exit 1
+    missing=1
   fi
 done
+test "${missing:-0}" -eq 0
 ```
 
 Then run the downstream app's normal RSC build and test path. A package install


### PR DESCRIPTION
## Summary
- Add a consumer-facing guide for testing unreleased react-on-rails-rsc builds.
- Cover yalc, canary npm publishes, throwaway dist branches, downstream verification, and package/gem version pairing.
- Link the guide from README.
- Broaden the downstream verification checklist after review noted that checking only two dist files could miss partial builds.
- Clarify the Yarn Classic Git-dependency risk, document yalc push, and use npm publish --ignore-scripts for canary publishing.
- Add npm auth preflight, remove the no-op unscoped package access flag, and include missing type entry points in the downstream checklist.

Fixes #109

## Validation
- git diff --check -- README.md docs/consuming-unreleased-builds.md
- Local README/docs link checks for the new references
- Code fence balance check on docs/consuming-unreleased-builds.md
- Follow-up docs checks after review fixes: git diff --check, link target check, code fence balance check, phrase checks for canary publish and yalc push updates
- Latest review-fix commit 19b83c3: git diff --check, code fence balance, link target check, phrase checks for npm whoami, npm publish --ignore-scripts --tag canary, flight-server.d.ts, Rspack type checks, and absence of --access public

## Review Triage
- Greptile noted the downstream verification checklist spot-checked too few dist entry points. Fixed in 9a81742.
- Claude noted the Yarn Classic Git-dependency claim was too absolute, npm publish should avoid a duplicate prepublishOnly build, and the npm publish exception should be documented. Fixed in 555e119.
- Claude then noted the no-op --access public flag, missing npm auth preflight, and missing type-file checks. Fixed in 19b83c3.
- CodeRabbit rate-limited and did not produce a substantive review.

## Coordination
- Batch: rsc-tonight-20260621
- Worker: codex-rsc-tonight-109-unreleased-build-docs
- Private agent-coord state: UNKNOWN; agent-coord status and doctor timed out in coordinator preflight.
- Public fallback claim: https://github.com/shakacode/react_on_rails_rsc/issues/109#issuecomment-4761496039

## Codex Decision Log
- **Non-blocking:** Whether to run yarn build for this docs-only change.
  - **Decision:** Skipped yarn build.
  - **Why:** The change only edits Markdown docs and README links; this repo has no markdown checker script, and TypeScript build does not exercise these files.
  - **Review later:** None.

## Churn Notes
- Pre-push review gate: worker self-review plus coordinator diff review.
- Post-push review churn: 3 follow-up docs commits to address review feedback; no behavior/CI churn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, build script, or dependency modifications.
> 
> **Overview**
> Adds **`docs/consuming-unreleased-builds.md`**, a consumer guide for testing `react-on-rails-rsc` fixes before an official npm release, and links it from the README under **Testing Unreleased Builds**.
> 
> The guide compares three temporary workflows—**yalc**, **canary npm publish**, and **throwaway dist branches**—and explains why a plain Yarn Classic Git dependency on a source branch is unreliable because `dist/` is not committed. It documents canary publishing with `npm whoami`, explicit `yarn build`, and `npm publish --ignore-scripts --tag canary`, plus cleanup via dist-tag removal and deprecation.
> 
> It also covers **version pairing** across `react_on_rails`, `react-on-rails-pro`, `react-on-rails-rsc`, and the React runtime line, and adds a **downstream verification checklist** that asserts a broad set of `dist/` JS and `.d.ts` entry points before relying on the consumer app’s RSC build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebd65ad95d9ba8eb37e8edabf63b15962c6ca04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->