### PR TITLE
Update CHANGELOG.md and package version for 19.2.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+## [19.2.0-rc.4] - 2026-06-21
+
 ### Added
 - Added a configurable client-build warning when a client reference appears in at least four client-reference chunk groups, helping surface cross-page JS/CSS duplication from chunk contamination. Set `chunkGroupWarningThreshold` to a positive number to tune the threshold, or to `0`/`false` to disable the warning. ([#120])
 
@@ -55,7 +57,8 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.3...HEAD
+[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.4...HEAD
+[19.2.0-rc.4]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.3...19.2.0-rc.4
 [19.2.0-rc.3]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.2...19.2.0-rc.3
 [19.2.0-rc.2]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.1...19.2.0-rc.2
 [19.2.0-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0-rc.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-rsc",
-  "version": "19.2.0-rc.3",
+  "version": "19.2.0-rc.4",
   "description": "React Server Components support for react_on_rails Ruby gem",
   "exports": {
     "./client": {


### PR DESCRIPTION
Stamps the `19.2.0-rc.4` prerelease.

## Changelog

### Added

- Configurable client-build warning when a client reference appears in at least four client-reference chunk groups (`chunkGroupWarningThreshold`). (#120)

## What changed

- Moved the #120 entry from `## [Unreleased]` into a new `## [19.2.0-rc.4] - 2026-06-21` section.
- Bumped `package.json` version `19.2.0-rc.3` → `19.2.0-rc.4`.
- Added the `[19.2.0-rc.4]` compare link and updated the `[Unreleased]` link.

No-entry PRs since rc.3: #119 (docs), #121 (release tooling), #122 (internal docs).

After this merges to `main`, release via `yarn release:check` from a clean synced `main`, then dispatch the printed `gh workflow run release.yml ...` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
