### PR TITLE
Warn when client references span many chunk groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added a configurable client-build warning when a client reference appears in at least four client-reference chunk groups, helping surface cross-page JS/CSS duplication from chunk contamination. Set `chunkGroupWarningThreshold` to a positive number to tune the threshold, or to `0`/`false` to disable the warning. ([#117])
+- Added a configurable client-build warning when a client reference appears in at least four client-reference chunk groups, helping surface cross-page JS/CSS duplication from chunk contamination. Set `chunkGroupWarningThreshold` to a positive number to tune the threshold, or to `0`/`false` to disable the warning. ([#120])
 
 ## [19.2.0-rc.3] - 2026-06-19
 
@@ -61,7 +61,7 @@ All notable changes to this package will be documented in this file.
 [19.2.0-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0-rc.1
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 
-[#117]: https://github.com/shakacode/react_on_rails_rsc/issues/117
+[#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#105]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Added a configurable client-build warning when a client reference appears in at least four client-reference chunk groups, helping surface cross-page JS/CSS duplication from chunk contamination. Set `chunkGroupWarningThreshold` to a positive number to tune the threshold, or to `0`/`false` to disable the warning. ([#117])
+
 ## [19.2.0-rc.3] - 2026-06-19
 
 ### Fixed
@@ -50,11 +55,13 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
+[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.3...HEAD
 [19.2.0-rc.3]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.2...19.2.0-rc.3
 [19.2.0-rc.2]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.1...19.2.0-rc.2
 [19.2.0-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0-rc.1
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 
+[#117]: https://github.com/shakacode/react_on_rails_rsc/issues/117
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#105]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/src/WebpackPlugin.ts
+++ b/src/WebpackPlugin.ts
@@ -18,6 +18,7 @@ export type Options = {
   isServer: boolean,
   clientReferences?: ClientReferencePath | ReadonlyArray<ClientReferencePath>,
   chunkName?: string,
+  chunkGroupWarningThreshold?: number | false,
   clientManifestFilename?: string,
   serverConsumerManifestFilename?: string,
 };

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -177,13 +177,8 @@ function normalizeChunkGroupWarningThreshold(
     typeof threshold !== 'number' ||
     !Number.isFinite(threshold) ||
     !Number.isInteger(threshold) ||
-    threshold < 0
+    threshold < 2
   ) {
-    throw new Error(
-      'React Server Plugin: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
-    );
-  }
-  if (threshold < 2) {
     throw new Error(
       'React Server Plugin: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
     );
@@ -603,6 +598,8 @@ export class RSCWebpackPlugin {
               if (!trackClientReferencePresence || this.chunkGroupWarningThreshold === false) {
                 return;
               }
+              // The warning is about physical chunk-group presence, including
+              // shared chunks, rather than only direct block dependencies.
               if (!module.resource || !resolvedClientFiles.has(module.resource)) {
                 return;
               }
@@ -845,13 +842,20 @@ export class RSCWebpackPlugin {
               }
             }
 
-            if (this.chunkGroupWarningThreshold !== false) {
+            const chunkGroupWarningThreshold = this.chunkGroupWarningThreshold;
+            if (chunkGroupWarningThreshold !== false) {
+              const chunkGroupWarningEntries = Array.from(clientReferenceChunkGroupsByResource)
+                .filter(([, chunkGroups]) => chunkGroups.size >= chunkGroupWarningThreshold)
+                .sort(
+                  ([leftResource, leftChunkGroups], [rightResource, rightChunkGroups]) =>
+                    rightChunkGroups.size - leftChunkGroups.size ||
+                    leftResource.localeCompare(rightResource)
+                );
               let emittedWarnings = 0;
               let suppressedWarnings = 0;
 
-              for (const [resource, chunkGroups] of clientReferenceChunkGroupsByResource) {
+              for (const [resource, chunkGroups] of chunkGroupWarningEntries) {
                 const groupCount = chunkGroups.size;
-                if (groupCount < this.chunkGroupWarningThreshold) continue;
 
                 if (emittedWarnings >= MAX_CHUNK_GROUP_WARNINGS) {
                   suppressedWarnings += 1;

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -154,9 +154,31 @@ export type Options = {
   isServer: boolean;
   clientReferences?: ClientReferencePath | ReadonlyArray<ClientReferencePath>;
   chunkName?: string;
+  chunkGroupWarningThreshold?: number | false;
   clientManifestFilename?: string;
   serverConsumerManifestFilename?: string;
 };
+
+const DEFAULT_CHUNK_GROUP_WARNING_THRESHOLD = 4;
+const CHUNK_GROUP_WARNING_DOCS =
+  'react_on_rails docs/oss/migrating/rsc-troubleshooting.md';
+
+function normalizeChunkGroupWarningThreshold(
+  threshold: number | false | undefined,
+): number | false {
+  if (threshold === undefined) {
+    return DEFAULT_CHUNK_GROUP_WARNING_THRESHOLD;
+  }
+  if (threshold === false || threshold === 0) {
+    return false;
+  }
+  if (typeof threshold !== 'number' || !Number.isFinite(threshold) || threshold < 0) {
+    throw new Error(
+      'React Server Plugin: chunkGroupWarningThreshold must be a positive number, 0, or false.',
+    );
+  }
+  return Math.ceil(threshold);
+}
 
 type ModuleMetadata = {
   id: string | number | null;
@@ -318,6 +340,8 @@ export class RSCWebpackPlugin {
 
   readonly chunkName: string;
 
+  readonly chunkGroupWarningThreshold: number | false;
+
   readonly clientManifestFilename: string;
 
   /**
@@ -359,6 +383,10 @@ export class RSCWebpackPlugin {
     } else {
       this.chunkName = 'client[index]';
     }
+
+    this.chunkGroupWarningThreshold = normalizeChunkGroupWarningThreshold(
+      options.chunkGroupWarningThreshold,
+    );
 
     const defaultClientManifestFilename = this.isServer
       ? 'react-server-client-manifest.json'
@@ -501,6 +529,7 @@ export class RSCWebpackPlugin {
           }
 
           let missingClientReferenceBlocksWarningEmitted = false;
+          const clientReferenceChunkGroupsByResource = new Map<string, Set<FlightChunkGroup>>();
 
           // Records every module of `chunkGroup` whose resource is in
           // `chunkResolvedClientFiles`, listing the chunk group's own
@@ -510,6 +539,7 @@ export class RSCWebpackPlugin {
           const recordChunkGroup = (
             chunkGroup: FlightChunkGroup,
             chunkResolvedClientFiles: Set<string>,
+            trackClientReferencePresence = false,
           ): void => {
             const chunks: (string | number | null)[] = [];
 
@@ -556,6 +586,21 @@ export class RSCWebpackPlugin {
                   name: '*',
                 };
               }
+            };
+
+            const recordClientReferencePresence = (module: FlightModule): void => {
+              if (!trackClientReferencePresence || this.chunkGroupWarningThreshold === false) {
+                return;
+              }
+              if (!module.resource || !resolvedClientFiles.has(module.resource)) {
+                return;
+              }
+              let chunkGroups = clientReferenceChunkGroupsByResource.get(module.resource);
+              if (!chunkGroups) {
+                chunkGroups = new Set();
+                clientReferenceChunkGroupsByResource.set(module.resource, chunkGroups);
+              }
+              chunkGroups.add(chunkGroup);
             };
 
             // Record the loadable JS file of every chunk in the group: the
@@ -664,9 +709,11 @@ export class RSCWebpackPlugin {
                 const moduleCss = siblingCss.length
                   ? [...new Set([...chunkCss, ...siblingCss])]
                   : chunkCss;
+                recordClientReferencePresence(module);
                 recordModule(moduleId, module, moduleCss);
                 if (module.modules) {
                   for (const concatenatedMod of module.modules) {
+                    recordClientReferencePresence(concatenatedMod);
                     recordModule(moduleId, concatenatedMod, moduleCss);
                   }
                 }
@@ -727,7 +774,7 @@ export class RSCWebpackPlugin {
                 }
               }
               if (chunkResolvedClientFiles.size > 0) {
-                recordChunkGroup(chunkGroup, chunkResolvedClientFiles);
+                recordChunkGroup(chunkGroup, chunkResolvedClientFiles, true);
               }
             }
 
@@ -782,6 +829,26 @@ export class RSCWebpackPlugin {
                       missing.length +
                       ' client reference(s). Rendering them will fail at runtime with a missing manifest entry:\n  ' +
                       missing.join('\n  '),
+                  ),
+                );
+              }
+            }
+
+            if (this.chunkGroupWarningThreshold !== false) {
+              for (const [resource, chunkGroups] of clientReferenceChunkGroupsByResource) {
+                const groupCount = chunkGroups.size;
+                if (groupCount < this.chunkGroupWarningThreshold) continue;
+                compilation.warnings.push(
+                  new webpack.WebpackError(
+                    'React Server Components: client reference module ' +
+                      resource +
+                      ' is present in ' +
+                      groupCount +
+                      ' client-reference chunk groups. ' +
+                      'This can duplicate its client JS/CSS across routes; consider a thin client wrapper or isolating imports to avoid chunk contamination. ' +
+                      'See ' +
+                      CHUNK_GROUP_WARNING_DOCS +
+                      ' for mitigation guidance.',
                   ),
                 );
               }

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -173,6 +173,8 @@ function normalizeChunkGroupWarningThreshold(
   if (threshold === false || threshold === 0) {
     return false;
   }
+  // Keep the runtime guard for JavaScript callers even though TypeScript
+  // narrows typed callers before this point.
   if (
     typeof threshold !== 'number' ||
     !Number.isFinite(threshold) ||
@@ -180,7 +182,7 @@ function normalizeChunkGroupWarningThreshold(
     threshold < 2
   ) {
     throw new Error(
-      'React Server Plugin: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
+      'React Server Components: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
     );
   }
   return threshold;

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -173,18 +173,22 @@ function normalizeChunkGroupWarningThreshold(
   if (threshold === false || threshold === 0) {
     return false;
   }
-  if (typeof threshold !== 'number' || !Number.isFinite(threshold) || threshold < 0) {
+  if (
+    typeof threshold !== 'number' ||
+    !Number.isFinite(threshold) ||
+    !Number.isInteger(threshold) ||
+    threshold < 0
+  ) {
     throw new Error(
-      'React Server Plugin: chunkGroupWarningThreshold must be at least 2, 0, or false.',
+      'React Server Plugin: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
     );
   }
-  const normalizedThreshold = Math.ceil(threshold);
-  if (normalizedThreshold < 2) {
+  if (threshold < 2) {
     throw new Error(
-      'React Server Plugin: chunkGroupWarningThreshold must be at least 2, 0, or false.',
+      'React Server Plugin: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
     );
   }
-  return normalizedThreshold;
+  return threshold;
 }
 
 type ModuleMetadata = {

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -182,7 +182,7 @@ function normalizeChunkGroupWarningThreshold(
     threshold < 2
   ) {
     throw new Error(
-      'React Server Components: chunkGroupWarningThreshold must be an integer at least 2, 0, or false.',
+      'React Server Components: chunkGroupWarningThreshold must be false/0 to disable, or an integer at least 2.',
     );
   }
   return threshold;
@@ -851,7 +851,7 @@ export class RSCWebpackPlugin {
                 .sort(
                   ([leftResource, leftChunkGroups], [rightResource, rightChunkGroups]) =>
                     rightChunkGroups.size - leftChunkGroups.size ||
-                    leftResource.localeCompare(rightResource)
+                    (leftResource < rightResource ? -1 : leftResource > rightResource ? 1 : 0)
                 );
               let emittedWarnings = 0;
               let suppressedWarnings = 0;

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -160,8 +160,9 @@ export type Options = {
 };
 
 const DEFAULT_CHUNK_GROUP_WARNING_THRESHOLD = 4;
+const MAX_CHUNK_GROUP_WARNINGS = 10;
 const CHUNK_GROUP_WARNING_DOCS =
-  'react_on_rails docs/oss/migrating/rsc-troubleshooting.md';
+  'https://github.com/shakacode/react_on_rails/blob/main/docs/oss/migrating/rsc-troubleshooting.md';
 
 function normalizeChunkGroupWarningThreshold(
   threshold: number | false | undefined,
@@ -174,10 +175,16 @@ function normalizeChunkGroupWarningThreshold(
   }
   if (typeof threshold !== 'number' || !Number.isFinite(threshold) || threshold < 0) {
     throw new Error(
-      'React Server Plugin: chunkGroupWarningThreshold must be a positive number, 0, or false.',
+      'React Server Plugin: chunkGroupWarningThreshold must be at least 2, 0, or false.',
     );
   }
-  return Math.ceil(threshold);
+  const normalizedThreshold = Math.ceil(threshold);
+  if (normalizedThreshold < 2) {
+    throw new Error(
+      'React Server Plugin: chunkGroupWarningThreshold must be at least 2, 0, or false.',
+    );
+  }
+  return normalizedThreshold;
 }
 
 type ModuleMetadata = {
@@ -835,9 +842,19 @@ export class RSCWebpackPlugin {
             }
 
             if (this.chunkGroupWarningThreshold !== false) {
+              let emittedWarnings = 0;
+              let suppressedWarnings = 0;
+
               for (const [resource, chunkGroups] of clientReferenceChunkGroupsByResource) {
                 const groupCount = chunkGroups.size;
                 if (groupCount < this.chunkGroupWarningThreshold) continue;
+
+                if (emittedWarnings >= MAX_CHUNK_GROUP_WARNINGS) {
+                  suppressedWarnings += 1;
+                  continue;
+                }
+
+                emittedWarnings += 1;
                 compilation.warnings.push(
                   new webpack.WebpackError(
                     'React Server Components: client reference module ' +
@@ -846,6 +863,20 @@ export class RSCWebpackPlugin {
                       groupCount +
                       ' client-reference chunk groups. ' +
                       'This can duplicate its client JS/CSS across routes; consider a thin client wrapper or isolating imports to avoid chunk contamination. ' +
+                      'See ' +
+                      CHUNK_GROUP_WARNING_DOCS +
+                      ' for mitigation guidance.',
+                  ),
+                );
+              }
+
+              if (suppressedWarnings > 0) {
+                compilation.warnings.push(
+                  new webpack.WebpackError(
+                    'React Server Components: suppressed ' +
+                      suppressedWarnings +
+                      ' additional client-reference chunk group warning(s). ' +
+                      'Increase chunkGroupWarningThreshold or inspect the module graph to narrow duplicated client references. ' +
                       'See ' +
                       CHUNK_GROUP_WARNING_DOCS +
                       ' for mitigation guidance.',

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -22,12 +22,16 @@ const buildManifest = ({
   chunkGroups,
   getChunkModulesIterable,
   clientFiles = [clientFile],
+  pluginOptions = {},
 }: {
   isServer: boolean;
   chunkGroups: (clientReferenceBlocks: unknown[]) => unknown[];
   getChunkModulesIterable: (chunk: Chunk) => unknown[];
   /** Client references to resolve. Defaults to the single shared `clientFile`. */
   clientFiles?: string[];
+  pluginOptions?: {
+    chunkGroupWarningThreshold?: number | false;
+  };
 }) => {
   const runtimeFile = require.resolve(
     isServer ? 'react-server-dom-webpack/client.node' : 'react-server-dom-webpack/client.browser',
@@ -35,6 +39,7 @@ const buildManifest = ({
   const plugin = new ReactFlightWebpackPlugin({
     isServer,
     clientReferences: clientFiles,
+    ...pluginOptions,
   });
 
   plugin.resolveAllClientFiles = jest.fn(
@@ -171,6 +176,41 @@ const buildManifest = ({
   };
 };
 
+const buildDuplicateClientReferenceFixture = (
+  groupCount: number,
+  pluginOptions: { chunkGroupWarningThreshold?: number | false } = {},
+) => {
+  const sharedFile = clientFile;
+  const wrapperFiles = Array.from(
+    { length: groupCount },
+    (_value, index) => `/app/pages/Page${index}.tsx`,
+  );
+  const chunks = wrapperFiles.map((_file, index) => ({
+    id: `client${index}`,
+    files: new Set([`js/client${index}.chunk.js`]),
+  }));
+
+  return buildManifest({
+    isServer: false,
+    clientFiles: [sharedFile, ...wrapperFiles],
+    pluginOptions,
+    chunkGroups: (clientReferenceBlocks) =>
+      chunks.map((chunk, index) => ({
+        getBlocks: () => [clientReferenceBlocks[index + 1]!],
+        chunks: [chunk],
+      })),
+    getChunkModulesIterable: (chunk) => {
+      const index = chunks.indexOf(chunk);
+      return [{ resource: wrapperFiles[index]! }, { resource: sharedFile }];
+    },
+  });
+};
+
+const duplicateClientReferenceWarnings = (warnings: unknown[]) =>
+  warnings.filter((warning) =>
+    String(warning).includes('client-reference chunk groups'),
+  );
+
 describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
   it('does not merge unrelated entry chunks into the client manifest entry', () => {
     const clientModule = { resource: clientFile };
@@ -273,6 +313,22 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
       css: ['/assets/shared.css', '/assets/a.css', '/assets/b.css'],
       name: '*',
     });
+  });
+
+  it('does not warn about duplicated client-reference chunk groups on the server build', () => {
+    const serverModule = { resource: clientFile };
+    const serverChunks = Array.from({ length: 4 }, (_value, index) => ({
+      id: `server-${index}`,
+      files: new Set([`server-${index}.js`]),
+    }));
+
+    const { warnings } = buildManifest({
+      isServer: true,
+      chunkGroups: () => serverChunks.map((chunk) => ({ chunks: [chunk] })),
+      getChunkModulesIterable: () => [serverModule],
+    });
+
+    expect(duplicateClientReferenceWarnings(warnings)).toEqual([]);
   });
 
   it('warns when a client chunk group cannot expose client-reference blocks', () => {
@@ -419,4 +475,44 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
       name: '*',
     });
   });
+
+  it('warns once by default when a client reference appears in four client-reference chunk groups', () => {
+    const { warnings } = buildDuplicateClientReferenceFixture(4);
+
+    const duplicateWarnings = duplicateClientReferenceWarnings(warnings);
+    expect(duplicateWarnings).toHaveLength(1);
+    expect(String(duplicateWarnings[0])).toContain(clientFile);
+    expect(String(duplicateWarnings[0])).toContain('4 client-reference chunk groups');
+    expect(String(duplicateWarnings[0])).toContain(
+      'react_on_rails docs/oss/migrating/rsc-troubleshooting.md',
+    );
+    expect(String(duplicateWarnings[0])).toContain('thin client wrapper');
+  });
+
+  it('does not warn below the default client-reference chunk group threshold', () => {
+    const { warnings } = buildDuplicateClientReferenceFixture(3);
+
+    expect(duplicateClientReferenceWarnings(warnings)).toEqual([]);
+  });
+
+  it('honors a configured client-reference chunk group warning threshold', () => {
+    const { warnings } = buildDuplicateClientReferenceFixture(3, {
+      chunkGroupWarningThreshold: 3,
+    });
+
+    const duplicateWarnings = duplicateClientReferenceWarnings(warnings);
+    expect(duplicateWarnings).toHaveLength(1);
+    expect(String(duplicateWarnings[0])).toContain('3 client-reference chunk groups');
+  });
+
+  it.each([false, 0] as const)(
+    'disables client-reference chunk group warnings when the threshold is %p',
+    (chunkGroupWarningThreshold) => {
+      const { warnings } = buildDuplicateClientReferenceFixture(4, {
+        chunkGroupWarningThreshold,
+      });
+
+      expect(duplicateClientReferenceWarnings(warnings)).toEqual([]);
+    },
+  );
 });

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -179,8 +179,8 @@ const buildManifest = ({
 const buildDuplicateClientReferenceFixture = (
   groupCount: number,
   pluginOptions: { chunkGroupWarningThreshold?: number | false } = {},
+  sharedFiles: string[] = [clientFile],
 ) => {
-  const sharedFile = clientFile;
   const wrapperFiles = Array.from(
     { length: groupCount },
     (_value, index) => `/app/pages/Page${index}.tsx`,
@@ -192,23 +192,23 @@ const buildDuplicateClientReferenceFixture = (
 
   return buildManifest({
     isServer: false,
-    clientFiles: [sharedFile, ...wrapperFiles],
+    clientFiles: [...sharedFiles, ...wrapperFiles],
     pluginOptions,
     chunkGroups: (clientReferenceBlocks) =>
       chunks.map((chunk, index) => ({
-        getBlocks: () => [clientReferenceBlocks[index + 1]!],
+        getBlocks: () => [clientReferenceBlocks[sharedFiles.length + index]!],
         chunks: [chunk],
       })),
     getChunkModulesIterable: (chunk) => {
       const index = chunks.indexOf(chunk);
-      return [{ resource: wrapperFiles[index]! }, { resource: sharedFile }];
+      return [{ resource: wrapperFiles[index]! }, ...sharedFiles.map((resource) => ({ resource }))];
     },
   });
 };
 
 const duplicateClientReferenceWarnings = (warnings: unknown[]) =>
   warnings.filter((warning) =>
-    String(warning).includes('client-reference chunk groups'),
+    String(warning).includes('client-reference chunk group'),
   );
 
 describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
@@ -484,7 +484,7 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     expect(String(duplicateWarnings[0])).toContain(clientFile);
     expect(String(duplicateWarnings[0])).toContain('4 client-reference chunk groups');
     expect(String(duplicateWarnings[0])).toContain(
-      'react_on_rails docs/oss/migrating/rsc-troubleshooting.md',
+      'https://github.com/shakacode/react_on_rails/blob/main/docs/oss/migrating/rsc-troubleshooting.md',
     );
     expect(String(duplicateWarnings[0])).toContain('thin client wrapper');
   });
@@ -515,4 +515,30 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
       expect(duplicateClientReferenceWarnings(warnings)).toEqual([]);
     },
   );
+
+  it('rejects a threshold of one because it would warn for every client reference', () => {
+    expect(() =>
+      buildDuplicateClientReferenceFixture(4, {
+        chunkGroupWarningThreshold: 1,
+      }),
+    ).toThrow('chunkGroupWarningThreshold must be at least 2');
+  });
+
+  it('caps duplicate client-reference chunk group warnings and emits a summary', () => {
+    const sharedFiles = Array.from(
+      { length: 12 },
+      (_value, index) => `/app/components/Shared${index}.tsx`,
+    );
+
+    const { warnings } = buildDuplicateClientReferenceFixture(4, {}, sharedFiles);
+
+    const duplicateWarnings = duplicateClientReferenceWarnings(warnings);
+    expect(duplicateWarnings).toHaveLength(11);
+    expect(duplicateWarnings.filter((warning) => String(warning).includes('Shared'))).toHaveLength(
+      10,
+    );
+    expect(String(duplicateWarnings[10])).toContain(
+      'suppressed 2 additional client-reference chunk group warning(s)',
+    );
+  });
 });

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -526,14 +526,14 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     },
   );
 
-  it.each([1, 2.5] as const)(
+  it.each([-1, 1, 2.5] as const)(
     'rejects an invalid warning threshold of %p',
     (chunkGroupWarningThreshold) => {
       expect(() =>
         buildDuplicateClientReferenceFixture(4, {
           chunkGroupWarningThreshold,
         }),
-      ).toThrow('chunkGroupWarningThreshold must be an integer at least 2');
+      ).toThrow('chunkGroupWarningThreshold must be false/0 to disable');
     },
   );
 

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -505,6 +505,16 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     expect(String(duplicateWarnings[0])).toContain('3 client-reference chunk groups');
   });
 
+  it('accepts the minimum client-reference chunk group warning threshold', () => {
+    const { warnings } = buildDuplicateClientReferenceFixture(2, {
+      chunkGroupWarningThreshold: 2,
+    });
+
+    const duplicateWarnings = duplicateClientReferenceWarnings(warnings);
+    expect(duplicateWarnings).toHaveLength(1);
+    expect(String(duplicateWarnings[0])).toContain('2 client-reference chunk groups');
+  });
+
   it.each([false, 0] as const)(
     'disables client-reference chunk group warnings when the threshold is %p',
     (chunkGroupWarningThreshold) => {

--- a/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
+++ b/tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
@@ -516,13 +516,16 @@ describe('ReactFlightWebpackPlugin client-reference chunk selection', () => {
     },
   );
 
-  it('rejects a threshold of one because it would warn for every client reference', () => {
-    expect(() =>
-      buildDuplicateClientReferenceFixture(4, {
-        chunkGroupWarningThreshold: 1,
-      }),
-    ).toThrow('chunkGroupWarningThreshold must be at least 2');
-  });
+  it.each([1, 2.5] as const)(
+    'rejects an invalid warning threshold of %p',
+    (chunkGroupWarningThreshold) => {
+      expect(() =>
+        buildDuplicateClientReferenceFixture(4, {
+          chunkGroupWarningThreshold,
+        }),
+      ).toThrow('chunkGroupWarningThreshold must be an integer at least 2');
+    },
+  );
 
   it('caps duplicate client-reference chunk group warnings and emits a summary', () => {
     const sharedFiles = Array.from(


### PR DESCRIPTION
## Summary
- Add chunkGroupWarningThreshold to warn on client builds when one client reference is present in too many client-reference chunk groups.
- Default the threshold to 4 and support disabling with 0 or false.
- Reject thresholds below 2 and fractional thresholds, cap emitted module warnings with a summary, and point warnings at the verified React on Rails troubleshooting URL.
- Cover above-threshold, below-threshold, configured-threshold, disabled, invalid-threshold, cap, and server-build behavior.
- Add an Unreleased changelog entry for the new user-visible warning.

Fixes #117

## Validation
- yarn
- yarn jest tests/react-flight-webpack-plugin-client-reference-chunks.test.ts
- yarn build
- yarn test
- git diff --check origin/main...HEAD
- Follow-up changelog PR-link commit: git diff --check
- Review-fix commit 5ae8dcd: git diff --check, yarn build, yarn jest tests/react-flight-webpack-plugin-client-reference-chunks.test.ts (17 tests)
- Review-fix commit 69ea5db: git diff --check, yarn build, yarn jest tests/react-flight-webpack-plugin-client-reference-chunks.test.ts (18 tests)

## Review Triage
- Fixed broken docs reference by using the verified GitHub URL for react_on_rails docs/oss/migrating/rsc-troubleshooting.md.
- Fixed threshold 1 footgun by rejecting thresholds below 2.
- Fixed fractional threshold ambiguity by requiring integer thresholds.
- Added a max-warning cap plus summary warning for large apps.
- The resolvedClientFiles vs chunkResolvedClientFiles comment is intentional: the warning detects physically co-bundled client references across client-reference chunk groups, not only explicit block dependencies.
- CodeRabbit rate-limited and did not produce a substantive review.

## Coordination
- Batch: rsc-tonight-20260621
- Worker: codex-rsc-tonight-117-warn-duplicate-client-groups
- Private agent-coord state: UNKNOWN; agent-coord status and doctor timed out in coordinator preflight.
- Public fallback claim: https://github.com/shakacode/react_on_rails_rsc/issues/117#issuecomment-4761496042

## Codex Decision Log
- **Non-blocking:** Whether a user-visible warning needs CHANGELOG coverage.
  - **Decision:** Added an Unreleased entry.
  - **Why:** The default build behavior now emits a webpack warning for duplicated client references.
  - **Review later:** None.

## Churn Notes
- Pre-push review gate: worker self-review, targeted tests, full test suite, build, coordinator diff review.
- Post-push review churn: 3 follow-up commits: one changelog-only PR-link fix, two review-fix commits for warning URL/threshold/cap behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time warnings and a new optional plugin option only; manifest emission logic is unchanged aside from presence tracking for warnings on client builds.
> 
> **Overview**
> Adds **`chunkGroupWarningThreshold`** to the RSC Webpack plugin so **client builds** emit webpack warnings when the same client reference module is physically present in too many client-reference chunk groups—a signal of cross-route JS/CSS duplication from chunk contamination.
> 
> **Default threshold is 4**; set **`0`** or **`false`** to disable. Invalid values (non-integers, below 2) throw at plugin construction. Warnings are capped at 10 per-module messages plus a summary when more would fire, link to RSC troubleshooting docs, and **do not run on server builds**. Public `RSCWebpackPlugin` options and an Unreleased changelog entry document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37572115d9aef7c922ab9d643f0622ff9b4172e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->