### PR TITLE
Add canonical release readiness check

### DIFF
--- a/.agents/skills/update-changelog/SKILL.md
+++ b/.agents/skills/update-changelog/SKILL.md
@@ -13,7 +13,7 @@ You are helping to add an entry to the CHANGELOG.md file for the `react-on-rails
 This skill accepts an optional mode argument from the invocation text:
 
 - **No argument** (`/update-changelog`): Add entries to `## [Unreleased]` without stamping a version header. Use this during development. (If the CHANGELOG has no `## [Unreleased]` section yet, add one at the top, immediately after the file's intro lines and above the newest version header.)
-- **`release`** (`/update-changelog release`): Add entries and stamp a version header. Auto-compute the next version based on changes (breaking -> major, added features -> minor, fixes -> patch). `scripts/release.sh` (run via `yarn release`) then reads this version from the top-most `## [x.y.z]` header automatically.
+- **`release`** (`/update-changelog release`): Add entries, stamp a version header, and bump `package.json` to the same version. Auto-compute the next version based on changes (breaking -> major, added features -> minor, fixes -> patch). `yarn release:check` then reads this version from the top-most `## [x.y.z]` header and verifies it matches `package.json` before the GitHub Actions release.
 - **`rc`** (`/update-changelog rc`): Same as `release`, but stamps an RC prerelease version (e.g., `19.0.5-rc.0`). Auto-increments the RC index if prior RCs exist for the same base version.
 - **`beta`** (`/update-changelog beta`): Same as `rc`, but stamps a beta prerelease version (e.g., `19.0.5-beta.0`).
 - **`classification-sweep`** (`/update-changelog classification-sweep BASE_REF..TARGET_REF`): Print a mechanical review table for every merged PR in the selected range before deciding which changelog entries to add. This read-only agent workflow runs git and GitHub API commands directly; it does not edit `CHANGELOG.md` and does not run `scripts/release.sh` or any version-stamping command.
@@ -37,21 +37,24 @@ This skill serves four use cases at different points in the release lifecycle:
 **Before a release** -- Stamp a version header and prepare for release:
 
 - Run `/update-changelog release` (or `rc`, `beta`, or an explicit version like `19.0.5-rc.10`) to add entries AND stamp the version header
+- Bump `package.json` to the same version in the same PR
 - The version is auto-computed from changes (breaking -> major, features -> minor, fixes -> patch) — skipped when an explicit version is provided
 - The skill commits, pushes, and opens a PR — review and merge it to `main`
-- Then run `yarn release` from `main` (no version argument needed -- `scripts/release.sh` reads the version from the top-most `## [x.y.z]` header in CHANGELOG.md)
-- The release script publishes to npm and automatically creates a GitHub release from the matching changelog section
+- Then run `yarn release:check` from clean synced `main` and dispatch the GitHub Actions `Release package` workflow with the command it prints
+- The workflow publishes to npm with trusted publishing and creates a GitHub release from the matching changelog section
 
 **After a release you forgot to update the changelog for** -- Catch-up mode:
 
 - The skill can retroactively find commits between tags and add missing entries
 - Ask the user whether to stamp a version header or add to `## [Unreleased]`
 
-### Why changelog comes BEFORE the release
+### Why changelog and package version come BEFORE the release
 
-- The release is **changelog-driven**: `scripts/release.sh` reads the TARGET VERSION from the top-most `## [x.y.z]` header in CHANGELOG.md, then bumps `package.json`, tags, publishes to npm, and creates the GitHub release. The required sequence is: **update CHANGELOG.md -> merge that change to `main` -> run `yarn release` from `main`.**
-- `scripts/release.sh` builds the GitHub release notes from the changelog section matching the target version — no separate sync step is needed.
-- If no changelog section matches the target version, the release script warns and creates a release without notes, so the section must exist first.
+- The release is **changelog-driven**: the target version comes from the top-most `## [x.y.z]` header in CHANGELOG.md, and `package.json` must match that version before the release PR merges.
+- The canonical GitHub Actions release workflow refuses to publish when `CHANGELOG.md` and `package.json` differ, the unprefixed tag already exists, or the npm version is already published.
+- `yarn release:check` mirrors those fast metadata/tag/npm gates locally and prints the exact workflow dispatch command. The required sequence is: **update CHANGELOG.md and package.json -> merge that change to `main` -> run `yarn release:check` from clean synced `main` -> dispatch `Release package`.**
+- The workflow builds the GitHub release notes from the changelog section matching the target version — no separate sync step is needed.
+- If no changelog section matches the target version, the release workflow fails, so the section must exist first.
 - A premature version header (if a release fails) is harmless -- you'll release eventually.
 
 ## Auto-Computing the Next Version
