### PR TITLE
Update CHANGELOG.md and package version for 19.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,7 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
-## [19.2.0-rc.4] - 2026-06-21
-
-### Added
-- Added a configurable client-build warning when a client reference appears in at least four client-reference chunk groups, helping surface cross-page JS/CSS duplication from chunk contamination. Set `chunkGroupWarningThreshold` to a positive number to tune the threshold, or to `0`/`false` to disable the warning. ([#120])
-
-## [19.2.0-rc.3] - 2026-06-19
-
-### Fixed
-- Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#110])
-- Recovered a client reference's own extracted CSS when `SplitChunks` + `MiniCssExtractPlugin` place it in a chunk separate from the one holding the reference's JS module (e.g. a cache group that matches the JS file but not its `.css` sibling). The plugin now follows each reference's direct `.css` imports to the chunk(s) carrying them, intersected with the reference's chunk group, so the `rsc-css` hint is still emitted for those styles. Only direct imports are followed, so the per-chunk scoping from `#110` continues not to re-broadcast shared dependency CSS. ([#113])
-
-## [19.2.0-rc.2] - 2026-06-16
-
-### Fixed
-- Fixed the Rspack RSC build skipping the client-references module map on the 19.2 line when `react-server-dom-webpack` resolves to a different install path than the plugin's own copy (duplicate installs, pnpm/yarn symlink stores, hoisted-vs-nested layouts). The plugin now recognizes the Flight client runtime by file-name suffix confirmed through a `react-server-dom-webpack` `package.json` walk instead of strict resolved-path equality, matching the Webpack plugin's duplicate-install handling, so the module map is emitted and Rspack-rendered RSC client content works again. ([#105])
-
-## [19.2.0-rc.1] - 2026-06-14
+## [19.2.0] - 2026-06-28
 
 ### Breaking Changes
 - Moved the package to the React 19.2 runtime line by depending on stock `react-server-dom-webpack@~19.2.7`, removing the published vendored Flight runtime, and raising the `react` and `react-dom` peer dependency floor to `^19.2.7`. ([#102])
@@ -33,11 +17,17 @@ All notable changes to this package will be documented in this file.
   4. Plain Node processes that import `react-on-rails-rsc/server` with `react-server` but without the `webpack` condition no longer provide unbundled server-action decoding APIs; those APIs now fail with an explicit migration error because React 19.2 removed the public unbundled runtime.
   5. Keep RSC client and server bundles on the same React 19.2 runtime line; React 19.2 Flight stylesheet hint rows can use the bare `:HS[...]` format that older 19.0.x clients do not parse.
 
+### Added
+- Added a configurable client-build warning when a client reference appears in at least four client-reference chunk groups, helping surface cross-page JS/CSS duplication from chunk contamination. Set `chunkGroupWarningThreshold` to a positive number to tune the threshold, or to `0`/`false` to disable the warning. ([#120])
+
 ### Changed
 - Set the 19.0.x package line to maintenance mode after the 19.2.x line becomes `latest`; future 19.0.x releases should be limited to security fixes, severe regressions, release-artifact repairs, or downstream React on Rails support obligations. ([#102])
 
 ### Fixed
+- Fixed the Rspack RSC build skipping the client-references module map on the 19.2 line when `react-server-dom-webpack` resolves to a different install path than the plugin's own copy (duplicate installs, pnpm/yarn symlink stores, hoisted-vs-nested layouts). The plugin now recognizes the Flight client runtime by file-name suffix confirmed through a `react-server-dom-webpack` `package.json` walk instead of strict resolved-path equality, matching the Webpack plugin's duplicate-install handling, so the module map is emitted and Rspack-rendered RSC client content works again. ([#106])
 - Preserved wrapper-layer RSC stylesheet hints for conditional `react-on-rails-rsc/server` Flight renderers, including edge/workerd, while using the stock React 19.2 runtime. ([#102])
+- Scoped per-client-reference CSS to the chunk(s) that actually contain the reference instead of collecting it across the whole chunk group. Shared dependency chunks (`vendor`/`common`/styleguide) that the page entry already loads are no longer re-broadcast as a render-blocking `<link rel="stylesheet" precedence="rsc-css">` per client reference — the dominant FCP/LCP regression when a real page is converted to RSC — while a reference's own extracted CSS (including the entry chunk's CSS for an eagerly-imported component) and the `#52` runtime-chunk exclusion are preserved. ([#110])
+- Recovered a client reference's own extracted CSS when `SplitChunks` + `MiniCssExtractPlugin` place it in a chunk separate from the one holding the reference's JS module (e.g. a cache group that matches the JS file but not its `.css` sibling). The plugin now follows each reference's direct `.css` imports to the chunk(s) carrying them, intersected with the reference's chunk group, so the `rsc-css` hint is still emitted for those styles. Only direct imports are followed, so the per-chunk scoping from `#110` continues not to re-broadcast shared dependency CSS. ([#113])
 
 ## [19.0.5] - 2026-06-13
 
@@ -57,16 +47,13 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.4...HEAD
-[19.2.0-rc.4]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.3...19.2.0-rc.4
-[19.2.0-rc.3]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.2...19.2.0-rc.3
-[19.2.0-rc.2]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0-rc.1...19.2.0-rc.2
-[19.2.0-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0-rc.1
+[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...HEAD
+[19.2.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
-[#105]: https://github.com/shakacode/react_on_rails_rsc/pull/106
+[#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23
 [#29]: https://github.com/shakacode/react_on_rails_rsc/pull/29
 [#33]: https://github.com/shakacode/react_on_rails_rsc/pull/33

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-rsc",
-  "version": "19.2.0-rc.4",
+  "version": "19.2.0",
   "description": "React Server Components support for react_on_rails Ruby gem",
   "exports": {
     "./client": {

--- a/tests/package-runtime-policy.test.ts
+++ b/tests/package-runtime-policy.test.ts
@@ -30,15 +30,15 @@ const collectExportTargets = (value: unknown): string[] => {
 };
 
 describe('19.2 runtime release policy', () => {
-  it('stamps the package and changelog for the 19.2.0 rc line', () => {
+  it('stamps the package and changelog for the 19.2.0 release line', () => {
     const pkg = readJson<PackageJson>('package.json');
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
 
     // Derive the expected version from package.json so a version bump doesn't
     // require editing this test (a hard-coded version here previously blocked
-    // the rc.3 release). Still pins the 19.2.0-rc line and requires the
+    // the rc.3 release). Still pins the 19.2.0 release line and requires the
     // CHANGELOG's top entry to match the package version exactly.
-    expect(pkg.version).toMatch(/^19\.2\.0-rc\.\d+$/);
+    expect(pkg.version).toMatch(/^19\.2\.0(?:-rc\.\d+)?$/);
     const topChangelogVersion = changelog.match(/^## \[([^\]]+)\] - \d{4}-\d{2}-\d{2}$/m)?.[1];
     expect(topChangelogVersion).toBe(pkg.version);
   });


### PR DESCRIPTION
## Summary

- Stamp `CHANGELOG.md` and `package.json` for the stable `19.2.0` release.
- Coalesce the `19.2.0-rc.*` changelog sections into one stable section, keeping only stable-user-facing entries and dropping prerelease/release-process churn.
- Update the 19.2 runtime policy test so the release-line assertion accepts the stable `19.2.0` stamp as well as RC stamps.

## Classification sweep

| PR | Title | Result | Category | Reason |
| --- | --- | --- | --- | --- |
| #97 | Document cross-agent coordination workflow | no-entry | internal | Agent coordination docs only; no package behavior or public API change. |
| #73 | Docs: June 2026 repository improvement audit | no-entry | internal | Repository audit documentation; no runtime, export, or packaging behavior change. |
| #99 | Archive React fork patch history and retire active fork guidance | no-entry | internal | Historical/contributor documentation for the retired fork path; no package behavior change. |
| #98 | Add downstream Pro dummy release gate | no-entry | release-process | Downstream release-gate scaffolding only; no published package behavior change. |
| #101 | Add npm badges and package link to README | no-entry | internal | README badge/link docs only; no behavior change. |
| #100 | Fix downstream E2E Node runtime split | no-entry | internal | Downstream E2E test harness adjustment; no package runtime change. |
| #102 | Prepare 19.2 runtime release line | entry-needed | product code | Moves the package to React 19.2, changes peers/dependencies/exports, and documents migration requirements. |
| #106 | Fix Rspack RSC client runtime discovery for duplicate installs (#105) | entry-needed | product code | Fixes Rspack manifest generation when duplicate installs or symlink stores change the Flight runtime path. |
| #107 | Update CHANGELOG.md for 19.2.0-rc.2 | no-entry | release-process | Prerelease changelog stamping only; stable section absorbs relevant entries. |
| UNKNOWN | Release 19.2.0-rc.2 | no-entry | release-process | Direct release automation commit with no PR; no separate stable changelog entry. |
| #110 | Scope per-client-reference CSS to its containing chunk(s) (#108) | entry-needed | perf-reliability | Fixes generated stylesheet hints to avoid rebroadcasting shared CSS per client reference. |
| #111 | Make main CI green and add a per-chunk CSS scoping regression test | no-entry | internal | Test/CI repair for the CSS scoping work; user-visible behavior is covered by #110. |
| #113 | Recover a client reference's own CSS when SplitChunks splits it from its JS module | entry-needed | product code | Fixes manifest CSS hints for split JS/CSS chunk layouts. |
| #115 | Update CHANGELOG.md for 19.2.0-rc.3 | no-entry | release-process | Prerelease changelog stamping only; stable section absorbs relevant entries. |
| UNKNOWN | Bump version to 19.2.0-rc.3 | no-entry | release-process | Direct version bump commit with no PR; no separate stable changelog entry. |
| #118 | Fix release-blocking version stamp test | no-entry | internal | Test-only release-policy fix; no package behavior change. |
| #122 | Internal docs: CSS association approaches and plugin known problems | no-entry | internal | Internal design notes; no package behavior change. |
| #119 | Docs: explain consuming unreleased RSC builds | no-entry | internal | Documentation for unreleased build consumption; no package behavior change. |
| #120 | Warn when client references span many chunk groups | entry-needed | product code | Adds a configurable client-build warning for cross-page JS/CSS duplication risk. |
| #121 | Add canonical release readiness check | no-entry | release-process | Release metadata/tag/npm readiness helper only; no package behavior change. |
| #123 | Reduce Dependabot PR noise | no-entry | release-process | Dependabot workflow configuration only; no package behavior change. |
| #125 | Consolidate Dependabot dependency updates | no-entry | release-process | Dependabot/dependency maintenance only; no package behavior change. |
| #127 | Bump @arethetypeswrong/cli in the root-minor-patch group | no-entry | release-process | Dev-tool dependency bump only; no package behavior change. |
| #124 | Update CHANGELOG.md and package version for 19.2.0-rc.4 | no-entry | release-process | Prerelease changelog/package stamping only; stable section absorbs relevant entries. |
| #133 | Adopt agent-workflow binstubs | no-entry | internal | Agent workflow wrapper/docs update only; no package behavior change. |

## Validation

- `yarn install --frozen-lockfile`
- `yarn build`
- `yarn jest tests/package-runtime-policy.test.ts`
- `yarn test`
- `RELEASE_CHECK_NPM_RETRY_DELAY=1 yarn release:check`
  - Expected PR-branch result: fails only because release readiness must be checked from `main`.
  - Confirmed metadata: `react-on-rails-rsc@19.2.0`, npm tag `latest`, 22 release-note lines.
  - Confirmed tag/npm state: local tag unused, origin tag unused, npm version unpublished; current dist-tags are `latest: 19.0.5`, `next: 19.2.0-rc.4`.

After this PR merges to `main`, rerun `yarn release:check` from clean synced `main` and dispatch the printed `Release package` workflow command.
