### PR TITLE
Add static RSC island diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this package will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added opt-in client-reference diagnostics that emit RSC client reference chunk files and byte sizes for static island performance audits. ([#144])
+- Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
 ## [19.2.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added opt-in client-reference diagnostics that emit RSC client reference chunk files and byte sizes for static island performance audits. ([#144])
+
 ## [19.2.0] - 2026-06-28
 
 ### Breaking Changes
@@ -52,6 +55,7 @@ All notable changes to this package will be documented in this file.
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
+[#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -38,9 +38,9 @@ the bundler exposes them:
   "totalChunkBytes": 1234,
   "clientReferences": [
     {
-      "file": "/absolute/path/to/TinyIsland.js",
-      "id": "/absolute/path/to/TinyIsland.js#default",
-      "name": "",
+      "file": "file:///absolute/path/to/TinyIsland.js",
+      "id": "./TinyIsland.js",
+      "name": "*",
       "chunks": [
         {
           "id": "client-TinyIsland-js",

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -1,0 +1,120 @@
+# RSC Static Island Diagnostics
+
+Use this guide when a public or mostly static RSC page should prove which client
+reference chunks it can load before introducing route-scoped manifest behavior.
+The current plugin model still emits one client manifest per build. It does not
+automatically infer per-page or per-route manifests.
+
+## Emit Diagnostics
+
+Enable the optional diagnostics asset on the client build:
+
+```js
+new RSCWebpackPlugin({
+  isServer: false,
+  clientReferenceDiagnosticsFilename: 'rsc-client-reference-diagnostics.json',
+});
+```
+
+Rspack uses the same option:
+
+```js
+new RSCRspackPlugin({
+  isServer: false,
+  clientReferenceDiagnosticsFilename: 'rsc-client-reference-diagnostics.json',
+});
+```
+
+The emitted JSON reports the client references recorded in the manifest, the JS
+chunk files attached to each reference, and byte sizes for emitted assets when
+the bundler exposes them:
+
+```json
+{
+  "version": 1,
+  "manifestFilename": "react-client-manifest.json",
+  "isServer": false,
+  "clientReferenceCount": 1,
+  "totalChunkBytes": 1234,
+  "clientReferences": [
+    {
+      "file": "/absolute/path/to/TinyIsland.js",
+      "id": "/absolute/path/to/TinyIsland.js#default",
+      "name": "",
+      "chunks": [
+        {
+          "id": "client-TinyIsland-js",
+          "file": "client-TinyIsland-js.chunk.js",
+          "bytes": 1234
+        }
+      ],
+      "totalBytes": 1234
+    }
+  ]
+}
+```
+
+`bytes` is `null` only when the bundler does not expose the asset source during
+manifest emission. `totalChunkBytes` counts each emitted JS chunk file once even
+when multiple client references share that chunk.
+
+## Static Page Patterns
+
+For a server-only static RSC entry, use an explicit empty client reference list
+for that build:
+
+```js
+new RSCWebpackPlugin({
+  isServer: false,
+  clientReferences: [],
+  clientReferenceDiagnosticsFilename: 'rsc-client-reference-diagnostics.json',
+});
+```
+
+This produces an empty client manifest and an empty diagnostics file. Use it only
+for a build target that cannot render client components. Do not apply
+`clientReferences: []` to a mixed RSC app; any page that renders a client
+component will miss the client reference metadata it needs at runtime.
+
+For a static page with one or two small islands, isolate the static build and
+declare only the island files that the public page may render:
+
+```js
+new RSCWebpackPlugin({
+  isServer: false,
+  clientReferences: [
+    {
+      directory: './app/public-rsc',
+      recursive: false,
+      include: /TinyIsland\.(js|jsx|ts|tsx)$/,
+    },
+  ],
+  clientReferenceDiagnosticsFilename: 'rsc-client-reference-diagnostics.json',
+});
+```
+
+The same descriptor shape is supported by `RSCRspackPlugin`. Keep the static page
+entry separate from the normal authenticated app entry when the app entry imports
+large global vendors, analytics, or dashboard-only clients. The diagnostics file
+then gives a direct audit trail for whether the tiny island pulls only its own
+chunk or also pulls an unexpected vendor chunk through an import.
+
+If an island imports a heavy dependency, the diagnostics file will show that
+dependency through the emitted chunk files and byte totals. Remove or defer the
+import in the island itself; the diagnostics option only reports what the build
+emitted and does not rewrite the module graph.
+
+## Boundaries
+
+This diagnostics slice is intentionally narrow:
+
+- It does not create route-scoped or page-scoped manifests.
+- It does not discover the exact client references rendered by a specific RSC
+  page.
+- It does not eliminate vendor chunks automatically.
+- It does not solve the broader dependency and manifest scoping work tracked
+  outside this page.
+
+Use the diagnostics output to decide whether an explicit static-page build is
+acceptable today, or whether the app needs the broader manifest-scoping product
+decision before treating static RSC pages as performance-isolated.

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -55,8 +55,8 @@ the bundler exposes them:
 ```
 
 `bytes` is `null` only when the bundler does not expose the asset source during
-manifest emission. `totalChunkBytes` counts each emitted JS chunk file once even
-when multiple client references share that chunk.
+manifest emission. `totalChunkBytes` counts each emitted JS or CSS asset file
+once even when multiple client references share that asset.
 
 ## Static Page Patterns
 

--- a/src/WebpackPlugin.ts
+++ b/src/WebpackPlugin.ts
@@ -21,6 +21,7 @@ export type Options = {
   chunkGroupWarningThreshold?: number | false,
   clientManifestFilename?: string,
   serverConsumerManifestFilename?: string,
+  clientReferenceDiagnosticsFilename?: string | false,
 };
 
 export class RSCWebpackPlugin {

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -784,11 +784,18 @@ function getCompilationAssetSize(
   file: string,
   publicPath: string,
 ): number | null {
-  const candidates = new Set([file]);
+  const candidates = new Set<string>();
+  const addCandidate = (candidate: string): void => {
+    candidates.add(candidate);
+    if (candidate.startsWith('/')) {
+      candidates.add(candidate.slice(1));
+    }
+  };
+
+  addCandidate(file);
   if (publicPath && publicPath !== 'auto' && file.startsWith(publicPath)) {
-    candidates.add(file.slice(publicPath.length));
+    addCandidate(file.slice(publicPath.length));
   }
-  if (file.startsWith('/')) candidates.add(file.slice(1));
 
   for (const candidate of candidates) {
     const source = compilation.getAsset?.(candidate)?.source ?? compilation.assets?.[candidate];

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -128,6 +128,12 @@ type AnyChunk = {
   canBeInitial?: () => boolean;
 };
 
+type ModuleMetadata = {
+  id: string | number | null;
+  chunks: (string | number | null)[];
+  name: string;
+};
+
 type Bundler = {
   sources: { RawSource: new (source: string, convertToString?: boolean) => unknown };
   Compilation: { PROCESS_ASSETS_STAGE_REPORT: number };
@@ -376,13 +382,19 @@ export class RSCRspackPlugin {
           } else {
             logger?.debug(`Resolved ${resolvedClientCount} RSC client reference(s)`);
           }
-          const manifest = this.buildManifest(compilation, bundler);
+          const diagnosticsCssFiles = new Map<string, string[]>();
+          const manifest = this.buildManifest(compilation, bundler, diagnosticsCssFiles);
           logger?.debug(
             `Emitting ${manifestFilename} with ` +
               `${Object.keys(manifest.filePathToModuleMetadata).length} entries`,
           );
           if (typeof this.options.clientReferenceDiagnosticsFilename === 'string') {
-            const diagnostics = this.buildDiagnostics(compilation, manifest, manifestFilename);
+            const diagnostics = this.buildDiagnostics(
+              compilation,
+              manifest,
+              manifestFilename,
+              diagnosticsCssFiles,
+            );
             compilation.emitAsset(
               this.options.clientReferenceDiagnosticsFilename,
               new bundler.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false),
@@ -550,9 +562,10 @@ export class RSCRspackPlugin {
   private buildManifest(
     compilation: AnyCompilation,
     bundler: Bundler,
+    diagnosticsCssFiles: Map<string, string[]>,
   ): {
     moduleLoading: { prefix: string; crossOrigin: string | null };
-    filePathToModuleMetadata: Record<string, { id: string | number | null; chunks: (string | number | null)[]; name: string }>;
+    filePathToModuleMetadata: Record<string, ModuleMetadata>;
   } {
     // Check if the client runtime module was found in this compilation.
     // The webpack plugin emits a warning and skips manifest emission if
@@ -568,17 +581,22 @@ export class RSCRspackPlugin {
     const resolvedClientFiles = new Set(this._resolvedClientFiles ?? []);
     const initialChunks = this.getInitialChunks(compilation);
 
-    const filePathToModuleMetadata: Record<
-      string,
-      { id: string | number | null; chunks: (string | number | null)[]; name: string }
-    > = {};
+    const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
+    let cssPrefix =
+      typeof compilation.outputOptions.publicPath === 'string' &&
+      compilation.outputOptions.publicPath !== 'auto'
+        ? compilation.outputOptions.publicPath
+        : null;
+    if (cssPrefix && !cssPrefix.endsWith('/')) {
+      cssPrefix += '/';
+    }
 
     // Walk chunk groups using group-level chunks (matching the webpack
     // plugin, lines 241-294). Each module gets the full list of sibling
     // chunks in its group — this ensures splitChunks dependencies are
     // included.
     for (const chunkGroup of compilation.chunkGroups) {
-      const groupChunks = this.getGroupChunks(chunkGroup, initialChunks);
+      const groupAssets = this.getGroupAssets(chunkGroup, initialChunks, cssPrefix);
 
       for (const chunkUnknown of chunkGroup.chunks) {
         const chunk = chunkUnknown as AnyChunk;
@@ -588,11 +606,27 @@ export class RSCRspackPlugin {
           if (isRuntimeResource(mod.resource, this.options.isServer)) clientFileNameFound = true;
 
           const moduleId = compilation.chunkGraph.getModuleId(mod);
-          this.recordModule(mod, moduleId, groupChunks, resolvedClientFiles, filePathToModuleMetadata);
+          this.recordModule(
+            mod,
+            moduleId,
+            groupAssets.chunks,
+            groupAssets.css,
+            resolvedClientFiles,
+            filePathToModuleMetadata,
+            diagnosticsCssFiles,
+          );
           if (mod.modules) {
             for (const inner of mod.modules) {
               if (isRuntimeResource(inner.resource, this.options.isServer)) clientFileNameFound = true;
-              this.recordModule(inner, moduleId, groupChunks, resolvedClientFiles, filePathToModuleMetadata);
+              this.recordModule(
+                inner,
+                moduleId,
+                groupAssets.chunks,
+                groupAssets.css,
+                resolvedClientFiles,
+                filePathToModuleMetadata,
+                diagnosticsCssFiles,
+              );
             }
           }
         }
@@ -634,12 +668,10 @@ export class RSCRspackPlugin {
     compilation: AnyCompilation,
     manifest: {
       moduleLoading: { prefix: string; crossOrigin: string | null };
-      filePathToModuleMetadata: Record<
-        string,
-        { id: string | number | null; chunks: (string | number | null)[]; name: string }
-      >;
+      filePathToModuleMetadata: Record<string, ModuleMetadata>;
     },
     manifestFilename: string,
+    diagnosticsCssFiles: ReadonlyMap<string, string[]>,
   ): {
     version: 1;
     manifestFilename: string;
@@ -652,6 +684,7 @@ export class RSCRspackPlugin {
       name: string;
       totalBytes: number;
       chunks: Array<{ id: string | number | null; file: string; bytes: number | null }>;
+      css?: Array<{ file: string; bytes: number | null }>;
     }>;
   } {
     const clientReferences = Object.entries(manifest.filePathToModuleMetadata)
@@ -666,13 +699,25 @@ export class RSCRspackPlugin {
             bytes: getCompilationAssetSize(compilation, chunkFile, manifest.moduleLoading.prefix),
           });
         }
-        const totalBytes = chunks.reduce((sum, entry) => sum + (entry.bytes ?? 0), 0);
+        const cssFiles = diagnosticsCssFiles.get(file);
+        const css =
+          cssFiles && cssFiles.length > 0
+            ? cssFiles.map((fileName) => ({
+                file: fileName,
+                bytes: getCompilationAssetSize(compilation, fileName, manifest.moduleLoading.prefix),
+              }))
+            : undefined;
+        const totalBytes = [...chunks, ...(css || [])].reduce(
+          (sum, entry) => sum + (entry.bytes ?? 0),
+          0,
+        );
         return {
           file,
           id: metadata.id,
           name: metadata.name,
           totalBytes,
           chunks,
+          ...(css ? { css } : {}),
         };
       });
 
@@ -690,23 +735,29 @@ export class RSCRspackPlugin {
   private _resolvedClientFiles: string[] = [];
 
   /** Build the chunks array from all async-loadable chunks in a chunk group. */
-  private getGroupChunks(
+  private getGroupAssets(
     chunkGroup: AnyChunkGroup,
     initialChunks: Set<unknown>,
-  ): (string | number | null)[] {
+    cssPrefix: string | null,
+  ): { chunks: (string | number | null)[]; css: string[] } {
     const chunks: (string | number | null)[] = [];
+    const css: string[] = [];
     for (const chunkUnknown of chunkGroup.chunks) {
       const c = chunkUnknown as AnyChunk;
       if (this.isInitialChunk(c, initialChunks)) continue;
       const files = c.files instanceof Set ? c.files : new Set(c.files);
+      let recordedJs = false;
       for (const file of files) {
-        if (!file.endsWith('.js')) continue;
-        if (file.endsWith('.hot-update.js')) continue;
+        if (file.endsWith('.css') && !file.endsWith('.hot-update.css') && cssPrefix !== null) {
+          css.push(cssPrefix + file);
+          continue;
+        }
+        if (recordedJs || !file.endsWith('.js') || file.endsWith('.hot-update.js')) continue;
         chunks.push(c.id, file);
-        break;
+        recordedJs = true;
       }
     }
-    return chunks;
+    return { chunks, css };
   }
 
   private getInitialChunks(compilation: AnyCompilation): Set<unknown> {
@@ -736,8 +787,10 @@ export class RSCRspackPlugin {
     module: AnyModule,
     moduleId: string | number | null,
     chunks: (string | number | null)[],
+    css: string[],
     resolvedClientFiles: Set<string>,
-    filePathToModuleMetadata: Record<string, { id: string | number | null; chunks: (string | number | null)[]; name: string }>,
+    filePathToModuleMetadata: Record<string, ModuleMetadata>,
+    diagnosticsCssFiles: Map<string, string[]>,
   ): void {
     if (!module.resource) return;
     if (!resolvedClientFiles.has(module.resource)) return;
@@ -752,25 +805,41 @@ export class RSCRspackPlugin {
       for (let i = 0; i < chunks.length; i += 2) {
         if (!seen.has(chunks[i]!)) existing.chunks.push(chunks[i]!, chunks[i + 1]!);
       }
+      this.recordDiagnosticsCssFiles(href, css, diagnosticsCssFiles);
     } else {
       filePathToModuleMetadata[href] = {
         id: moduleId,
         chunks: chunks.slice(),
         name: '*',
       };
+      this.recordDiagnosticsCssFiles(href, css, diagnosticsCssFiles);
     }
+  }
+
+  private recordDiagnosticsCssFiles(
+    href: string,
+    css: string[],
+    diagnosticsCssFiles: Map<string, string[]>,
+  ): void {
+    if (css.length === 0) return;
+    const existing = diagnosticsCssFiles.get(href) ?? [];
+    for (const cssFile of css) {
+      if (!existing.includes(cssFile)) existing.push(cssFile);
+    }
+    diagnosticsCssFiles.set(href, existing);
   }
 }
 
 function sumUniqueKnownBytes(
   clientReferences: Array<{
     chunks: Array<{ file: string; bytes: number | null }>;
+    css?: Array<{ file: string; bytes: number | null }>;
   }>,
 ): number {
   const seen = new Set<string>();
   let total = 0;
   for (const reference of clientReferences) {
-    for (const chunk of reference.chunks) {
+    for (const chunk of [...reference.chunks, ...(reference.css ?? [])]) {
       if (chunk.bytes === null || seen.has(chunk.file)) continue;
       seen.add(chunk.file);
       total += chunk.bytes;

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -94,9 +94,16 @@ type AnyCompilation = {
   };
   entrypoints?: ReadonlyMap<string, AnyEntrypoint>;
   emitAsset(filename: string, source: unknown): void;
+  assets?: Record<string, AssetSource>;
+  getAsset?: (filename: string) => { source?: AssetSource } | undefined;
   warnings: unknown[];
   compiler: AnyCompiler;
   getLogger?(name: string): AnyLogger;
+};
+
+type AssetSource = {
+  size?: () => number;
+  source?: () => string | Buffer;
 };
 
 // Helper to read/write our private Symbol key on the compilation. Using a
@@ -177,6 +184,11 @@ export interface Options {
    * file path). Default: `"client[index]"`.
    */
   chunkName?: string;
+  /**
+   * Optional diagnostics asset that lists client references, their emitted
+   * chunk files, and known emitted asset byte sizes. Disabled by default.
+   */
+  clientReferenceDiagnosticsFilename?: string | false;
 }
 
 // Default loader rule — applied to all JS/TS files so our directive detector
@@ -369,6 +381,13 @@ export class RSCRspackPlugin {
             `Emitting ${manifestFilename} with ` +
               `${Object.keys(manifest.filePathToModuleMetadata).length} entries`,
           );
+          if (typeof this.options.clientReferenceDiagnosticsFilename === 'string') {
+            const diagnostics = this.buildDiagnostics(compilation, manifest, manifestFilename);
+            compilation.emitAsset(
+              this.options.clientReferenceDiagnosticsFilename,
+              new bundler.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false),
+            );
+          }
           compilation.emitAsset(
             manifestFilename,
             new bundler.sources.RawSource(JSON.stringify(manifest, null, 2), false),
@@ -611,6 +630,62 @@ export class RSCRspackPlugin {
     };
   }
 
+  private buildDiagnostics(
+    compilation: AnyCompilation,
+    manifest: {
+      moduleLoading: { prefix: string; crossOrigin: string | null };
+      filePathToModuleMetadata: Record<
+        string,
+        { id: string | number | null; chunks: (string | number | null)[]; name: string }
+      >;
+    },
+    manifestFilename: string,
+  ): {
+    version: 1;
+    manifestFilename: string;
+    isServer: boolean;
+    clientReferenceCount: number;
+    totalChunkBytes: number;
+    clientReferences: Array<{
+      file: string;
+      id: string | number | null;
+      name: string;
+      totalBytes: number;
+      chunks: Array<{ id: string | number | null; file: string; bytes: number | null }>;
+    }>;
+  } {
+    const clientReferences = Object.entries(manifest.filePathToModuleMetadata)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([file, metadata]) => {
+        const chunks = [];
+        for (let i = 0; i < metadata.chunks.length; i += 2) {
+          const chunkFile = String(metadata.chunks[i + 1]);
+          chunks.push({
+            id: metadata.chunks[i] ?? null,
+            file: chunkFile,
+            bytes: getCompilationAssetSize(compilation, chunkFile, manifest.moduleLoading.prefix),
+          });
+        }
+        const totalBytes = chunks.reduce((sum, entry) => sum + (entry.bytes ?? 0), 0);
+        return {
+          file,
+          id: metadata.id,
+          name: metadata.name,
+          totalBytes,
+          chunks,
+        };
+      });
+
+    return {
+      version: 1,
+      manifestFilename,
+      isServer: this.options.isServer,
+      clientReferenceCount: clientReferences.length,
+      totalChunkBytes: sumUniqueKnownBytes(clientReferences),
+      clientReferences,
+    };
+  }
+
   /** Stash resolved client files so buildManifest can filter by them. */
   private _resolvedClientFiles: string[] = [];
 
@@ -685,6 +760,55 @@ export class RSCRspackPlugin {
       };
     }
   }
+}
+
+function sumUniqueKnownBytes(
+  clientReferences: Array<{
+    chunks: Array<{ file: string; bytes: number | null }>;
+  }>,
+): number {
+  const seen = new Set<string>();
+  let total = 0;
+  for (const reference of clientReferences) {
+    for (const chunk of reference.chunks) {
+      if (chunk.bytes === null || seen.has(chunk.file)) continue;
+      seen.add(chunk.file);
+      total += chunk.bytes;
+    }
+  }
+  return total;
+}
+
+function getCompilationAssetSize(
+  compilation: AnyCompilation,
+  file: string,
+  publicPath: string,
+): number | null {
+  const candidates = new Set([file]);
+  if (publicPath && publicPath !== 'auto' && file.startsWith(publicPath)) {
+    candidates.add(file.slice(publicPath.length));
+  }
+  if (file.startsWith('/')) candidates.add(file.slice(1));
+
+  for (const candidate of candidates) {
+    const source = compilation.getAsset?.(candidate)?.source ?? compilation.assets?.[candidate];
+    const size = getSourceSize(source);
+    if (size !== null) return size;
+  }
+  return null;
+}
+
+function getSourceSize(source: AssetSource | undefined): number | null {
+  if (!source) return null;
+  if (typeof source.size === 'function') {
+    const size = source.size();
+    return Number.isFinite(size) ? size : null;
+  }
+  if (typeof source.source === 'function') {
+    const value = source.source();
+    return typeof value === 'string' ? Buffer.byteLength(value) : value.length;
+  }
+  return null;
 }
 
 // Also export as default to match how `WebpackPlugin` is imported elsewhere.

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -157,6 +157,7 @@ export type Options = {
   chunkGroupWarningThreshold?: number | false;
   clientManifestFilename?: string;
   serverConsumerManifestFilename?: string;
+  clientReferenceDiagnosticsFilename?: string | false;
 };
 
 const DEFAULT_CHUNK_GROUP_WARNING_THRESHOLD = 4;
@@ -193,6 +194,31 @@ type ModuleMetadata = {
   chunks: (string | number | null)[];
   css: string[] | null;
   name: string;
+};
+
+type AssetSource = {
+  size?: () => number;
+  source?: () => string | Buffer;
+};
+
+type FlightAsset = {
+  source?: AssetSource;
+};
+
+type ClientReferenceDiagnostics = {
+  version: 1;
+  manifestFilename: string;
+  isServer: boolean;
+  clientReferenceCount: number;
+  totalChunkBytes: number;
+  clientReferences: Array<{
+    file: string;
+    id: string | number | null;
+    name: string;
+    totalBytes: number;
+    chunks: Array<{ id: string | number | null; file: string; bytes: number | null }>;
+    css?: Array<{ file: string; bytes: number | null }>;
+  }>;
 };
 
 /**
@@ -252,6 +278,8 @@ type FlightCompilation = {
       module: FlightModule,
     ): Iterable<{ module?: FlightModule | null; resolvedModule?: FlightModule | null }>;
   };
+  assets?: Record<string, AssetSource>;
+  getAsset?: (filename: string) => FlightAsset | undefined;
   hooks: {
     processAssets: {
       tap(options: { name: string; stage: number }, fn: () => void): void;
@@ -359,6 +387,8 @@ export class RSCWebpackPlugin {
    */
   readonly serverConsumerManifestFilename: string;
 
+  readonly clientReferenceDiagnosticsFilename: string | false | undefined;
+
   static __internal_isReactOnRailsRSCRuntimeResource = isReactOnRailsRSCRuntimeResource;
 
   constructor(options: Options) {
@@ -403,6 +433,7 @@ export class RSCWebpackPlugin {
       options.clientManifestFilename || defaultClientManifestFilename;
     this.serverConsumerManifestFilename =
       options.serverConsumerManifestFilename || 'react-ssr-manifest.json';
+    this.clientReferenceDiagnosticsFilename = options.clientReferenceDiagnosticsFilename;
   }
 
   apply(compiler: webpack.Compiler): void {
@@ -896,6 +927,14 @@ export class RSCWebpackPlugin {
             }
           }
 
+          if (typeof this.clientReferenceDiagnosticsFilename === 'string') {
+            const diagnostics = this.buildDiagnostics(compilation, manifest);
+            compilation.emitAsset(
+              this.clientReferenceDiagnosticsFilename,
+              new webpack.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false),
+            );
+          }
+
           compilation.emitAsset(
             this.clientManifestFilename,
             new webpack.sources.RawSource(JSON.stringify(manifest, null, 2), false),
@@ -903,6 +942,58 @@ export class RSCWebpackPlugin {
         },
       );
     });
+  }
+
+  private buildDiagnostics(
+    compilation: FlightCompilation,
+    manifest: {
+      moduleLoading: { prefix: string; crossOrigin: string | null };
+      filePathToModuleMetadata: Record<string, ModuleMetadata>;
+    },
+  ): ClientReferenceDiagnostics {
+    const clientReferences = Object.entries(manifest.filePathToModuleMetadata)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([file, metadata]) => {
+        const chunks = [];
+        for (let i = 0; i < metadata.chunks.length; i += 2) {
+          const chunkFile = String(metadata.chunks[i + 1]);
+          chunks.push({
+            id: metadata.chunks[i] ?? null,
+            file: chunkFile,
+            bytes: getCompilationAssetSize(compilation, chunkFile, manifest.moduleLoading.prefix),
+          });
+        }
+
+        const css =
+          metadata.css && metadata.css.length > 0
+            ? metadata.css.map((fileName) => ({
+                file: fileName,
+                bytes: getCompilationAssetSize(compilation, fileName, manifest.moduleLoading.prefix),
+              }))
+            : undefined;
+        const totalBytes = [...chunks, ...(css || [])].reduce(
+          (sum, entry) => sum + (entry.bytes ?? 0),
+          0,
+        );
+
+        return {
+          file,
+          id: metadata.id,
+          name: metadata.name,
+          totalBytes,
+          chunks,
+          ...(css ? { css } : {}),
+        };
+      });
+
+    return {
+      version: 1,
+      manifestFilename: this.clientManifestFilename,
+      isServer: this.isServer,
+      clientReferenceCount: clientReferences.length,
+      totalChunkBytes: sumUniqueKnownBytes(clientReferences),
+      clientReferences,
+    };
   }
 
   /**
@@ -993,6 +1084,53 @@ export class RSCWebpackPlugin {
       },
     );
   }
+}
+
+function sumUniqueKnownBytes(
+  clientReferences: ClientReferenceDiagnostics['clientReferences'],
+): number {
+  const seen = new Set<string>();
+  let total = 0;
+  for (const reference of clientReferences) {
+    for (const chunk of reference.chunks) {
+      if (chunk.bytes === null || seen.has(chunk.file)) continue;
+      seen.add(chunk.file);
+      total += chunk.bytes;
+    }
+  }
+  return total;
+}
+
+function getCompilationAssetSize(
+  compilation: FlightCompilation,
+  file: string,
+  publicPath: string,
+): number | null {
+  const candidates = new Set([file]);
+  if (publicPath && publicPath !== 'auto' && file.startsWith(publicPath)) {
+    candidates.add(file.slice(publicPath.length));
+  }
+  if (file.startsWith('/')) candidates.add(file.slice(1));
+
+  for (const candidate of candidates) {
+    const source = compilation.getAsset?.(candidate)?.source ?? compilation.assets?.[candidate];
+    const size = getSourceSize(source);
+    if (size !== null) return size;
+  }
+  return null;
+}
+
+function getSourceSize(source: AssetSource | undefined): number | null {
+  if (!source) return null;
+  if (typeof source.size === 'function') {
+    const size = source.size();
+    return Number.isFinite(size) ? size : null;
+  }
+  if (typeof source.source === 'function') {
+    const value = source.source();
+    return typeof value === 'string' ? Buffer.byteLength(value) : value.length;
+  }
+  return null;
 }
 
 export default RSCWebpackPlugin;

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -1106,11 +1106,18 @@ function getCompilationAssetSize(
   file: string,
   publicPath: string,
 ): number | null {
-  const candidates = new Set([file]);
+  const candidates = new Set<string>();
+  const addCandidate = (candidate: string): void => {
+    candidates.add(candidate);
+    if (candidate.startsWith('/')) {
+      candidates.add(candidate.slice(1));
+    }
+  };
+
+  addCandidate(file);
   if (publicPath && publicPath !== 'auto' && file.startsWith(publicPath)) {
-    candidates.add(file.slice(publicPath.length));
+    addCandidate(file.slice(publicPath.length));
   }
-  if (file.startsWith('/')) candidates.add(file.slice(1));
 
   for (const candidate of candidates) {
     const source = compilation.getAsset?.(candidate)?.source ?? compilation.assets?.[candidate];

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -1092,7 +1092,7 @@ function sumUniqueKnownBytes(
   const seen = new Set<string>();
   let total = 0;
   for (const reference of clientReferences) {
-    for (const chunk of reference.chunks) {
+    for (const chunk of [...reference.chunks, ...(reference.css ?? [])]) {
       if (chunk.bytes === null || seen.has(chunk.file)) continue;
       seen.add(chunk.file);
       total += chunk.bytes;

--- a/tests/rspack-plugin/fixtures/static-islands/HeavyIsland.js
+++ b/tests/rspack-plugin/fixtures/static-islands/HeavyIsland.js
@@ -1,0 +1,7 @@
+'use client';
+
+import { heavyValue } from './heavy-vendor';
+
+export default function HeavyIsland() {
+  return `heavy interactive island:${heavyValue.length}`;
+}

--- a/tests/rspack-plugin/fixtures/static-islands/StyledIsland.css
+++ b/tests/rspack-plugin/fixtures/static-islands/StyledIsland.css
@@ -1,0 +1,3 @@
+.styled-island {
+  color: rebeccapurple;
+}

--- a/tests/rspack-plugin/fixtures/static-islands/StyledIsland.js
+++ b/tests/rspack-plugin/fixtures/static-islands/StyledIsland.js
@@ -1,0 +1,7 @@
+'use client';
+
+import './StyledIsland.css';
+
+export default function StyledIsland() {
+  return 'styled interactive island';
+}

--- a/tests/rspack-plugin/fixtures/static-islands/TinyIsland.js
+++ b/tests/rspack-plugin/fixtures/static-islands/TinyIsland.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function TinyIsland() {
+  return 'tiny interactive island';
+}

--- a/tests/rspack-plugin/fixtures/static-islands/app-vendor.js
+++ b/tests/rspack-plugin/fixtures/static-islands/app-vendor.js
@@ -1,0 +1,1 @@
+export const appVendorLabel = 'large app shell vendor loaded by the page entry';

--- a/tests/rspack-plugin/fixtures/static-islands/heavy-vendor.js
+++ b/tests/rspack-plugin/fixtures/static-islands/heavy-vendor.js
@@ -1,0 +1,3 @@
+export const heavyValue =
+  'heavy-client-dependency:' +
+  '0123456789abcdefghijklmnopqrstuvwxyz'.repeat(256);

--- a/tests/rspack-plugin/fixtures/static-islands/index.js
+++ b/tests/rspack-plugin/fixtures/static-islands/index.js
@@ -1,0 +1,5 @@
+import { appVendorLabel } from './app-vendor';
+
+export default function renderStaticPage() {
+  return `static page:${appVendorLabel}`;
+}

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -19,6 +19,7 @@ const FIXTURES_ROOT = path.resolve(__dirname, '../fixtures');
 export interface CompileOptions {
   isServer?: boolean;
   clientManifestFilename?: string;
+  clientReferenceDiagnosticsFilename?: string | false;
   publicPath?: string;
   crossOriginLoading?: false | 'anonymous' | 'use-credentials';
   clientReferences?: unknown;
@@ -36,6 +37,21 @@ export interface CompileResult {
   };
   manifestSource: string;
   manifestPath: string;
+  clientReferenceDiagnostics?: {
+    version: 1;
+    manifestFilename: string;
+    isServer: boolean;
+    clientReferenceCount: number;
+    totalChunkBytes: number;
+    clientReferences: Array<{
+      file: string;
+      id: string | number | null;
+      name: string;
+      totalBytes: number;
+      chunks: Array<{ id: string | number | null; file: string; bytes: number | null }>;
+    }>;
+  };
+  clientReferenceDiagnosticsSource?: string;
   assets: string[];
   outputPath: string;
 }
@@ -55,10 +71,11 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     outputPath,
     isServer: options.isServer ?? false,
     clientManifestFilename: options.clientManifestFilename,
+    clientReferenceDiagnosticsFilename: options.clientReferenceDiagnosticsFilename,
     clientReferences: serializeForRunner(options.clientReferences),
     publicPath: options.publicPath,
     crossOriginLoading: options.crossOriginLoading,
-    configExtra: options.configExtra ?? {},
+    configExtra: serializeForRunner(options.configExtra ?? {}),
   };
   const argsFile = path.join(outputPath, '__args__.json');
   fs.writeFileSync(argsFile, JSON.stringify(runnerArgs));
@@ -98,11 +115,23 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
   }
   const manifestSource = fs.readFileSync(manifestPath, 'utf8');
   const manifest = JSON.parse(manifestSource) as CompileResult['manifest'];
+  const diagnosticsFilename = options.clientReferenceDiagnosticsFilename;
+  const diagnosticsPath =
+    typeof diagnosticsFilename === 'string' ? path.join(outputPath, diagnosticsFilename) : undefined;
+  const clientReferenceDiagnosticsSource =
+    diagnosticsPath && fs.existsSync(diagnosticsPath)
+      ? fs.readFileSync(diagnosticsPath, 'utf8')
+      : undefined;
+  const clientReferenceDiagnostics = clientReferenceDiagnosticsSource
+    ? (JSON.parse(clientReferenceDiagnosticsSource) as CompileResult['clientReferenceDiagnostics'])
+    : undefined;
 
   return {
     manifest,
     manifestSource,
     manifestPath,
+    clientReferenceDiagnostics,
+    clientReferenceDiagnosticsSource,
     assets: result.assets ?? [],
     outputPath,
   };

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -23,6 +23,7 @@ export interface CompileOptions {
   publicPath?: string;
   crossOriginLoading?: false | 'anonymous' | 'use-credentials';
   clientReferences?: unknown;
+  withCss?: boolean;
   /** Additional rspack config to merge. Use sparingly. */
   configExtra?: Record<string, unknown>;
 }
@@ -49,6 +50,7 @@ export interface CompileResult {
       name: string;
       totalBytes: number;
       chunks: Array<{ id: string | number | null; file: string; bytes: number | null }>;
+      css?: Array<{ file: string; bytes: number | null }>;
     }>;
   };
   clientReferenceDiagnosticsSource?: string;
@@ -75,6 +77,7 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     clientReferences: serializeForRunner(options.clientReferences),
     publicPath: options.publicPath,
     crossOriginLoading: options.crossOriginLoading,
+    withCss: options.withCss,
     configExtra: serializeForRunner(options.configExtra ?? {}),
   };
   const argsFile = path.join(outputPath, '__args__.json');

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -11,6 +11,7 @@
  *     outputPath: string,
  *     isServer: boolean,
  *     clientManifestFilename?: string,
+ *     clientReferenceDiagnosticsFilename?: string|false,
  *     clientReferences?: unknown,
  *     publicPath?: string,
  *     crossOriginLoading?: false|'anonymous'|'use-credentials',
@@ -41,6 +42,7 @@ const {
   outputPath,
   isServer,
   clientManifestFilename,
+  clientReferenceDiagnosticsFilename,
   clientReferences: rawClientReferences,
   publicPath,
   crossOriginLoading,
@@ -69,6 +71,7 @@ if (missingRuntimeEntries.length > 0) {
 }
 const runtimeEntry = isServer ? runtimeEntries.server : runtimeEntries.client;
 const clientReferences = reviveFromRunner(rawClientReferences);
+const revivedConfigExtra = reviveFromRunner(configExtra);
 
 const config = {
   mode: 'development',
@@ -92,10 +95,11 @@ const config = {
     new RSCRspackPlugin({
       isServer: isServer,
       clientManifestFilename: clientManifestFilename,
+      clientReferenceDiagnosticsFilename: clientReferenceDiagnosticsFilename,
       clientReferences: clientReferences,
     }),
   ],
-  ...(configExtra || {}),
+  ...(revivedConfigExtra || {}),
 };
 
 rspack(config, (err, stats) => {

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -15,6 +15,7 @@
  *     clientReferences?: unknown,
  *     publicPath?: string,
  *     crossOriginLoading?: false|'anonymous'|'use-credentials',
+ *     withCss?: boolean,
  *     configExtra?: object,
  *   }
  *
@@ -46,6 +47,7 @@ const {
   clientReferences: rawClientReferences,
   publicPath,
   crossOriginLoading,
+  withCss,
   configExtra,
 } = args;
 
@@ -72,6 +74,22 @@ if (missingRuntimeEntries.length > 0) {
 const runtimeEntry = isServer ? runtimeEntries.server : runtimeEntries.client;
 const clientReferences = reviveFromRunner(rawClientReferences);
 const revivedConfigExtra = reviveFromRunner(configExtra);
+const plugins = [
+  new RSCRspackPlugin({
+    isServer: isServer,
+    clientManifestFilename: clientManifestFilename,
+    clientReferenceDiagnosticsFilename: clientReferenceDiagnosticsFilename,
+    clientReferences: clientReferences,
+  }),
+];
+if (withCss) {
+  plugins.push(
+    new rspack.CssExtractRspackPlugin({
+      filename: '[name].css',
+      chunkFilename: '[name].chunk.css',
+    }),
+  );
+}
 
 const config = {
   mode: 'development',
@@ -91,14 +109,14 @@ const config = {
     minimize: false,
   },
   devtool: false,
-  plugins: [
-    new RSCRspackPlugin({
-      isServer: isServer,
-      clientManifestFilename: clientManifestFilename,
-      clientReferenceDiagnosticsFilename: clientReferenceDiagnosticsFilename,
-      clientReferences: clientReferences,
-    }),
-  ],
+  ...(withCss
+    ? {
+        module: {
+          rules: [{ test: /\.css$/, use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'] }],
+        },
+      }
+    : {}),
+  plugins,
   ...(revivedConfigExtra || {}),
 };
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -26,6 +26,33 @@ type ManifestChunks =
 const manifestChunkFiles = (chunks: ManifestChunks): string[] =>
   chunks.filter((_chunk, index) => index % 2 === 1).map(String);
 
+const staticIslandClientReferences = (include: RegExp) => [
+  { directory: '.', recursive: false, include },
+];
+
+const splitStaticIslandVendors = {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      cacheGroups: {
+        default: false,
+        defaultVendors: false,
+        appVendor: {
+          test: /app-vendor\.js$/,
+          name: 'vendors-app',
+          enforce: true,
+        },
+        heavyVendor: {
+          test: /heavy-vendor\.js$/,
+          name: 'vendors-heavy',
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+
 afterAll(() => cleanupOutputDirs(created));
 
 const DIST_PLUGIN = path.resolve(__dirname, '../../dist/react-server-dom-rspack/plugin.js');
@@ -68,6 +95,71 @@ describe('RSCRspackPlugin', () => {
       const a = run('basic-client');
       const b = run('basic-client');
       expect(a.manifestSource).toBe(b.manifestSource);
+    });
+  });
+
+  describe('static island diagnostics', () => {
+    const diagnosticsFilename = 'rsc-client-reference-diagnostics.json';
+
+    it('emits empty diagnostics for an explicitly server-only static page config', () => {
+      const result = run('static-islands', {
+        clientReferences: [],
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+      });
+
+      expect(result.manifest.filePathToModuleMetadata).toEqual({});
+      expect(result.assets).toContain(diagnosticsFilename);
+      expect(result.clientReferenceDiagnostics).toEqual({
+        version: 1,
+        manifestFilename: 'react-client-manifest.json',
+        isServer: false,
+        clientReferenceCount: 0,
+        totalChunkBytes: 0,
+        clientReferences: [],
+      });
+    });
+
+    it('shows a tiny island avoiding unrelated app/vendor chunks', () => {
+      const result = run('static-islands', {
+        clientReferences: staticIslandClientReferences(/TinyIsland\.js$/),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        configExtra: splitStaticIslandVendors,
+      });
+
+      expect(result.assets).toContain('vendors-app.js');
+      const tinyKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('/TinyIsland.js'),
+      );
+      expect(tinyKey).toBeTruthy();
+      const tiny = result.manifest.filePathToModuleMetadata[tinyKey!]!;
+      expect(manifestChunkFiles(tiny.chunks).join(',')).not.toContain('vendors');
+
+      const diagnosticEntry = result.clientReferenceDiagnostics?.clientReferences[0]!;
+      expect(diagnosticEntry.file).toContain('/TinyIsland.js');
+      expect(diagnosticEntry.chunks.map((chunk) => chunk.file).join(',')).not.toContain('vendors');
+      expect(diagnosticEntry.totalBytes).toBeGreaterThan(0);
+    });
+
+    it('reports a larger byte total for the heavy island chunk', () => {
+      const tinyResult = run('static-islands', {
+        clientReferences: staticIslandClientReferences(/TinyIsland\.js$/),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        configExtra: splitStaticIslandVendors,
+      });
+      const heavyResult = run('static-islands', {
+        clientReferences: staticIslandClientReferences(/HeavyIsland\.js$/),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        configExtra: splitStaticIslandVendors,
+      });
+
+      const heavyEntry = heavyResult.clientReferenceDiagnostics?.clientReferences[0]!;
+      expect(heavyEntry.file).toContain('/HeavyIsland.js');
+      expect(heavyEntry.chunks).toHaveLength(1);
+      expect(heavyEntry.chunks[0]!.bytes).toBeGreaterThan(0);
+      expect(heavyEntry.totalBytes).toBeGreaterThan(
+        tinyResult.clientReferenceDiagnostics!.clientReferences[0]!.totalBytes,
+      );
+      expect(heavyResult.clientReferenceDiagnostics?.totalChunkBytes).toBe(heavyEntry.totalBytes);
     });
   });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -161,6 +161,35 @@ describe('RSCRspackPlugin', () => {
       );
       expect(heavyResult.clientReferenceDiagnostics?.totalChunkBytes).toBe(heavyEntry.totalBytes);
     });
+
+    it('includes CSS asset bytes in static island diagnostics', () => {
+      const result = run('static-islands', {
+        clientReferences: staticIslandClientReferences(/StyledIsland\.js$/),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        publicPath: '/assets',
+        withCss: true,
+      });
+
+      expect(result.assets).toContain('client0.chunk.css');
+
+      const manifestEntry = Object.entries(result.manifest.filePathToModuleMetadata).find(([file]) =>
+        file.endsWith('/StyledIsland.js'),
+      )?.[1];
+      expect(manifestEntry).not.toHaveProperty('css');
+
+      const diagnosticEntry = result.clientReferenceDiagnostics?.clientReferences[0]!;
+      expect(diagnosticEntry.file).toContain('/StyledIsland.js');
+      expect(diagnosticEntry.css).toEqual([
+        {
+          file: '/assets/client0.chunk.css',
+          bytes: expect.any(Number),
+        },
+      ]);
+      expect(diagnosticEntry.totalBytes).toBe(
+        diagnosticEntry.chunks[0]!.bytes! + diagnosticEntry.css![0]!.bytes!,
+      );
+      expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
+    });
   });
 
   describe('top-level manifest shape', () => {

--- a/tests/webpack-plugin/fixtures/static-islands/HeavyIsland.js
+++ b/tests/webpack-plugin/fixtures/static-islands/HeavyIsland.js
@@ -1,0 +1,7 @@
+'use client';
+
+import { heavyValue } from './heavy-vendor';
+
+export default function HeavyIsland() {
+  return `heavy interactive island:${heavyValue.length}`;
+}

--- a/tests/webpack-plugin/fixtures/static-islands/TinyIsland.js
+++ b/tests/webpack-plugin/fixtures/static-islands/TinyIsland.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function TinyIsland() {
+  return 'tiny interactive island';
+}

--- a/tests/webpack-plugin/fixtures/static-islands/app-vendor.js
+++ b/tests/webpack-plugin/fixtures/static-islands/app-vendor.js
@@ -1,0 +1,1 @@
+export const appVendorLabel = 'large app shell vendor loaded by the page entry';

--- a/tests/webpack-plugin/fixtures/static-islands/heavy-vendor.js
+++ b/tests/webpack-plugin/fixtures/static-islands/heavy-vendor.js
@@ -1,0 +1,3 @@
+export const heavyValue =
+  'heavy-client-dependency:' +
+  '0123456789abcdefghijklmnopqrstuvwxyz'.repeat(256);

--- a/tests/webpack-plugin/fixtures/static-islands/index.js
+++ b/tests/webpack-plugin/fixtures/static-islands/index.js
@@ -1,0 +1,5 @@
+import { appVendorLabel } from './app-vendor';
+
+export default function renderStaticPage() {
+  return `static page:${appVendorLabel}`;
+}

--- a/tests/webpack-plugin/helpers/compile.ts
+++ b/tests/webpack-plugin/helpers/compile.ts
@@ -17,6 +17,7 @@ const FIXTURES_ROOT = path.resolve(__dirname, '../fixtures');
 export interface CompileOptions {
   isServer?: boolean;
   clientManifestFilename?: string;
+  clientReferenceDiagnosticsFilename?: string | false;
   /** Passed through to the plugin; RegExps survive the child-process hop. */
   clientReferences?: unknown;
   /** Chunk name template, e.g. 'client-[request]' for readable chunk ids. */
@@ -48,6 +49,22 @@ export interface ModuleMetadata {
   name: string;
 }
 
+export interface ClientReferenceDiagnostics {
+  version: 1;
+  manifestFilename: string;
+  isServer: boolean;
+  clientReferenceCount: number;
+  totalChunkBytes: number;
+  clientReferences: Array<{
+    file: string;
+    id: string | number | null;
+    name: string;
+    totalBytes: number;
+    chunks: Array<{ id: string | number | null; file: string; bytes: number | null }>;
+    css?: Array<{ file: string; bytes: number | null }>;
+  }>;
+}
+
 export interface CompileResult {
   manifest: {
     moduleLoading: { prefix: string; crossOrigin: string | null };
@@ -55,6 +72,8 @@ export interface CompileResult {
   };
   manifestSource: string;
   manifestPath: string;
+  clientReferenceDiagnostics?: ClientReferenceDiagnostics;
+  clientReferenceDiagnosticsSource?: string;
   assets: string[];
   warnings: string[];
   outputPath: string;
@@ -89,6 +108,7 @@ const compileInto = (
     outputPath,
     isServer: options.isServer ?? false,
     clientManifestFilename: options.clientManifestFilename,
+    clientReferenceDiagnosticsFilename: options.clientReferenceDiagnosticsFilename,
     clientReferences: serializeForRunner(options.clientReferences),
     chunkName: options.chunkName,
     publicPath: options.publicPath,
@@ -142,11 +162,23 @@ const compileInto = (
   }
   const manifestSource = fs.readFileSync(manifestPath, 'utf8');
   const manifest = JSON.parse(manifestSource) as CompileResult['manifest'];
+  const diagnosticsFilename = options.clientReferenceDiagnosticsFilename;
+  const diagnosticsPath =
+    typeof diagnosticsFilename === 'string' ? path.join(outputPath, diagnosticsFilename) : undefined;
+  const clientReferenceDiagnosticsSource =
+    diagnosticsPath && fs.existsSync(diagnosticsPath)
+      ? fs.readFileSync(diagnosticsPath, 'utf8')
+      : undefined;
+  const clientReferenceDiagnostics = clientReferenceDiagnosticsSource
+    ? (JSON.parse(clientReferenceDiagnosticsSource) as ClientReferenceDiagnostics)
+    : undefined;
 
   return {
     manifest,
     manifestSource,
     manifestPath,
+    clientReferenceDiagnostics,
+    clientReferenceDiagnosticsSource,
     assets: result.assets ?? [],
     warnings: result.warnings ?? [],
     outputPath,

--- a/tests/webpack-plugin/helpers/runWebpackWithPlugin.js
+++ b/tests/webpack-plugin/helpers/runWebpackWithPlugin.js
@@ -21,6 +21,7 @@
  *     outputPath: string,
  *     isServer: boolean,
  *     clientManifestFilename?: string,
+ *     clientReferenceDiagnosticsFilename?: string|false,
  *     clientReferences?: unknown,   // RegExps encoded as {__type:'RegExp',...}
  *     chunkName?: string,
  *     publicPath?: string,
@@ -71,6 +72,7 @@ const {
   outputPath,
   isServer,
   clientManifestFilename,
+  clientReferenceDiagnosticsFilename,
   clientReferences: rawClientReferences,
   chunkName,
   publicPath,
@@ -95,6 +97,7 @@ const plugins = [
   new ReactFlightWebpackPlugin({
     isServer,
     clientManifestFilename,
+    clientReferenceDiagnosticsFilename,
     clientReferences,
     chunkName,
   }),

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -422,6 +422,10 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
           bytes: expect.any(Number),
         },
       ]);
+      expect(diagnosticEntry.totalBytes).toBe(
+        diagnosticEntry.chunks[0]!.bytes! + diagnosticEntry.css![0]!.bytes!,
+      );
+      expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
       expectNoWarnings(result);
     });
   });

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -403,6 +403,7 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
     it("records a chunk group's CSS under `css` with the normalized publicPath prefix", () => {
       const result = run('css-import', {
         chunkName: 'client-[request]',
+        clientReferenceDiagnosticsFilename: 'rsc-client-reference-diagnostics.json',
         // No trailing slash on purpose: the plugin must normalize the
         // cssPrefix by appending one.
         publicPath: '/assets',
@@ -414,6 +415,13 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
       expect(button.css).toEqual(['/assets/client-Button-js.chunk.css']);
       // CSS files belong in `css`, never in the JS chunk pair list.
       expect(chunkFiles(button)).toEqual(['client-Button-js.chunk.js']);
+      const diagnosticEntry = result.clientReferenceDiagnostics?.clientReferences[0]!;
+      expect(diagnosticEntry.css).toEqual([
+        {
+          file: '/assets/client-Button-js.chunk.css',
+          bytes: expect.any(Number),
+        },
+      ]);
       expectNoWarnings(result);
     });
   });

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -56,7 +56,102 @@ const expectNoWarnings = (result: CompileResult): void => {
   expect(result.warnings).toEqual([]);
 };
 
+const staticIslandClientReferences = (include: RegExp) => [
+  { directory: '.', recursive: false, include },
+];
+
+const splitStaticIslandVendors = {
+  splitChunks: {
+    chunks: 'all',
+    minSize: 0,
+    cacheGroups: {
+      default: false,
+      defaultVendors: false,
+      appVendor: {
+        test: /app-vendor\.js$/,
+        name: 'vendors-app',
+        enforce: true,
+      },
+      heavyVendor: {
+        test: /heavy-vendor\.js$/,
+        name: 'vendors-heavy',
+        enforce: true,
+      },
+    },
+  },
+};
+
 describe('ReactFlightWebpackPlugin (real webpack)', () => {
+  describe('static island diagnostics', () => {
+    const diagnosticsFilename = 'rsc-client-reference-diagnostics.json';
+
+    it('emits empty diagnostics for an explicitly server-only static page config', () => {
+      const result = run('static-islands', {
+        clientReferences: [],
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+      });
+
+      expect(result.manifest.filePathToModuleMetadata).toEqual({});
+      expect(result.assets).toContain(diagnosticsFilename);
+      expect(result.clientReferenceDiagnostics).toEqual({
+        version: 1,
+        manifestFilename: 'react-client-manifest.json',
+        isServer: false,
+        clientReferenceCount: 0,
+        totalChunkBytes: 0,
+        clientReferences: [],
+      });
+      expectNoWarnings(result);
+    });
+
+    it('shows a tiny island avoiding unrelated app/vendor chunks', () => {
+      const result = run('static-islands', {
+        chunkName: 'client-[request]',
+        clientReferences: staticIslandClientReferences(/TinyIsland\.js$/),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        optimizationExtra: splitStaticIslandVendors,
+      });
+
+      expect(result.assets).toContain('vendors-app.js');
+
+      const tiny = entryEndingWith(result.manifest, '/TinyIsland.js');
+      expect(chunkFiles(tiny)).toEqual(['client-TinyIsland-js.chunk.js']);
+
+      const diagnostics = result.clientReferenceDiagnostics;
+      expect(diagnostics?.clientReferenceCount).toBe(1);
+      const diagnosticEntry = diagnostics?.clientReferences[0]!;
+      expect(diagnosticEntry.file).toContain('/TinyIsland.js');
+      expect(diagnosticEntry.chunks.map((chunk) => chunk.file)).toEqual([
+        'client-TinyIsland-js.chunk.js',
+      ]);
+      expect(diagnosticEntry.chunks[0]!.bytes).toBeGreaterThan(0);
+      expect(diagnosticEntry.totalBytes).toBe(diagnosticEntry.chunks[0]!.bytes);
+      expect(diagnosticEntry.chunks.map((chunk) => chunk.file).join(',')).not.toContain('vendors');
+      expectNoWarnings(result);
+    });
+
+    it('reports the heavy island vendor chunk and byte size', () => {
+      const result = run('static-islands', {
+        chunkName: 'client-[request]',
+        clientReferences: staticIslandClientReferences(/HeavyIsland\.js$/),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        optimizationExtra: splitStaticIslandVendors,
+      });
+
+      const heavy = entryEndingWith(result.manifest, '/HeavyIsland.js');
+      expect(chunkFiles(heavy)).toEqual(
+        expect.arrayContaining(['client-HeavyIsland-js.chunk.js', 'vendors-heavy.chunk.js']),
+      );
+
+      const diagnosticEntry = result.clientReferenceDiagnostics?.clientReferences[0]!;
+      const heavyVendor = diagnosticEntry.chunks.find((chunk) => chunk.file === 'vendors-heavy.chunk.js');
+      expect(heavyVendor?.bytes).toBeGreaterThan(0);
+      expect(diagnosticEntry.totalBytes).toBeGreaterThan(heavyVendor!.bytes!);
+      expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
+      expectNoWarnings(result);
+    });
+  });
+
   describe('splitChunks shared module across chunk groups (issue #22 scenario)', () => {
     // Button.js ('use client') is forced into a `shared-button` chunk that
     // belongs to two chunk groups: Button's own client-reference group and


### PR DESCRIPTION
## Summary

- Add an opt-in `clientReferenceDiagnosticsFilename` asset for webpack and rspack client builds.
- Report client-reference JS/CSS asset files and known emitted byte sizes so static RSC island builds can audit vendor/chunk cost.
- Document explicit static-page patterns and add webpack/rspack fixtures for empty, tiny-island, heavy-island, and CSS diagnostics.

Closes #142.

## Codex Decision Log

- **Non-blocking:** Should this PR implement route/page-scoped manifests or automatic vendor elimination?
  - **Decision:** No. Keep this PR to diagnostics, docs, and fixtures only.
  - **Why:** Route-scoped manifests are the broader product/API work tracked by #134; implementing that here would widen #142 into module-graph and route-entry design.
  - **Review later:** #134 remains open for automatic per-route/page manifest scoping.

## Validation

- `yarn jest tests/webpack-plugin/plugin-integration.test.ts -t "static island diagnostics"`
- `yarn jest tests/rspack-plugin/plugin.test.ts -t "static island diagnostics"`
- `yarn jest tests/webpack-plugin/plugin-integration.test.ts tests/rspack-plugin/plugin.test.ts tests/webpack-plugin-options.test.ts`
- `yarn build`
- `yarn test`
- `git diff --check`
- `git diff --cached --check`
- Review-fix asset-size pass: `yarn build && yarn jest tests/webpack-plugin/plugin-integration.test.ts -t "CSS chunk files"`
- Review-fix regression pass: `yarn jest tests/webpack-plugin/plugin-integration.test.ts tests/rspack-plugin/plugin.test.ts tests/webpack-plugin-options.test.ts`
- Review-fix rspack e2e contract pass: `RSC_E2E_BUNDLER=rspack yarn test:e2e`
- Final full pass after CSS totals fix: `yarn test`
- Final docs/changelog pass: `git diff --check`
- Local AI review: `codex review --uncommitted` found the rspack manifest-scope issue and changelog gap; both fixed in `68c299f`.

## Review Churn / Audit Notes

- Pre-push review gate: `codex review --base origin/main` found a real webpack CSS byte-size lookup gap when `publicPath` had no trailing slash; fixed in `4b391ca` and covered by a webpack diagnostics assertion.
- Follow-up local review: `codex review --base origin/main` found stale docs JSON shape; fixed in `3d223ef` so the example matches emitted `file://` URLs, webpack module id, and `name: "*"`.
- Review fix `68c299f` includes CSS asset bytes in both webpack and rspack diagnostics totals while keeping rspack manifest/runtime stylesheet-hint behavior unchanged; `RSC_E2E_BUNDLER=rspack yarn test:e2e` confirms that contract.
- Draft Claude review found the same CSS byte-size issue on the initial draft head; it was fixed before this PR was marked ready.
- Code duplication between webpack/rspack diagnostics helpers is intentionally left in place for this PR to avoid a cross-bundler refactor while the new output is being introduced.
- #134 route/page-scoped manifests remain out of scope and open; this PR only provides diagnostics for manual audit and downstream measurement.

## Notes

- No Lighthouse/ShakaPerf improvement is claimed here; diagnostics only expose emitted build cost for downstream measurement.
- Changelog updated because this adds and refines user-visible diagnostics output.
- Current head: `68c299f9dcd0f37b9a76187e10bc752f7c895923`.
