### PR TITLE
Reduce Dependabot PR noise: grouping, monthly cadence, auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 5
     groups:
-      root-dev-minor-patch:
-        dependency-type: development
+      root-minor-patch:
         patterns:
           - '*'
         update-types:
@@ -16,7 +16,8 @@ updates:
   - package-ecosystem: npm
     directory: /scripts/react-upgrade
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 5
     groups:
       react-upgrade-minor-patch:
         patterns:
@@ -28,7 +29,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 5
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+# Enables GitHub native auto-merge for low-risk Dependabot PRs (minor/patch and
+# GitHub Actions bumps). The PR still merges only once all checks GitHub treats
+# as required have passed. NOTE: `main` currently has no branch protection, so
+# "required" is empty and an enabled PR merges as soon as it is mergeable. Add
+# branch protection on `main` with the real CI checks (unit-tests, e2e-tests,
+# verify-artifacts, the compatibility matrix) marked required — but NOT
+# claude-review — to make this gate on green CI.
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Dependabot has been opening a separate PR for **every** production dependency
(jest, webpack-sources, acorn-loose, semver, ...), which is the main source of
noise. The existing groups only matched `dependency-type: development`, so
production deps were never batched.

## Changes

- **Group all npm minor/patch updates** (production + development) into one
  grouped PR per directory, instead of one PR per package.
- **weekly → monthly** for all three ecosystems (npm root, npm
  `/scripts/react-upgrade`, github-actions).
- **`open-pull-requests-limit: 5`** as a backstop.
- **New `dependabot-auto-merge.yml` workflow** that enables GitHub native
  auto-merge for minor/patch and GitHub Actions bumps.

Major-version bumps still open individual PRs by design — those can break and
deserve eyes.

## Follow-up needed for auto-merge to gate on CI

`main` currently has **no branch protection**, so "required checks" is empty and
an auto-merge-enabled PR merges as soon as it is mergeable. To make auto-merge
wait for green CI, add branch protection on `main` with the real checks
required (`unit-tests`, `e2e-tests`, `verify-artifacts`, the compatibility
matrix) — but **not** `claude-review`, which is an advisory AI review that
flakily reports failure.

"Allow auto-merge" has been enabled in repo settings so the workflow can call
`gh pr merge --auto`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update schedules to a monthly cadence with improved management limits.
  * Enhanced automation for routine dependency updates to streamline maintenance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->