### PR TITLE
Adopt agent-workflow binstubs (.agents/bin/ + AGENTS.md pointer)

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,0 +1,13 @@
+# Non-command agent-workflow configuration for portable shared skills.
+# Commands live as scripts in .agents/bin/ (see .agents/bin/README.md).
+base_branch: main
+changelog: "/CHANGELOG.md — Keep-a-Changelog; user-visible changes only; reference-style PR links (e.g. [#52])"
+follow_up_prefix: "Follow-up:"
+review_gate: "AI reviewers (Claude, CodeRabbit, Greptile, Bugbot, Codex) are advisory unless they confirm a blocker; merge gate is the full gh pr checks list green (not --required) + all threads resolved + mergeable clean"
+approval_exempt: "at batch closeout, auto-merge ready low-risk PRs that pass the merge gate; keep high-risk (CI/workflow, build-config, dependency or runtime bumps, broad refactors, release) maintainer-gated"
+coordination_backend: "private shakacode/agent-coordination (claims/heartbeats namespaced by full repo name)"
+benchmark_labels: n/a
+merge_ledger: n/a
+ci_parity_environment: "n/a — reproduce CI-only failures from the matching job in .github/workflows/**"
+hosted_ci_trigger: "n/a — the unit-tests workflow runs on every PR; no +ci-* commands"
+ci_change_detector: n/a

--- a/.agents/bin/README.md
+++ b/.agents/bin/README.md
@@ -1,0 +1,17 @@
+# Agent Workflow Scripts
+
+Standard entry points that portable agent-workflow skills call, so a skill can
+run `.agents/bin/<name>` in any repo without knowing this repo's specific
+commands. Each script is a thin, repo-owned wrapper. A script that is **absent**
+means that capability is n/a here.
+
+| Script | Purpose | This repo runs |
+| --- | --- | --- |
+| `setup` | Install dependencies | `yarn install` |
+| `validate` | Pre-push gate (run before pushing) | `build` + `test` |
+| `test` | Run tests | `yarn test` (`test:rsc` + `test:non-rsc`) |
+| `build` | Build / type-check | `yarn build` (tsc; also the typecheck) |
+| `lint` | Lint / format | n/a — eslint/prettier are not wired into a blocking gate |
+
+For one RSC test file: `NODE_CONDITIONS=react-server yarn jest <path>` (for
+`*.rsc.test.*`). Non-command policy lives in [`../agent-workflow.yml`](../agent-workflow.yml).

--- a/.agents/bin/build
+++ b/.agents/bin/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Build (tsc; this is also the typecheck).
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec yarn build

--- a/.agents/bin/build
+++ b/.agents/bin/build
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build (tsc; this is also the typecheck).
+set -euo pipefail
+exec yarn build

--- a/.agents/bin/setup
+++ b/.agents/bin/setup
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Install dependencies.
+set -euo pipefail
+exec yarn install

--- a/.agents/bin/setup
+++ b/.agents/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Install dependencies.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec yarn install

--- a/.agents/bin/test
+++ b/.agents/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Run tests (test:rsc + test:non-rsc). For a single RSC file:
+#   NODE_CONDITIONS=react-server yarn jest <path>   (for *.rsc.test.*)
+set -euo pipefail
+exec yarn test "$@"

--- a/.agents/bin/test
+++ b/.agents/bin/test
@@ -2,4 +2,5 @@
 # Run tests (test:rsc + test:non-rsc). For a single RSC file:
 #   NODE_CONDITIONS=react-server yarn jest <path>   (for *.rsc.test.*)
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec yarn test "$@"

--- a/.agents/bin/validate
+++ b/.agents/bin/validate
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Pre-push gate: build + test (run before pushing).
 set -euo pipefail
-here="$(cd "$(dirname "$0")" && pwd)"
-"$here/build"
-"$here/test"
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+"$root/.agents/bin/build"
+"$root/.agents/bin/test"

