### PR TITLE
Restore CSS hints for CSS-only split chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this package will be documented in this file.
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
 ### Fixed
-- Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#148])
+- Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#151])
 
 ## [19.2.0] - 2026-06-28
 
@@ -61,7 +61,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
-[#148]: https://github.com/shakacode/react_on_rails_rsc/issues/148
+[#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this package will be documented in this file.
 - Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
+### Fixed
+- Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#148])
+
 ## [19.2.0] - 2026-06-28
 
 ### Breaking Changes
@@ -58,6 +61,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
+[#148]: https://github.com/shakacode/react_on_rails_rsc/issues/148
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -230,6 +230,7 @@ type ClientReferenceDiagnostics = {
  */
 type FlightModule = {
   resource?: string;
+  type?: string;
   /** Inner modules of a ConcatenatedModule. */
   modules?: FlightModule[];
   addBlock?: (block: unknown) => void;
@@ -686,13 +687,14 @@ export class RSCWebpackPlugin {
             // Sibling-chunk CSS recovery (#112): SplitChunks + MiniCssExtract
             // can place a reference's *own* extracted CSS in a chunk separate
             // from the one holding its JS module (e.g. a cache group that
-            // matches the JS file but not its `.css` sibling). That CSS chunk's
-            // only modules are CSS/shared modules, so the per-chunk pass alone
-            // would drop it. Follow the module's DIRECT `.css` imports to the
-            // chunk(s) that carry them, intersected with this chunk group, and
-            // merge that CSS. Only direct imports are followed, so CSS reached
-            // through a shared dependency (imported by another module, not the
-            // reference) is NOT picked up — the #108 broadcast stays fixed.
+            // matches the JS file but not its `.css` sibling, or a
+            // css/mini-extract cache group that moves the extracted CssModule
+            // into a CSS-only chunk). Follow the module's DIRECT `.css`
+            // imports to the chunk(s) that carry them, intersected with this
+            // chunk group, and merge that CSS. Only direct imports are
+            // followed, so CSS reached through a shared dependency (imported by
+            // another module, not the reference) is NOT picked up — the #108
+            // broadcast stays fixed.
             // Guarded on `moduleGraph`/`getModuleChunksIterable`, which the
             // unit-test mocks omit (they exercise the per-chunk pass only).
             const moduleGraph = compilation.moduleGraph;
@@ -701,6 +703,16 @@ export class RSCWebpackPlugin {
             const directCssDepFiles = (module: FlightModule): string[] => {
               if (!moduleGraph || !getModuleChunksIterable || cssPrefix === null) return [];
               const files = new Set<string>();
+              const addCssFromModuleChunks = (cssModule: FlightModule): void => {
+                for (const cssChunk of getModuleChunksIterable(cssModule)) {
+                  if (!groupChunks.has(cssChunk)) continue;
+                  for (const file of cssChunk.files) {
+                    if (isRecordableCss(file)) {
+                      files.add(cssPrefix + file);
+                    }
+                  }
+                }
+              };
               for (const connection of moduleGraph.getOutgoingConnections(module)) {
                 // `module` is the resolved destination for most connections;
                 // some dependency types leave it null with the target on
@@ -714,13 +726,13 @@ export class RSCWebpackPlugin {
                 // resource query/fragment (`./Button.css?inline`) first.
                 const depResource = depModule.resource.replace(/[?#].*$/, '');
                 if (!STYLE_SOURCE_RE.test(depResource)) continue;
-                for (const cssChunk of getModuleChunksIterable(depModule)) {
-                  if (!groupChunks.has(cssChunk)) continue;
-                  for (const file of cssChunk.files) {
-                    if (isRecordableCss(file)) {
-                      files.add(cssPrefix + file);
-                    }
+                addCssFromModuleChunks(depModule);
+                for (const cssConnection of moduleGraph.getOutgoingConnections(depModule)) {
+                  const extractedCssModule = cssConnection.module ?? cssConnection.resolvedModule;
+                  if (!extractedCssModule || extractedCssModule.type !== 'css/mini-extract') {
+                    continue;
                   }
+                  addCssFromModuleChunks(extractedCssModule);
                 }
               }
               return [...files];

--- a/tests/webpack-plugin/fixtures/split-css-only-chunk/Button.css
+++ b/tests/webpack-plugin/fixtures/split-css-only-chunk/Button.css
@@ -1,0 +1,3 @@
+.button {
+  color: red;
+}

--- a/tests/webpack-plugin/fixtures/split-css-only-chunk/Button.js
+++ b/tests/webpack-plugin/fixtures/split-css-only-chunk/Button.js
@@ -1,0 +1,7 @@
+'use client';
+
+import './Button.css';
+
+export default function Button() {
+  return 'button';
+}

--- a/tests/webpack-plugin/fixtures/split-css-only-chunk/entryOnly.js
+++ b/tests/webpack-plugin/fixtures/split-css-only-chunk/entryOnly.js
@@ -1,0 +1,1 @@
+export const entryOnly = 'entry-only-module';

--- a/tests/webpack-plugin/fixtures/split-css-only-chunk/index.js
+++ b/tests/webpack-plugin/fixtures/split-css-only-chunk/index.js
@@ -1,0 +1,6 @@
+// Button is reached only through the plugin-created client-reference async
+// block. A css/mini-extract SplitChunks cache group moves Button.css into a
+// CSS-only sibling chunk in that block's chunk group.
+import { entryOnly } from './entryOnly';
+
+export const app = [entryOnly];

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -356,6 +356,102 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
     });
   });
 
+  describe('CSS-only SplitChunks chunks: own CSS moved away from its JS module', () => {
+    let result: CompileResult;
+
+    beforeAll(() => {
+      result = run('split-css-only-chunk', {
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              styles: {
+                name: 'styles',
+                type: 'css/mini-extract',
+                chunks: 'all',
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('emits the merged styles chunk as a CSS-only split chunk (precondition)', () => {
+      expect(result.assets).toContain('styles.chunk.css');
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(chunkFiles(button)).toContain('client-Button-js.chunk.js');
+      expect(result.assets).not.toContain('client-Button-js.chunk.css');
+    });
+
+    it("keeps the client reference's own CSS when SplitChunks moves it to a CSS-only chunk", () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(button.css).toContain('/assets/styles.chunk.css');
+    });
+
+    it('produces no fallback warning', () => {
+      expectNoWarnings(result);
+    });
+  });
+
+  describe('CSS-only shared dependency chunks stay excluded from client-reference CSS', () => {
+    let result: CompileResult;
+
+    beforeAll(() => {
+      result = run('split-shared-css', {
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              sharedJs: {
+                test: /shared\.js$/,
+                name: 'shared-js',
+                minChunks: 2,
+                enforce: true,
+              },
+              sharedStyles: {
+                test: /shared\.css$/,
+                name: 'shared-styles',
+                type: 'css/mini-extract',
+                chunks: 'all',
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('emits the shared dependency stylesheet as a CSS-only split chunk (precondition)', () => {
+      expect(result.assets).toContain('shared-styles.chunk.css');
+    });
+
+    it('does not attach the CSS-only shared dependency stylesheet to client references', () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      const settings = entryEndingWith(result.manifest, '/SettingsPage.js');
+      expect(button.css).toContain('/assets/client-Button-js.chunk.css');
+      expect(settings.css).toContain('/assets/client-SettingsPage-js.chunk.css');
+      expect(button.css ?? []).not.toContain('/assets/shared-styles.chunk.css');
+      expect(settings.css ?? []).not.toContain('/assets/shared-styles.chunk.css');
+    });
+
+    it('produces no fallback warning', () => {
+      expectNoWarnings(result);
+    });
+  });
+
   describe('duplicated module across chunk groups (issue #19 class, no splitChunks)', () => {
     // SettingsPage imports Button; with no splitChunks, Button's module is
     // duplicated into SettingsPage's chunk, so it appears in two chunk


### PR DESCRIPTION
## Summary
- follow direct stylesheet imports to their extracted `css/mini-extract` modules so CSS-only SplitChunks outputs stay in the RSC client reference manifest
- preserve the existing shared-dependency guard so shared CSS split chunks are not rebroadcast to every client reference
- add webpack integration coverage for the CSS-only split-chunk regression and the shared CSS exclusion guard

Fixes #148

## Test plan
- Reproduced before the fix: `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand --testNamePattern="CSS-only SplitChunks"` failed with the Button manifest entry reporting `css: []`
- `yarn build`
- `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand --testNamePattern=CSS-only`
- `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand`
- `yarn test` passed during the final `codex review --uncommitted` pass
- `codex review --uncommitted` reported no correctness issues after fixing one accepted shared-CSS review finding

## Review notes
- Churn: one pre-push autoreview finding was accepted and fixed before opening this PR; no public review-fix churn yet.
- CHANGELOG records this fix with the PR #151 reference.