### PR TITLE
Skip rspack diagnostics CSS work when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this package will be documented in this file.
 - Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
+### Changed
+- Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
+
 ### Fixed
 - Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#151])
 
@@ -62,6 +65,7 @@ All notable changes to this package will be documented in this file.
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151
+[#152]: https://github.com/shakacode/react_on_rails_rsc/pull/152
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -582,7 +582,9 @@ export class RSCRspackPlugin {
     const initialChunks = this.getInitialChunks(compilation);
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
+    const diagnosticsEnabled = typeof this.options.clientReferenceDiagnosticsFilename === 'string';
     let cssPrefix =
+      diagnosticsEnabled &&
       typeof compilation.outputOptions.publicPath === 'string' &&
       compilation.outputOptions.publicPath !== 'auto'
         ? compilation.outputOptions.publicPath

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -100,6 +100,47 @@ describe('RSCRspackPlugin', () => {
 
   describe('static island diagnostics', () => {
     const diagnosticsFilename = 'rsc-client-reference-diagnostics.json';
+    const captureBuildManifestCssPrefixes = (
+      options: { clientReferenceDiagnosticsFilename?: string | false } = {},
+    ): Array<string | null> => {
+      const { RSCRspackPlugin } = require(DIST_PLUGIN);
+      const plugin = new RSCRspackPlugin({ isServer: false, ...options });
+      const cssPrefixes: Array<string | null> = [];
+      const internals = plugin as {
+        getGroupAssets: (
+          chunkGroup: unknown,
+          initialChunks: Set<unknown>,
+          cssPrefix: string | null,
+        ) => { chunks: (string | number | null)[]; css: string[] };
+        buildManifest: (
+          compilation: unknown,
+          bundler: unknown,
+          diagnosticsCssFiles: Map<string, string[]>,
+        ) => unknown;
+      };
+      internals.getGroupAssets = (
+        _chunkGroup: unknown,
+        _initialChunks: Set<unknown>,
+        cssPrefix: string | null,
+      ) => {
+        cssPrefixes.push(cssPrefix);
+        return { chunks: [], css: [] };
+      };
+
+      internals.buildManifest(
+        {
+          outputOptions: { publicPath: '/assets' },
+          entrypoints: new Map(),
+          chunkGroups: [{ chunks: [] }],
+          chunkGraph: { getChunkModulesIterable: () => [] },
+          warnings: [],
+        },
+        {},
+        new Map(),
+      );
+
+      return cssPrefixes;
+    };
 
     it('emits empty diagnostics for an explicitly server-only static page config', () => {
       const result = run('static-islands', {
@@ -189,6 +230,18 @@ describe('RSCRspackPlugin', () => {
         diagnosticEntry.chunks[0]!.bytes! + diagnosticEntry.css![0]!.bytes!,
       );
       expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
+    });
+
+    it('skips CSS asset collection when diagnostics are disabled', () => {
+      expect(captureBuildManifestCssPrefixes()).toEqual([null]);
+    });
+
+    it('keeps CSS asset collection enabled for diagnostics output', () => {
+      expect(
+        captureBuildManifestCssPrefixes({
+          clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        }),
+      ).toEqual(['/assets/']);
     });
   });
 


### PR DESCRIPTION
## Summary
- gate rspack CSS collection on `clientReferenceDiagnosticsFilename` so default diagnostics-off builds pass `null` into group asset CSS collection
- keep diagnostics-on CSS collection and byte reporting unchanged
- add focused regression coverage for diagnostics-off and diagnostics-on CSS collection gates

Fixes #149

## Test plan
- Reproduced before the fix: `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand --testNamePattern="CSS asset collection"` failed because diagnostics-off passed `/assets/` into CSS collection instead of `null`
- `yarn build`
- `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand --testNamePattern="CSS asset collection"`
- `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand`
- `yarn test`
- `codex review --uncommitted`

## Review notes
- Churn: no public review-fix churn yet; local AI review reported no correctness regression.
- CHANGELOG records this change with the PR #152 reference.
- Merge order: this PR is independent of #151 in code, but both touch `CHANGELOG.md`, so merge #151 first and refresh this branch if GitHub reports a changelog conflict.