--- a/.agents/bin/validate
+++ b/.agents/bin/validate
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Pre-push gate: build + test (run before pushing).
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+"$here/build"
+"$here/test"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,38 +282,9 @@ Update `/CHANGELOG.md` for **user-visible changes only** (features, bug fixes, b
 
 ## Agent Workflow Configuration
 
-Portable shared skills resolve every repo-specific value through this section.
-Adopting repos replace these values with their own and validate the seam with
-`agent-workflow-seam-doctor` (add `--shared <agent-workflows-root>` when checking
-user-installed shared skills outside the checkout). The shared source lives at
-[`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows).
+Portable shared skills resolve this repo's commands and policy through:
 
-- **Base branch**: `main`.
-- **Pre-push local validation**: `yarn build && yarn test` (tsc typecheck + jest). For a
-  single file run `yarn jest <path>`, prefixed `NODE_CONDITIONS=react-server` for
-  `*.rsc.test.*`.
-- **CI change detector**: n/a — no detector script; run the full suite.
-- **Hosted-CI trigger**: n/a — the unit-tests workflow runs on every PR; no manual
-  trigger or `+ci-*` commands.
-- **CI parity environment**: n/a — reproduce CI-only failures from the matching job in
-  `.github/workflows/**`.
-- **Benchmark labels**: n/a.
-- **Follow-up issue prefix**: `Follow-up:`.
-- **Changelog**: `/CHANGELOG.md` — Keep-a-Changelog; user-visible changes only;
-  reference-style PR links (e.g. `([#52])`).
-- **Lint / format**: n/a — eslint/prettier configs exist but are not wired into a gate;
-  do not run them as a blocking check.
-- **Merge ledger**: n/a.
-- **Docs checks**: n/a.
-- **Tests**: `yarn test` (`yarn test:rsc` + `yarn test:non-rsc`); single file
-  `yarn jest <path>`, prefix `NODE_CONDITIONS=react-server` for `*.rsc.test.*`.
-- **Build / type checks**: `yarn build` (runs `tsc`; this is the typecheck — no separate
-  type-check script).
-- **Review gate**: AI reviewers (Claude, CodeRabbit, Greptile, Bugbot, Codex) are
-  advisory, not blocking unless they confirm a blocker; merge gate is the full
-  `gh pr checks` list green (not `--required`) + all threads resolved + `mergeable` clean.
-- **Approval-exempt change categories**: at batch closeout, auto-merge ready low-risk PRs
-  that pass the merge gate; keep high-risk (CI/workflow, build-config, dependency or
-  runtime bumps, broad refactors, release) maintainer-gated.
-- **Coordination backend**: private `shakacode/agent-coordination` (claims/heartbeats
-  namespaced by full repo name).
+- **Commands** — run `.agents/bin/<name>` (`setup`, `validate`, `test`, `build`);
+  see [`.agents/bin/README.md`](.agents/bin/README.md). A missing script means that
+  capability is n/a here.
+- **Policy / config** — [`.agents/agent-workflow.yml`](.agents/agent-workflow.yml).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,3 +279,45 @@ Update `/CHANGELOG.md` for **user-visible changes only** (features, bug fixes, b
 - **Format**: Keep-a-Changelog. Version headings are `## [x.y.z] - YYYY-MM-DD`; group entries under `### Added` / `### Changed` / `### Fixed` / `### Removed`.
 - **PR links**: reference style, e.g. `- Past-tense description of the change. ([#52])`, with the link definition collected at the bottom of the file: `[#52]: https://github.com/shakacode/react_on_rails_rsc/pull/52`.
 - The release version is read from the top changelog heading by `scripts/release.sh`. See `.agents/skills/update-changelog/SKILL.md` for the full flow.
+
+## Agent Workflow Configuration
+
+Portable shared skills resolve every repo-specific value through this section.
+Adopting repos replace these values with their own and validate the seam with
+`agent-workflow-seam-doctor` (add `--shared <agent-workflows-root>` when checking
+user-installed shared skills outside the checkout). The shared source lives at
+[`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows).
+
+- **Base branch**: `main` (fetch and compare via `origin/main`).
+- **Pre-push local validation**: `yarn build` (tsc typecheck) and `yarn test`, or a
+  targeted `yarn jest` over the changed surface (prefix `NODE_CONDITIONS=react-server`
+  for `*.rsc.test.*` files).
+- **CI change detector**: n/a (no detector script; use `$run-ci` to reproduce CI job
+  selection locally).
+- **Hosted-CI trigger**: n/a (the jest unit-tests workflow runs automatically on every
+  PR; no `+ci-*` commands or CI-expansion labels).
+- **CI parity environment**: n/a (no documented `act`/runner image; reproduce CI-only
+  failures from the exact `.github/workflows/**` job).
+- **Benchmark labels**: n/a.
+- **Follow-up issue prefix**: `Follow-up:` (prefer fixing or declining in the PR;
+  default to no new issue).
+- **Changelog**: `/CHANGELOG.md` (Keep-a-Changelog; user-visible changes only;
+  reference-style PR links such as `([#52])`).
+- **Lint / format**: n/a (ESLint/Prettier configs exist but are not installed or wired
+  into a script or CI gate; `yarn test` + `yarn build` are the gates).
+- **Merge ledger**: n/a (no merge-ledger script or `Agent Merge Confidence` protocol).
+- **Docs checks**: n/a.
+- **Tests**: `yarn test` (runs `yarn test:rsc` then `yarn test:non-rsc`); run one file
+  with `yarn jest` (prefix `NODE_CONDITIONS=react-server` for `*.rsc.test.*`).
+- **Build / type checks**: `yarn build` (runs `tsc`; the build is also the typecheck).
+- **Review gate**: AI reviewers (Claude Code Review, CodeRabbit, Greptile, Cursor
+  Bugbot, Codex) are advisory unless they identify a confirmed blocker; the merge gate
+  is the full `gh pr checks <PR>` list green (not `--required`), all review threads
+  resolved or triaged, and `mergeable` clean.
+- **Approval-exempt change categories**: batch-closeout auto-merge of ready, low-risk
+  PRs that clear full merge qualification; high-risk classes (CI/workflow, build-config,
+  dependency or runtime-version bumps, broad refactors, release-process) stay
+  maintainer-gated.
+- **Coordination backend**: ShakaCode-internal; shares the private
+  `shakacode/agent-coordination` backend (claims/heartbeats namespaced by full repo
+  name).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,36 +288,32 @@ Adopting repos replace these values with their own and validate the seam with
 user-installed shared skills outside the checkout). The shared source lives at
 [`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows).
 
-- **Base branch**: `main` (fetch and compare via `origin/main`).
-- **Pre-push local validation**: `yarn build` (tsc typecheck) and `yarn test`, or a
-  targeted `yarn jest` over the changed surface (prefix `NODE_CONDITIONS=react-server`
-  for `*.rsc.test.*` files).
-- **CI change detector**: n/a (no detector script; use `$run-ci` to reproduce CI job
-  selection locally).
-- **Hosted-CI trigger**: n/a (the jest unit-tests workflow runs automatically on every
-  PR; no `+ci-*` commands or CI-expansion labels).
-- **CI parity environment**: n/a (no documented `act`/runner image; reproduce CI-only
-  failures from the exact `.github/workflows/**` job).
+- **Base branch**: `main`.
+- **Pre-push local validation**: `yarn build && yarn test` (tsc typecheck + jest). For a
+  single file run `yarn jest <path>`, prefixed `NODE_CONDITIONS=react-server` for
+  `*.rsc.test.*`.
+- **CI change detector**: n/a — no detector script; run the full suite.
+- **Hosted-CI trigger**: n/a — the unit-tests workflow runs on every PR; no manual
+  trigger or `+ci-*` commands.
+- **CI parity environment**: n/a — reproduce CI-only failures from the matching job in
+  `.github/workflows/**`.
 - **Benchmark labels**: n/a.
-- **Follow-up issue prefix**: `Follow-up:` (prefer fixing or declining in the PR;
-  default to no new issue).
-- **Changelog**: `/CHANGELOG.md` (Keep-a-Changelog; user-visible changes only;
-  reference-style PR links such as `([#52])`).
-- **Lint / format**: n/a (ESLint/Prettier configs exist but are not installed or wired
-  into a script or CI gate; `yarn test` + `yarn build` are the gates).
-- **Merge ledger**: n/a (no merge-ledger script or `Agent Merge Confidence` protocol).
+- **Follow-up issue prefix**: `Follow-up:`.
+- **Changelog**: `/CHANGELOG.md` — Keep-a-Changelog; user-visible changes only;
+  reference-style PR links (e.g. `([#52])`).
+- **Lint / format**: n/a — eslint/prettier configs exist but are not wired into a gate;
+  do not run them as a blocking check.
+- **Merge ledger**: n/a.
 - **Docs checks**: n/a.
-- **Tests**: `yarn test` (runs `yarn test:rsc` then `yarn test:non-rsc`); run one file
-  with `yarn jest` (prefix `NODE_CONDITIONS=react-server` for `*.rsc.test.*`).
-- **Build / type checks**: `yarn build` (runs `tsc`; the build is also the typecheck).
-- **Review gate**: AI reviewers (Claude Code Review, CodeRabbit, Greptile, Cursor
-  Bugbot, Codex) are advisory unless they identify a confirmed blocker; the merge gate
-  is the full `gh pr checks <PR>` list green (not `--required`), all review threads
-  resolved or triaged, and `mergeable` clean.
-- **Approval-exempt change categories**: batch-closeout auto-merge of ready, low-risk
-  PRs that clear full merge qualification; high-risk classes (CI/workflow, build-config,
-  dependency or runtime-version bumps, broad refactors, release-process) stay
-  maintainer-gated.
-- **Coordination backend**: ShakaCode-internal; shares the private
-  `shakacode/agent-coordination` backend (claims/heartbeats namespaced by full repo
-  name).
+- **Tests**: `yarn test` (`yarn test:rsc` + `yarn test:non-rsc`); single file
+  `yarn jest <path>`, prefix `NODE_CONDITIONS=react-server` for `*.rsc.test.*`.
+- **Build / type checks**: `yarn build` (runs `tsc`; this is the typecheck — no separate
+  type-check script).
+- **Review gate**: AI reviewers (Claude, CodeRabbit, Greptile, Bugbot, Codex) are
+  advisory, not blocking unless they confirm a blocker; merge gate is the full
+  `gh pr checks` list green (not `--required`) + all threads resolved + `mergeable` clean.
+- **Approval-exempt change categories**: at batch closeout, auto-merge ready low-risk PRs
+  that pass the merge gate; keep high-risk (CI/workflow, build-config, dependency or
+  runtime bumps, broad refactors, release) maintainer-gated.
+- **Coordination backend**: private `shakacode/agent-coordination` (claims/heartbeats
+  namespaced by full repo name).


### PR DESCRIPTION
## Summary

Adopts the portable agent-workflow contract from
[shakacode/agent-workflows](https://github.com/shakacode/agent-workflows) using the
"Scripts to Rule Them All" pattern. **This supersedes the earlier inline-seam approach
on the same branch.**

- **`.agents/bin/<name>`** — executable wrappers (`setup`, `validate`, `test`, `build`);
  a skill runs `.agents/bin/test` without knowing this repo's commands. See
  `.agents/bin/README.md`. Lint is n/a (eslint/prettier aren't wired into a gate).
- **`.agents/agent-workflow.yml`** — non-command policy (base branch, changelog, review
  gate, coordination backend, …).
- **`AGENTS.md`** — the `## Agent Workflow Configuration` section is now a thin pointer;
  the existing `## Commands` / `## Testing` prose is untouched.

The scripts wrap existing commands (`yarn build` / `yarn test`); nothing executable changes.

## Validation

- `bash -n` on each script; all `chmod +x`; `agent-workflow.yml` parses.
- `.agents/bin/validate` composes `build` + `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