@@ -256,13 +259,17 @@ To stamp a version:
 
 1. Compute the version per "Auto-Computing the Next Version" (or use the explicit version provided).
 2. If a `## [Unreleased]` section exists, rename it to `## [<version>] - YYYY-MM-DD` (today's date), or insert a new `## [<version>] - YYYY-MM-DD` header above the previous newest version header and move the relevant entries beneath it.
-3. Update the reference links at the bottom of the file (see "Version Links").
+3. Update `package.json` so its `version` equals `<version>`.
+4. Update the reference links at the bottom of the file (see "Version Links").
 
-Do NOT manually edit `package.json` — `scripts/release.sh` (via release-it) bumps `package.json` to match the changelog version during `yarn release`.
+Bump `package.json` to match the version you stamp, in the same PR. The local
+`yarn release` fallback will see it already correct; the GitHub Actions release
+path requires it. Plain `/update-changelog` with no version-stamping argument
+does not touch `package.json`.
 
 **When to use which path:**
 
-- **`/update-changelog release` (this skill)**: Full automation -- analyzes commits, writes changelog entries, then stamps the version header. Use before a release.
+- **`/update-changelog release` (this skill)**: Full automation -- analyzes commits, writes changelog entries, stamps the version header, and bumps `package.json` to match. Use before a release.
 - **`/update-changelog` (this skill, no args)**: Adds entries to `## [Unreleased]` during development. Does not stamp a version header.
 
 ### Finding the Most Recent Version
@@ -384,12 +391,14 @@ If the user passed `release`, `rc`, `beta`, or an explicit version string as an 
 
 1. Auto-compute the next version per "Auto-Computing the Next Version" (prerelease index is determined solely from git tags, not changelog headers) and confirm it with the user.
 2. Stamp the header: rename `## [Unreleased]` to `## [<version>] - YYYY-MM-DD`, or insert a new `## [<version>] - YYYY-MM-DD` header above the previous newest version header and move the relevant entries beneath it.
-3. Update the reference links at the bottom (add the version compare link; ensure all `[#NN]` PR links used by the new section are present).
+3. Update `package.json` so its `version` equals `<version>`.
+4. Update the reference links at the bottom (add the version compare link; ensure all `[#NN]` PR links used by the new section are present).
 
 **For an explicit version string** (e.g., `19.0.5-rc.10`):
 
 1. Use the explicit version directly for the header (do not auto-compute).
-2. **Verify** the stamped header and compare link match the requested version.
+2. Update `package.json` so its `version` equals the requested version.
+3. **Verify** the stamped header, `package.json`, and compare link match the requested version.
 
 If no argument was passed, skip this step -- entries stay in `## [Unreleased]`.
 
@@ -402,20 +411,22 @@ If no argument was passed, skip this step -- entries stay in `## [Unreleased]`.
    - File ends with a newline character
    - **No duplicate section headings** (e.g., don't create two `### Fixed` sections — merge entries into the existing heading)
 2. **Verify version sections are in order** (Unreleased -> newest tag -> older tags)
-3. **Verify the reference links** at the bottom of the file are correct (version compare links use the bare version with no `v` prefix; every `([#NN])` has a matching `[#NN]:` definition)
-4. **Show the user** a summary of what was done:
+3. If in `release`/`rc`/`beta` mode or explicit-version mode, **verify `package.json` matches the stamped version**. If no argument was passed, verify `package.json` was not changed.
+4. **Verify the reference links** at the bottom of the file are correct (version compare links use the bare version with no `v` prefix; every `([#NN])` has a matching `[#NN]:` definition)
+5. **Show the user** a summary of what was done:
    - Which version sections were created
+   - Whether `package.json` was updated or intentionally left untouched
    - Which entries were moved from Unreleased
    - Which new entries were added
    - Which PRs were skipped (and why)
-5. If in `release`/`rc`/`beta` mode or explicit-version mode, **automatically commit, push, and open a PR**:
-   - Verify the working tree only has `CHANGELOG.md` changes; if there are other uncommitted changes, warn the user and stop
+6. If in `release`/`rc`/`beta` mode or explicit-version mode, **automatically commit, push, and open a PR**:
+   - Verify the working tree only has `CHANGELOG.md` and `package.json` changes; if there are other uncommitted changes, warn the user and stop
    - Verify the current branch is `main` (`git branch --show-current`); if not, warn the user and stop
    - Create a feature branch (e.g., `changelog-19.0.5-rc.10`)
-   - Stage only `CHANGELOG.md` (`git add CHANGELOG.md`) and commit with message `Update CHANGELOG.md for VERSION` (using the stamped version)
+   - Stage only `CHANGELOG.md` and `package.json` (`git add CHANGELOG.md package.json`) and commit with message `Update CHANGELOG.md and package version for VERSION` (using the stamped version)
    - Push and open a PR with the changelog diff as the body
    - If the push or PR creation fails, the CHANGELOG is already stamped locally — fix the issue (e.g., authentication, branch protection), then run `git push -u origin <branch>` and `gh pr create` manually
-   - Remind the user that, **after the PR merges to `main`**, the release is run with `yarn release` from `main` (it reads the version from the top-most `## [x.y.z]` header, publishes to npm, and creates the GitHub release). Use `yarn release:dry-run` first to preview without publishing.
+   - Remind the user that, **after the PR merges to `main`**, the canonical release path is `yarn release:check` from clean synced `main`, followed by the `gh workflow run release.yml ...` command that the check prints. Use `yarn release:dry-run` only when debugging the maintainer-only local fallback path.
 
 ### For Prerelease Versions (RC and Beta)
 
@@ -558,4 +569,4 @@ grep -A 3 "^### " CHANGELOG.md | head -30
 - Use past tense for the description
 - Be consistent with existing formatting in the changelog
 - Always ensure the file ends with a trailing newline
-- Before a release, you can sanity-check the pipeline with `yarn release:dry-run` (no publish, no tag, no push). The release itself verifies the build with `yarn test` and `yarn build` (tsc) before publishing.
+- Before a release, sanity-check the canonical GitHub Actions path with `yarn release:check` from clean synced `main`; it prints the dispatch command on success. Use `yarn release:dry-run` only for the maintainer-only local fallback path. The GitHub Actions release verifies the build with `yarn test` and `yarn build` (tsc) before publishing.

--- a/.agents/skills/update-changelog/SKILL.md
+++ b/.agents/skills/update-changelog/SKILL.md
@@ -569,4 +569,4 @@ grep -A 3 "^### " CHANGELOG.md | head -30
 - Use past tense for the description
 - Be consistent with existing formatting in the changelog
 - Always ensure the file ends with a trailing newline
-- Before a release, sanity-check the canonical GitHub Actions path with `yarn release:check` from clean synced `main`; it prints the dispatch command on success. Use `yarn release:dry-run` only for the maintainer-only local fallback path. The GitHub Actions release verifies the build with `yarn test` and `yarn build` (tsc) before publishing.
+- Before a release, sanity-check the canonical GitHub Actions path with `yarn release:check` from clean synced `main`; it prints the dispatch command on success. Use `yarn release:dry-run` only for the maintainer-only local fallback path. The GitHub Actions release verifies the build with `yarn build`, `yarn test`, and `yarn verify:artifacts` before publishing; run `yarn verify:artifacts` before `yarn release` on the local fallback path.

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -30,6 +30,10 @@ This repository does not currently have a rake changelog task. Edit
   [19.0.5-rc.6]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5-rc.5...19.0.5-rc.6
   ```
 
+- When stamping a version section, update `package.json` to the same version in
+  the same PR. Plain `/update-changelog` entries under `[Unreleased]` do not
+  change `package.json`.
+
 ## What To Include
 
 Only add user-visible changes:
@@ -80,22 +84,28 @@ Keep wording concise and focused on observable behavior.
 
 4. Add or update the version section in `CHANGELOG.md`.
 
-5. Update the compare links at the bottom:
+5. If you stamped a release version, update `package.json` so its `version`
+   equals the stamped changelog header.
+
+6. Update the compare links at the bottom:
 
    - `[new-version]` compares `<previous-tag>...<new-version>`
    - Older links remain below it
 
-6. Verify formatting:
+7. Verify formatting:
 
    ```bash
    sed -n '1,240p' CHANGELOG.md
    ```
 
-7. For release readiness, run:
+8. After the changelog/version PR merges to `main`, run the canonical GitHub
+   Actions preflight:
 
    ```bash
-   yarn release:dry-run
+   yarn release:check
    ```
+
+   Use `yarn release:dry-run` only for the maintainer-only local fallback path.
 
 ## rc.6 Example
 

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -105,7 +105,10 @@ Keep wording concise and focused on observable behavior.
    yarn release:check
    ```
 
-   Use `yarn release:dry-run` only for the maintainer-only local fallback path.
+   The Actions workflow runs `yarn build`, `yarn test`, and
+   `yarn verify:artifacts` before publishing. Use `yarn release:dry-run` only
+   for the maintainer-only local fallback path; run `yarn verify:artifacts`
+   before `yarn release` on that fallback path.
 
 ## rc.6 Example
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@ yarn jest tests/path/to/file.test.ts
 # For an RSC test file, set the react-server condition:
 NODE_CONDITIONS=react-server yarn jest tests/path/to/file.rsc.test.ts
 
-# Dry-run a release (no publish/tag/push) to validate the changelog-driven release
+# Fast read-only preflight for the canonical GitHub Actions release
+yarn release:check
+
+# Dry-run the maintainer-only local fallback release path (no publish/tag/push)
 yarn release:dry-run
 
 # Verify the packed npm artifact, exports, runtime peer policy, publint, and attw
@@ -166,10 +169,12 @@ exposed secrets, auth bypass) still require investigation before dismissal, rega
 or build-config changes, dependency or runtime-version bumps, broad refactors, and release-process
 changes. When unsure whether a PR is low-risk, leave it ready and ask.
 
-**Releasing** is changelog-driven: update `CHANGELOG.md` with the target version, merge that to `main`,
-then run `yarn release` from `main` (or `yarn release:dry-run` to validate first). `scripts/release.sh`
-reads the version from `CHANGELOG.md` and publishes `react-on-rails-rsc` to npm via release-it. See
-`.agents/skills/update-changelog/SKILL.md`.
+**Releasing** is changelog-driven and the GitHub Actions workflow is canonical: stamp
+`CHANGELOG.md` and `package.json` to the same target version, merge that PR to `main`, run
+`yarn release:check` from a clean synced `main` checkout, then dispatch `Release package`
+using the command printed by the check. `yarn release` / `yarn release:dry-run` are
+maintainer-only local fallback paths when GitHub Actions is blocked. See
+`.agents/skills/update-changelog/SKILL.md` and `docs/releasing.md`.
 
 ## Review Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,10 @@ changes. When unsure whether a PR is low-risk, leave it ready and ask.
 **Releasing** is changelog-driven and the GitHub Actions workflow is canonical: stamp
 `CHANGELOG.md` and `package.json` to the same target version, merge that PR to `main`, run
 `yarn release:check` from a clean synced `main` checkout, then dispatch `Release package`
-using the command printed by the check. `yarn release` / `yarn release:dry-run` are
-maintainer-only local fallback paths when GitHub Actions is blocked. See
+using the command printed by the check. The Actions workflow runs `yarn build`,
+`yarn test`, and `yarn verify:artifacts` before publishing. `yarn release` /
+`yarn release:dry-run` are maintainer-only local fallback paths when GitHub Actions is blocked;
+run `yarn verify:artifacts` before `yarn release` on that fallback path. See
 `.agents/skills/update-changelog/SKILL.md` and `docs/releasing.md`.
 
 ## Review Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,10 @@ then release from a clean, synced `main` checkout.
 1. Run `yarn release:check`.
 2. Run the `gh workflow run release.yml --ref main ...` command printed by the
    check.
-3. Use `yarn release:dry-run` and `yarn release` only as maintainer-only local
-   fallback paths when GitHub Actions is blocked.
+3. The Actions workflow runs `yarn build`, `yarn test`, and
+   `yarn verify:artifacts` before publishing.
+4. Use `yarn release:dry-run`, `yarn verify:artifacts`, and `yarn release` only
+   as maintainer-only local fallback paths when GitHub Actions is blocked.
 
 `yarn release:check` reads the target version from the first version header in
 `CHANGELOG.md`, verifies `package.json` matches it, checks that the unprefixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,23 +35,28 @@ lint, format, or type-check script. `yarn test` runs both halves of the suite:
 
 ## Release Flow
 
-Releases are changelog-driven. Update `CHANGELOG.md`, merge that changelog PR to
-`main`, then release from a clean `main` checkout.
+Releases are changelog-driven, and the GitHub Actions `Release package`
+workflow is canonical. When stamping a release, update `CHANGELOG.md` and
+`package.json` to the same target version in one PR, merge that PR to `main`,
+then release from a clean, synced `main` checkout.
 
-1. Run `yarn release:dry-run` first.
-2. Run `yarn verify:artifacts` to check the packed npm artifact, package
-   exports, runtime peer policy, `publint`, and Are The Types Wrong.
-3. Run `yarn release` only after the dry run and artifact verification succeed.
+1. Run `yarn release:check`.
+2. Run the `gh workflow run release.yml --ref main ...` command printed by the
+   check.
+3. Use `yarn release:dry-run` and `yarn release` only as maintainer-only local
+   fallback paths when GitHub Actions is blocked.
 
-`scripts/release.sh` reads the target version from the first version header in
-`CHANGELOG.md`. Do not pass a version to the release script. Tags have no `v`
-prefix, for example `19.0.5-rc.7`, not `v19.0.5-rc.7`. Prereleases publish
-with the npm `next` dist-tag. Current `scripts/release.sh` publishes final
-non-prerelease versions with the npm `latest` dist-tag.
+`yarn release:check` reads the target version from the first version header in
+`CHANGELOG.md`, verifies `package.json` matches it, checks that the unprefixed
+tag and npm version are unused, and confirms the checkout is clean synced
+`main`. Tags have no `v` prefix, for example `19.0.5-rc.7`, not
+`v19.0.5-rc.7`. Prereleases publish with the npm `next` dist-tag; final
+non-prerelease versions publish with `latest` only after the downstream release
+gate accepts the candidate.
 
-See `.agents/skills/update-changelog/SKILL.md` and `AGENTS.md` for release
-policy. If `docs/releasing.md` exists, treat it as supplementary detail and
-defer to `AGENTS.md` on conflicts. If `docs/releasing.md` is not present in your
+See `AGENTS.md`, `docs/releasing.md`, and
+`.agents/skills/update-changelog/SKILL.md` for release policy. If those files
+conflict, `AGENTS.md` wins. If `docs/releasing.md` is not present in your
 checkout, treat its contents as `UNKNOWN`.
 
 The runtime-line versioning policy lives in `docs/versioning.md`; use it before

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,39 @@
 # Releasing react-on-rails-rsc
 
 This project uses a changelog-driven release workflow. The target version is
-read from `CHANGELOG.md`; do not pass a version to the release tooling. Update
-the changelog and `package.json` first, merge that change to `main`, then
-publish from the GitHub Actions release workflow.
+read from `CHANGELOG.md`, and `package.json` must match that version before the
+release PR merges. Publish from the GitHub Actions release workflow; the local
+`yarn release` path is maintainer-only fallback.
+
+## Release Quickstart
+
+1. Stamp the changelog and package version in one PR:
+
+   ```text
+   /update-changelog rc
+   ```
+
+   Use `/update-changelog release`, `/update-changelog beta`, or an explicit
+   version such as `/update-changelog 19.2.0-rc.4` when that is the intended
+   release type.
+
+2. Review the stamped `CHANGELOG.md` and matching `package.json`, do a final
+   changelog sweep for any PRs merged during the release window, then merge the
+   PR to `main`.
+
+3. From a clean, current `main` checkout, run the fast Actions preflight:
+
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   yarn release:check
+   ```
+
+4. For final non-prerelease versions, run the downstream React on Rails gate
+   before dispatching the release so `latest` does not advance prematurely.
+
+5. Run the `gh workflow run release.yml ...` command printed by
+   `yarn release:check`.
 
 Tags in this repository do not use a `v` prefix. For example, use
 `X.Y.Z-rc.N`, not `vX.Y.Z-rc.N`.
@@ -67,7 +97,7 @@ For an actual release:
 Before choosing a target version, confirm the runtime-line policy in
 [versioning.md](versioning.md).
 
-### 1. Update The Changelog
+### 1. Update The Changelog And Package Version
 
 Use the local Claude Code command:
 
@@ -88,24 +118,38 @@ The changelog compare links at the bottom should also use unprefixed tags:
 [X.Y.Z-rc.N]: https://github.com/shakacode/react_on_rails_rsc/compare/PREVIOUS-TAG...X.Y.Z-rc.N
 ```
 
+When stamping a version with `/update-changelog release`, `rc`, `beta`, or an
+explicit version, bump `package.json` to the same version in the same PR. Plain
+`/update-changelog` entries under `[Unreleased]` do not change `package.json`.
+
 Review and merge the changelog/version PR before publishing.
 
-### 2. Run A Local Dry Run
+### 2. Run The GitHub Actions Readiness Check
 
 From `main`:
 
 ```bash
-yarn release:dry-run
+yarn release:check
 ```
 
-The dry run verifies the release version, npm/GitHub auth where available,
-package publish state, tests, build, and `npm pack --dry-run`. It does not
-publish to npm, push a tag, or create a GitHub release.
+This fast read-only check mirrors the GitHub Actions release metadata, tag, and
+npm publish-state gates. It verifies:
 
-Use this dry run as the local fallback whenever you need to validate release
-readiness without publishing. In dry-run mode, missing npm or GitHub auth is a
-warning instead of a release blocker, and no npm publish, git tag, tag push, or
-GitHub release is created.
+1. The top `CHANGELOG.md` release header is valid semver and has release notes.
+2. `package.json` has the same version.
+3. The unprefixed git tag does not exist locally or on `origin`.
+4. `react-on-rails-rsc@X.Y.Z` is not already published to npm.
+5. The local checkout is on clean, synced `main`.
+
+On success, it prints the exact dispatch command:
+
+```bash
+gh workflow run release.yml --ref main -f version=X.Y.Z -f confirm_publish=publish
+```
+
+This is distinct from `yarn release:dry-run`, which drives the heavier local
+release-it fallback path. Use `release:dry-run` only when the GitHub Actions path
+is blocked or a maintainer needs to debug the local fallback without publishing.
 
 ### 3. Run The Downstream React On Rails Gate
 
@@ -147,8 +191,9 @@ downstream checkout or rollout branch.
 
 ### 4. Publish From GitHub Actions
 
-After the changelog/version PR lands on `main`, open GitHub Actions and run
-`Release package` from the `main` branch.
+After `yarn release:check` passes, open GitHub Actions and run `Release package`
+from the `main` branch, or run the `gh workflow run release.yml ...` command
+printed by the check.
 
 Use these `workflow_dispatch` inputs:
 
@@ -185,13 +230,18 @@ Use the local publish path only if the GitHub Actions release path is blocked
 and a maintainer explicitly chooses to publish from a trusted workstation:
 
 ```bash
+yarn release:dry-run
+```
+
+```bash
 yarn release
 ```
 
 The script will:
 
 1. Read the target version from the first `## [X.Y.Z]` header in `CHANGELOG.md`.
-2. Verify that `package.json` is not ahead of the changelog version.
+2. Verify that `package.json` is not ahead of the changelog version; when using
+   the canonical Actions path, `package.json` should already match.
 3. Stop if the release tag already exists or the npm version is already published.
 4. Publish prereleases such as `X.Y.Z-rc.N` with the npm `next` dist-tag.
 5. Run `yarn test`, `yarn run build`, and `npm pack --dry-run`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -234,6 +234,10 @@ yarn release:dry-run
 ```
 
 ```bash
+yarn verify:artifacts
+```
+
+```bash
 yarn release
 ```
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "verify:artifacts": "bash scripts/verify-release.sh",
     "prepublishOnly": "yarn run build",
     "release": "bash scripts/release.sh",
+    "release:check": "bash scripts/check-release-ready.sh",
     "release:dry-run": "bash scripts/release.sh --dry-run",
     "build-if-needed": "test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/flight-server.js -a -f dist/flight-server.browser.js -a -f dist/flight-server.edge.js -a -f dist/flight-server.node.js -a -f dist/flight-server.node.unbundled.js -a -f dist/RSCReferenceDiscoveryPlugin.js -a -f dist/RSCReferenceDiscoveryPlugin.d.ts -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js -a -f dist/webpack/RSCWebpackPlugin.js || (yarn run build && test -f dist/client.browser.js -a -f dist/client.node.js -a -f dist/server.node.js -a -f dist/flight-server.js -a -f dist/flight-server.browser.js -a -f dist/flight-server.edge.js -a -f dist/flight-server.node.js -a -f dist/flight-server.node.unbundled.js -a -f dist/RSCReferenceDiscoveryPlugin.js -a -f dist/RSCReferenceDiscoveryPlugin.d.ts -a -f dist/react-server-dom-rspack/plugin.js -a -f dist/react-server-dom-rspack/loader.js -a -f dist/webpack/RSCWebpackPlugin.js)",
     "prepack": "yarn run build-if-needed",

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -209,6 +209,8 @@ check_npm_unpublished() {
       return
     fi
 
+    # Attempts 1-4 retry transient network failures; attempt 5 falls through
+    # to the exhaustion check below.
     if [[ "$attempt" -lt 5 ]] && grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$NPM_VIEW_OUTPUT_FILE"; then
       log_warn "npm view failed before publish; retrying in ${retry_delay}s (attempt ${attempt}/5):"
       cat "$NPM_VIEW_OUTPUT_FILE" >&2
@@ -216,6 +218,7 @@ check_npm_unpublished() {
       continue
     fi
 
+    # Attempt 5 exhausted; network uncertainty is now a hard release blocker.
     if grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$NPM_VIEW_OUTPUT_FILE"; then
       record_error "npm view failed after 5 attempts due to a network error; publish state is UNKNOWN."
       cat "$NPM_VIEW_OUTPUT_FILE" >&2

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -11,6 +11,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 ERROR_COUNT=0
+METADATA_JSON_FILE=
 
 # Keep npm usable in sandboxed shells where the default user cache can be
 # unwritable. User-provided cache settings still win.
@@ -26,12 +27,30 @@ record_error() {
 }
 
 metadata_value() {
-  node -e "const metadata = JSON.parse(process.argv[1]); process.stdout.write(String(metadata[process.argv[2]]));" "$METADATA_JSON" "$1"
+  node -e "const fs = require('node:fs'); const metadata = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(metadata[process.argv[2]]));" "$METADATA_JSON_FILE" "$1"
+}
+
+cleanup_metadata_file() {
+  if [[ -n "${METADATA_JSON_FILE:-}" ]]; then
+    rm -f "$METADATA_JSON_FILE"
+  fi
+}
+
+npm_error_code() {
+  node - "$1" <<'NODE'
+const fs = require('node:fs');
+try {
+  const parsed = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+  process.stdout.write(parsed.error?.code || '');
+} catch {
+}
+NODE
 }
 
 read_release_metadata() {
   # Mirrors .github/workflows/release.yml "Read release metadata".
-  METADATA_JSON=$(
+  local metadata_json
+  metadata_json=$(
     node <<'NODE'
 const fs = require('node:fs');
 
@@ -44,6 +63,11 @@ if (!header) {
 }
 
 const [, changelogVersion, changelogDate] = header;
+const beforeReleaseHeader = changelog.slice(0, header.index ?? 0);
+const unreleased = beforeReleaseHeader.match(/^## \[Unreleased\]([\s\S]*)$/m);
+if (unreleased && unreleased[1].trim()) {
+  throw new Error('CHANGELOG.md has entries under ## [Unreleased]; stamp or move them before releasing.');
+}
 
 if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/.test(changelogVersion)) {
   throw new Error(`CHANGELOG.md version "${changelogVersion}" is not valid semver (expected X.Y.Z or X.Y.Z-pre.N).`);
@@ -86,6 +110,8 @@ console.log(JSON.stringify({
 }));
 NODE
   )
+  METADATA_JSON_FILE=$(mktemp)
+  printf '%s\n' "$metadata_json" >"$METADATA_JSON_FILE"
 
   PACKAGE_NAME=$(metadata_value packageName)
   RELEASE_VERSION=$(metadata_value version)
@@ -149,15 +175,7 @@ check_npm_unpublished() {
     fi
 
     local error_code
-    error_code=$(node - "$npm_view_output" <<'NODE'
-const fs = require('node:fs');
-try {
-  const parsed = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
-  process.stdout.write(parsed.error?.code || '');
-} catch {
-}
-NODE
-    )
+    error_code=$(npm_error_code "$npm_view_output")
 
     if [[ "$error_code" =~ ^(E401|E403|ENEEDAUTH)$ ]]; then
       log_warn "npm metadata check hit ${error_code}; retrying anonymously against the public registry."
@@ -168,15 +186,7 @@ NODE
         cat "$npm_view_output" >&2
         return
       fi
-      error_code=$(node - "$npm_view_output" <<'NODE'
-const fs = require('node:fs');
-try {
-  const parsed = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
-  process.stdout.write(parsed.error?.code || '');
-} catch {
-}
-NODE
-      )
+      error_code=$(npm_error_code "$npm_view_output")
     fi
 
     if [[ "$error_code" == "E404" ]]; then
@@ -223,11 +233,13 @@ check_release_checkout() {
     echo "  - Current branch is main"
   fi
 
-  if git diff --quiet && git diff --cached --quiet; then
+  local status_output
+  status_output=$(git status --porcelain)
+  if [[ -z "$status_output" ]]; then
     echo "  - Working tree is clean"
   else
     record_error "Working tree is not clean."
-    git status --short >&2
+    printf '%s\n' "$status_output" >&2
   fi
 
   local remote_main
@@ -282,4 +294,5 @@ main() {
   echo ""
 }
 
+trap cleanup_metadata_file EXIT
 main

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -128,6 +128,14 @@ check_npm_unpublished() {
   # Mirrors release.yml "Validate release ref and publish state".
   local npm_view_output
   npm_view_output=$(mktemp)
+  cleanup_npm_view_output() {
+    if [[ -n "${npm_view_output:-}" ]]; then
+      rm -f "$npm_view_output"
+    fi
+    trap - RETURN INT TERM
+  }
+  trap cleanup_npm_view_output RETURN
+  trap 'cleanup_npm_view_output; exit 130' INT TERM
 
   local attempt
   for attempt in 1 2 3 4 5; do
@@ -137,7 +145,6 @@ check_npm_unpublished() {
     if [[ "$npm_exit" -eq 0 ]]; then
       record_error "${PACKAGE_NAME}@${RELEASE_VERSION} is already published."
       cat "$npm_view_output" >&2
-      rm -f "$npm_view_output"
       return
     fi
 
@@ -152,9 +159,28 @@ try {
 NODE
     )
 
+    if [[ "$error_code" =~ ^(E401|E403|ENEEDAUTH)$ ]]; then
+      log_warn "npm metadata check hit ${error_code}; retrying anonymously against the public registry."
+      npm_exit=0
+      NPM_CONFIG_USERCONFIG=/dev/null npm --silent --registry=https://registry.npmjs.org/ view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json >"$npm_view_output" 2>&1 || npm_exit=$?
+      if [[ "$npm_exit" -eq 0 ]]; then
+        record_error "${PACKAGE_NAME}@${RELEASE_VERSION} is already published."
+        cat "$npm_view_output" >&2
+        return
+      fi
+      error_code=$(node - "$npm_view_output" <<'NODE'
+const fs = require('node:fs');
+try {
+  const parsed = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+  process.stdout.write(parsed.error?.code || '');
+} catch {
+}
+NODE
+      )
+    fi
+
     if [[ "$error_code" == "E404" ]]; then
       echo "  - npm version ${PACKAGE_NAME}@${RELEASE_VERSION} is unpublished"
-      rm -f "$npm_view_output"
       return
     fi
 
@@ -165,13 +191,16 @@ NODE
       continue
     fi
 
+    if grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$npm_view_output"; then
+      record_error "npm view failed after 5 attempts due to a network error; publish state is UNKNOWN."
+      cat "$npm_view_output" >&2
+      return
+    fi
+
     record_error "Unexpected npm error (code: ${error_code:-unknown}) while checking publish state."
     cat "$npm_view_output" >&2
-    rm -f "$npm_view_output"
     return
   done
-
-  rm -f "$npm_view_output"
 }
 
 show_dist_tags() {

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ERROR_COUNT=0
+
+# Keep npm usable in sandboxed shells where the default user cache can be
+# unwritable. User-provided cache settings still win.
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-${npm_config_cache:-${TMPDIR:-/tmp}/react-on-rails-rsc-npm-cache}}"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+record_error() {
+  ERROR_COUNT=$((ERROR_COUNT + 1))
+  log_error "$*"
+}
+
+metadata_value() {
+  node -e "const metadata = JSON.parse(process.argv[1]); process.stdout.write(String(metadata[process.argv[2]]));" "$METADATA_JSON" "$1"
+}
+
+read_release_metadata() {
+  # Mirrors .github/workflows/release.yml "Read release metadata".
+  METADATA_JSON=$(
+    node <<'NODE'
+const fs = require('node:fs');
+
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+const header = changelog.match(/^## \[([0-9][^\]]*)\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})$/m);
+
+if (!header) {
+  throw new Error('CHANGELOG.md must start its release entries with ## [X.Y.Z] - YYYY-MM-DD.');
+}
+
+const [, changelogVersion, changelogDate] = header;
+
+if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/.test(changelogVersion)) {
+  throw new Error(`CHANGELOG.md version "${changelogVersion}" is not valid semver (expected X.Y.Z or X.Y.Z-pre.N).`);
+}
+
+if (packageJson.version !== changelogVersion) {
+  throw new Error(`package.json version ${packageJson.version} does not match CHANGELOG.md ${changelogVersion}.`);
+}
+
+const releaseLines = [];
+let inSection = false;
+for (const line of changelog.split(/\r?\n/)) {
+  if (line === header[0]) {
+    inSection = true;
+    continue;
+  }
+
+  if (inSection && /^## \[[0-9]/.test(line)) {
+    break;
+  }
+
+  if (inSection) {
+    releaseLines.push(line);
+  }
+}
+
+const notes = releaseLines.join('\n').trim();
+if (!notes) {
+  throw new Error(`CHANGELOG.md has no release notes for ${changelogVersion}.`);
+}
+
+const isPrerelease = changelogVersion.includes('-');
+console.log(JSON.stringify({
+  packageName: packageJson.name,
+  version: changelogVersion,
+  date: changelogDate,
+  npmTag: isPrerelease ? 'next' : 'latest',
+  isPrerelease,
+  notesLineCount: notes.split(/\r?\n/).length,
+}));
+NODE
+  )
+
+  PACKAGE_NAME=$(metadata_value packageName)
+  RELEASE_VERSION=$(metadata_value version)
+  RELEASE_DATE=$(metadata_value date)
+  NPM_TAG=$(metadata_value npmTag)
+  NOTES_LINE_COUNT=$(metadata_value notesLineCount)
+
+  log_info "CHANGELOG/package metadata is ready: ${PACKAGE_NAME}@${RELEASE_VERSION} (${RELEASE_DATE})"
+  echo "  - npm dist-tag on publish: ${NPM_TAG}"
+  echo "  - release notes lines: ${NOTES_LINE_COUNT}"
+}
+
+check_git_tags() {
+  # Mirrors release.yml tag absence, with an additional local-tag guard.
+  if git show-ref --verify --quiet "refs/tags/${RELEASE_VERSION}"; then
+    record_error "Release tag ${RELEASE_VERSION} already exists locally."
+  else
+    echo "  - Local tag ${RELEASE_VERSION} is unused"
+  fi
+
+  local output
+  local status=0
+  output=$(git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" 2>&1) || status=$?
+  case "$status" in
+    0)
+      record_error "Release tag ${RELEASE_VERSION} already exists on origin."
+      printf '%s\n' "$output" >&2
+      ;;
+    2)
+      echo "  - Origin tag ${RELEASE_VERSION} is unused"
+      ;;
+    *)
+      record_error "Unable to verify whether origin tag ${RELEASE_VERSION} exists."
+      printf '%s\n' "$output" >&2
+      ;;
+  esac
+}
+
+check_npm_unpublished() {
+  # Mirrors release.yml "Validate release ref and publish state".
+  local npm_view_output
+  npm_view_output=$(mktemp)
+
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    local npm_exit=0
+    npm --silent view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json >"$npm_view_output" 2>&1 || npm_exit=$?
+
+    if [[ "$npm_exit" -eq 0 ]]; then
+      record_error "${PACKAGE_NAME}@${RELEASE_VERSION} is already published."
+      cat "$npm_view_output" >&2
+      rm -f "$npm_view_output"
+      return
+    fi
+
+    local error_code
+    error_code=$(node - "$npm_view_output" <<'NODE'
+const fs = require('node:fs');
+try {
+  const parsed = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+  process.stdout.write(parsed.error?.code || '');
+} catch {
+}
+NODE
+    )
+
+    if [[ "$error_code" == "E404" ]]; then
+      echo "  - npm version ${PACKAGE_NAME}@${RELEASE_VERSION} is unpublished"
+      rm -f "$npm_view_output"
+      return
+    fi
+
+    if [[ "$attempt" -lt 5 ]] && grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$npm_view_output"; then
+      log_warn "npm view failed before publish; retrying in 10s (attempt ${attempt}/5):"
+      cat "$npm_view_output" >&2
+      sleep 10
+      continue
+    fi
+
+    record_error "Unexpected npm error (code: ${error_code:-unknown}) while checking publish state."
+    cat "$npm_view_output" >&2
+    rm -f "$npm_view_output"
+    return
+  done
+
+  rm -f "$npm_view_output"
+}
+
+show_dist_tags() {
+  local dist_tags
+  if dist_tags=$(npm --silent view "${PACKAGE_NAME}" dist-tags --json 2>&1); then
+    echo "  - Current npm dist-tags: ${dist_tags}"
+  else
+    log_warn "Unable to read current npm dist-tags for ${PACKAGE_NAME}; publish-state check above is the release gate."
+    printf '%s\n' "$dist_tags" >&2
+  fi
+}
+
+check_release_checkout() {
+  # Local-only checks that the GitHub Action enforces inside its clean checkout.
+  local branch
+  branch=$(git branch --show-current || true)
+  if [[ "$branch" != "main" ]]; then
+    record_error "Release readiness must be checked from main; current branch is ${branch:-DETACHED}."
+  else
+    echo "  - Current branch is main"
+  fi
+
+  if git diff --quiet && git diff --cached --quiet; then
+    echo "  - Working tree is clean"
+  else
+    record_error "Working tree is not clean."
+    git status --short >&2
+  fi
+
+  local remote_main
+  local remote_status=0
+  remote_main=$(git ls-remote origin refs/heads/main 2>/dev/null | awk '{print $1}') || remote_status=$?
+  if [[ "$remote_status" -ne 0 || -z "$remote_main" ]]; then
+    record_error "Unable to verify origin/main for sync check."
+    return
+  fi
+
+  local head_sha
+  head_sha=$(git rev-parse HEAD)
+  if [[ "$branch" == "main" && "$head_sha" == "$remote_main" ]]; then
+    echo "  - Local main matches origin/main (${remote_main})"
+  elif [[ "$branch" == "main" ]]; then
+    record_error "Local main (${head_sha}) does not match origin/main (${remote_main})."
+  else
+    log_warn "Skipped main sync pass/fail because current branch is not main; origin/main is ${remote_main}."
+  fi
+}
+
+main() {
+  echo ""
+  echo -e "${BOLD}react-on-rails-rsc release readiness check${NC}"
+  echo ""
+
+  read_release_metadata
+
+  echo ""
+  log_info "Checking git tag state..."
+  check_git_tags
+
+  echo ""
+  log_info "Checking npm publish state..."
+  check_npm_unpublished
+  show_dist_tags
+
+  echo ""
+  log_info "Checking release checkout state..."
+  check_release_checkout
+
+  echo ""
+  if [[ "$ERROR_COUNT" -ne 0 ]]; then
+    log_error "Release is not ready; ${ERROR_COUNT} check(s) failed."
+    exit 1
+  fi
+
+  echo -e "${GREEN}${BOLD}Release is ready to dispatch.${NC}"
+  echo ""
+  echo "Run:"
+  echo "  gh workflow run release.yml --ref main -f version=${RELEASE_VERSION} -f confirm_publish=publish"
+  echo ""
+}
+
+main

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -166,7 +166,9 @@ check_npm_unpublished() {
   local attempt
   for attempt in 1 2 3 4 5; do
     local npm_exit=0
-    npm --silent view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json >"$npm_view_output" 2>&1 || npm_exit=$?
+    NPM_CONFIG_USERCONFIG=/dev/null \
+      npm --silent --registry=https://registry.npmjs.org/ view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json \
+      >"$npm_view_output" 2>&1 || npm_exit=$?
 
     if [[ "$npm_exit" -eq 0 ]]; then
       record_error "${PACKAGE_NAME}@${RELEASE_VERSION} is already published."
@@ -176,18 +178,6 @@ check_npm_unpublished() {
 
     local error_code
     error_code=$(npm_error_code "$npm_view_output")
-
-    if [[ "$error_code" =~ ^(E401|E403|ENEEDAUTH)$ ]]; then
-      log_warn "npm metadata check hit ${error_code}; retrying anonymously against the public registry."
-      npm_exit=0
-      NPM_CONFIG_USERCONFIG=/dev/null npm --silent --registry=https://registry.npmjs.org/ view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json >"$npm_view_output" 2>&1 || npm_exit=$?
-      if [[ "$npm_exit" -eq 0 ]]; then
-        record_error "${PACKAGE_NAME}@${RELEASE_VERSION} is already published."
-        cat "$npm_view_output" >&2
-        return
-      fi
-      error_code=$(npm_error_code "$npm_view_output")
-    fi
 
     if [[ "$error_code" == "E404" ]]; then
       echo "  - npm version ${PACKAGE_NAME}@${RELEASE_VERSION} is unpublished"

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -27,7 +27,15 @@ record_error() {
 }
 
 metadata_value() {
-  node -e "const fs = require('node:fs'); const metadata = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(String(metadata[process.argv[2]]));" "$METADATA_JSON_FILE" "$1"
+  node - "$METADATA_JSON_FILE" "$1" <<'NODE'
+const fs = require('node:fs');
+const metadata = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const key = process.argv[3];
+if (!Object.hasOwn(metadata, key)) {
+  throw new Error(`Unknown release metadata key: ${key}`);
+}
+process.stdout.write(String(metadata[key]));
+NODE
 }
 
 cleanup_metadata_file() {
@@ -160,6 +168,7 @@ check_npm_unpublished() {
     fi
     trap - RETURN INT TERM
   }
+  # RETURN keeps this temp-file cleanup scoped to check_npm_unpublished.
   trap cleanup_npm_view_output RETURN
   trap 'cleanup_npm_view_output; exit 130' INT TERM
 
@@ -205,7 +214,10 @@ check_npm_unpublished() {
 
 show_dist_tags() {
   local dist_tags
-  if dist_tags=$(npm --silent view "${PACKAGE_NAME}" dist-tags --json 2>&1); then
+  if dist_tags=$(
+    NPM_CONFIG_USERCONFIG=/dev/null \
+      npm --silent --registry=https://registry.npmjs.org/ view "${PACKAGE_NAME}" dist-tags --json 2>&1
+  ); then
     echo "  - Current npm dist-tags: ${dist_tags}"
   else
     log_warn "Unable to read current npm dist-tags for ${PACKAGE_NAME}; publish-state check above is the release gate."

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -174,6 +174,7 @@ check_npm_unpublished() {
   retry_delay="${RELEASE_CHECK_NPM_RETRY_DELAY:-10}"
   NPM_VIEW_OUTPUT_FILE=$(mktemp)
   cleanup_npm_view_output() {
+    # Bash inner functions are global; keep this helper name unique.
     if [[ -n "${NPM_VIEW_OUTPUT_FILE:-}" ]]; then
       rm -f "$NPM_VIEW_OUTPUT_FILE"
       NPM_VIEW_OUTPUT_FILE=
@@ -185,6 +186,7 @@ check_npm_unpublished() {
 
   local attempt
   local npm_exit
+  local error_code
   for attempt in 1 2 3 4 5; do
     npm_exit=0
     # Use the public registry without user .npmrc auth so public metadata reads
@@ -200,7 +202,6 @@ check_npm_unpublished() {
       return
     fi
 
-    local error_code
     error_code=$(npm_error_code "$NPM_VIEW_OUTPUT_FILE")
 
     if [[ "$error_code" == "E404" ]]; then
@@ -260,10 +261,13 @@ check_release_checkout() {
   fi
 
   local remote_main
+  local remote_output
   local remote_status=0
-  remote_main=$(git ls-remote origin refs/heads/main 2>/dev/null | awk '{print $1}') || remote_status=$?
+  remote_output=$(git ls-remote origin refs/heads/main 2>&1) || remote_status=$?
+  remote_main=$(printf '%s\n' "$remote_output" | awk '{print $1}')
   if [[ "$remote_status" -ne 0 || -z "$remote_main" ]]; then
     record_error "Unable to verify origin/main for sync check."
+    [[ -n "$remote_output" ]] && printf '%s\n' "$remote_output" >&2
     return
   fi
 

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -12,6 +12,7 @@ NC='\033[0m'
 
 ERROR_COUNT=0
 METADATA_JSON_FILE=
+NPM_VIEW_OUTPUT_FILE=
 
 # Keep npm usable in sandboxed shells where the default user cache can be
 # unwritable. User-provided cache settings still win.
@@ -38,10 +39,19 @@ process.stdout.write(String(metadata[key]));
 NODE
 }
 
-cleanup_metadata_file() {
+cleanup_temp_files() {
   if [[ -n "${METADATA_JSON_FILE:-}" ]]; then
     rm -f "$METADATA_JSON_FILE"
   fi
+  if [[ -n "${NPM_VIEW_OUTPUT_FILE:-}" ]]; then
+    rm -f "$NPM_VIEW_OUTPUT_FILE"
+  fi
+}
+
+handle_interrupt() {
+  cleanup_temp_files
+  trap - EXIT INT TERM
+  exit 130
 }
 
 npm_error_code() {
@@ -160,54 +170,59 @@ check_git_tags() {
 
 check_npm_unpublished() {
   # Mirrors release.yml "Validate release ref and publish state".
-  local npm_view_output
-  npm_view_output=$(mktemp)
+  local retry_delay
+  retry_delay="${RELEASE_CHECK_NPM_RETRY_DELAY:-10}"
+  NPM_VIEW_OUTPUT_FILE=$(mktemp)
   cleanup_npm_view_output() {
-    if [[ -n "${npm_view_output:-}" ]]; then
-      rm -f "$npm_view_output"
+    if [[ -n "${NPM_VIEW_OUTPUT_FILE:-}" ]]; then
+      rm -f "$NPM_VIEW_OUTPUT_FILE"
+      NPM_VIEW_OUTPUT_FILE=
     fi
-    trap - RETURN INT TERM
+    trap - RETURN
   }
   # RETURN keeps this temp-file cleanup scoped to check_npm_unpublished.
   trap cleanup_npm_view_output RETURN
-  trap 'cleanup_npm_view_output; exit 130' INT TERM
 
   local attempt
+  local npm_exit
   for attempt in 1 2 3 4 5; do
-    local npm_exit=0
+    npm_exit=0
+    # Use the public registry without user .npmrc auth so public metadata reads
+    # are not blocked by private registry credentials. Proxy settings can still
+    # be supplied through environment variables such as HTTPS_PROXY.
     NPM_CONFIG_USERCONFIG=/dev/null \
       npm --silent --registry=https://registry.npmjs.org/ view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --json \
-      >"$npm_view_output" 2>&1 || npm_exit=$?
+      >"$NPM_VIEW_OUTPUT_FILE" 2>&1 || npm_exit=$?
 
     if [[ "$npm_exit" -eq 0 ]]; then
       record_error "${PACKAGE_NAME}@${RELEASE_VERSION} is already published."
-      cat "$npm_view_output" >&2
+      cat "$NPM_VIEW_OUTPUT_FILE" >&2
       return
     fi
 
     local error_code
-    error_code=$(npm_error_code "$npm_view_output")
+    error_code=$(npm_error_code "$NPM_VIEW_OUTPUT_FILE")
 
     if [[ "$error_code" == "E404" ]]; then
       echo "  - npm version ${PACKAGE_NAME}@${RELEASE_VERSION} is unpublished"
       return
     fi
 
-    if [[ "$attempt" -lt 5 ]] && grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$npm_view_output"; then
-      log_warn "npm view failed before publish; retrying in 10s (attempt ${attempt}/5):"
-      cat "$npm_view_output" >&2
-      sleep 10
+    if [[ "$attempt" -lt 5 ]] && grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$NPM_VIEW_OUTPUT_FILE"; then
+      log_warn "npm view failed before publish; retrying in ${retry_delay}s (attempt ${attempt}/5):"
+      cat "$NPM_VIEW_OUTPUT_FILE" >&2
+      sleep "$retry_delay"
       continue
     fi
 
-    if grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$npm_view_output"; then
+    if grep -Eiq 'ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|network|timeout' "$NPM_VIEW_OUTPUT_FILE"; then
       record_error "npm view failed after 5 attempts due to a network error; publish state is UNKNOWN."
-      cat "$npm_view_output" >&2
+      cat "$NPM_VIEW_OUTPUT_FILE" >&2
       return
     fi
 
     record_error "Unexpected npm error (code: ${error_code:-unknown}) while checking publish state."
-    cat "$npm_view_output" >&2
+    cat "$NPM_VIEW_OUTPUT_FILE" >&2
     return
   done
 }
@@ -296,5 +311,6 @@ main() {
   echo ""
 }
 
-trap cleanup_metadata_file EXIT
+trap cleanup_temp_files EXIT
+trap handle_interrupt INT TERM
 main


### PR DESCRIPTION
## Summary
- Add yarn release:check via scripts/check-release-ready.sh for the fast release metadata, tag, npm publish-state, and clean-main readiness gates.
- Make the GitHub Actions Release package path canonical in release docs, AGENTS, CLAUDE, and update-changelog skill text.
- Update update-changelog guidance so version-stamping modes also bump package.json while plain Unreleased updates leave it alone.
- Harden npm metadata checks with temp-file cleanup, clearer network exhaustion errors, and anonymous public-registry retry when local npm auth blocks public metadata reads.

Fixes #116

## Validation
- bash -n scripts/check-release-ready.sh
- yarn release:check (expected failure in current rc.3 state: local/origin tag exists, npm version is already published, next dist-tag is 19.2.0-rc.3, and the feature branch is not main)
- npm view react-on-rails-rsc@19.2.0-rc.3 version --json => "19.2.0-rc.3"
- npm view react-on-rails-rsc dist-tags --json => latest=19.0.5, next=19.2.0-rc.3
- git diff --check / git diff --cached --check
- yarn
- yarn build
- yarn test
- Review-fix commit 87cd079: bash -n scripts/check-release-ready.sh, git diff --check, yarn release:check expected failure for already-published/tagged rc.3 plus non-main/dirty checkout

## Dependency Gate
- PR #118 is merged at b68c6cb698af6fe45528548f214e7e53fcf7ebc9.
- The Release package run for rc.3 on b68c6cb completed successfully.
- Verify package artifacts on b68c6cb completed successfully; compatibility matrix was reported green by the worker.
- No current package-runtime-policy failure was seen.

## Review Triage
- Greptile temp-file cleanup and network-exhaustion comments were fixed in 87cd079.
- Codex review comment about auth-blocked npm metadata checks was fixed in 87cd079 by retrying public npm metadata reads anonymously.
- CodeRabbit rate-limited and did not produce a substantive review.

## Risk / Merge Policy
- High-risk release-process PR. Do not auto-merge.
- No .github/workflows files changed, so no Workflow Change Audit comment is required.

## Coordination
- Batch: rsc-tonight-20260621
- Worker: codex-rsc-tonight-116-release-readiness-check
- Private agent-coord state: UNKNOWN; agent-coord status and doctor timed out in coordinator preflight.
- Public fallback claim: https://github.com/shakacode/react_on_rails_rsc/issues/116#issuecomment-4761496038

## Codex Decision Log
- **Non-blocking:** Whether to move contributor-only docs as part of this PR.
  - **Decision:** Kept the scope to canonical release path and release:check instead of moving docs.
  - **Why:** The batch goal prioritized release path consistency and a readiness check; doc moves would broaden the release-process PR and conflict with the #109 docs lane.
  - **Review later:** Contributor-info doc relocation can be handled separately if still desired.

## Churn Notes
- Pre-push review gate: worker self-review, bash syntax check, release:check smoke, yarn build, yarn test. codex review --uncommitted was attempted but hung inside its own yarn release:check and was terminated as inconclusive.
- Post-push review churn: 1 follow-up script-hardening commit from review feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes maintainer release sequencing and gates; mistakes could block or mislead publishes, though runtime package behavior is unchanged.
> 
> **Overview**
> Introduces **`yarn release:check`** (`scripts/check-release-ready.sh`), a read-only preflight that mirrors key **Release package** workflow gates: changelog header and notes, **`package.json` version parity**, unused local/origin tags, npm publish state (with retries and anonymous public-registry reads), plus clean synced **`main`**. On success it prints the exact **`gh workflow run release.yml`** dispatch command.
> 
> **Release documentation** across `AGENTS.md`, `CLAUDE.md`, `docs/releasing.md`, and the update-changelog skill/command is updated so publishing via **GitHub Actions** is canonical; **`yarn release` / `yarn release:dry-run`** are maintainer-only fallbacks. Version-stamping changelog modes now require bumping **`package.json`** in the same PR; plain **`[Unreleased]`** updates do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352cf610c1a8134a04fd72a599b21b4c783d5a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `yarn release:check` to validate release readiness before dispatching the GitHub Actions “Release package” workflow, including changelog formatting, matching CHANGELOG.md/package.json versions, tag/publish status checks, and a clean, synced `main` requirement.
* **Documentation**
  * Updated release/changelog procedures to be changelog-driven and GitHub Actions–canonical, require package.json sync when stamping release/rc/beta versions, and clarify maintainer-only local fallback behavior when Actions is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->