### PR TITLE
Fail closed before Dependabot auto-merge

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   claude-review:
     if: |
+      github.actor != 'dependabot[bot]' &&
       !(
         startsWith(github.event.pull_request.title, 'Release react-on-rails-rsc ') ||
         startsWith(github.event.pull_request.title, 'Stamp CHANGELOG and package version for ') ||

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,8 +3,9 @@ name: Dependabot auto-merge
 # Enables GitHub native auto-merge for low-risk Dependabot minor/patch package
 # updates. Native auto-merge only waits for checks that branch protection marks
 # required, so this workflow refuses to enable auto-merge when the base branch
-# has no required checks configured. GitHub Actions ecosystem bumps stay
-# maintainer-gated because they edit workflow execution.
+# has no required checks configured through classic branch protection or active
+# branch rulesets. GitHub Actions ecosystem bumps stay maintainer-gated because
+# they edit workflow execution.
 
 on:
   pull_request_target:
@@ -24,45 +25,87 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Hold GitHub Actions updates for workflow audit
-        if: steps.metadata.outputs.package-ecosystem == 'github_actions'
+      - name: Classify auto-merge eligibility
+        id: auto-merge-eligibility
+        env:
+          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
-          echo "::notice::GitHub Actions Dependabot updates are not auto-merged. Review workflow permissions, triggers, secrets, and third-party action changes manually."
+          set -euo pipefail
+
+          eligible=false
+          if [ "${PACKAGE_ECOSYSTEM}" = "github_actions" ]; then
+            echo "::notice::GitHub Actions Dependabot updates are not auto-merged. Review workflow permissions, triggers, secrets, and third-party action changes manually."
+          elif [ "${UPDATE_TYPE}" = "version-update:semver-minor" ] || [ "${UPDATE_TYPE}" = "version-update:semver-patch" ]; then
+            eligible=true
+          else
+            echo "::notice::Dependabot update type ${UPDATE_TYPE} is not auto-merged."
+          fi
+
+          echo "eligible=${eligible}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify required checks protect auto-merge
-        if: |
-          steps.metadata.outputs.package-ecosystem != 'github_actions' &&
-          (
-            steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-            steps.metadata.outputs.update-type == 'version-update:semver-patch'
-          )
+        if: steps.auto-merge-eligibility.outputs.eligible == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          if ! required_count="$(
-            gh api "repos/${REPO}/branches/${BASE_BRANCH}/protection/required_status_checks" \
-              --jq '((.contexts // []) | length) + ((.checks // []) | length)' 2>/dev/null
-          )"; then
-            required_count=0
+          ruleset_error="$(mktemp)"
+          ruleset_required_count=0
+          ruleset_read_error=false
+          ruleset_output="$(
+            gh api "repos/${REPO}/rules/branches/${BASE_BRANCH}" \
+              --jq '[.[] | select(.type == "required_status_checks") | ((.parameters.required_status_checks // []) | length)] | add // 0' 2>"${ruleset_error}"
+          )" || ruleset_status=$?
+          ruleset_status="${ruleset_status:-0}"
+
+          if [ "${ruleset_status}" -eq 0 ]; then
+            ruleset_required_count="${ruleset_output}"
+          else
+            ruleset_read_error=true
           fi
 
-          if [ "${required_count:-0}" -eq 0 ]; then
-            echo "::error::Dependabot auto-merge is disabled because ${BASE_BRANCH} has no required status checks configured. Configure branch protection for the deterministic CI checks before re-enabling auto-merge."
+          legacy_error="$(mktemp)"
+          legacy_required_count=0
+          legacy_read_error=false
+          legacy_output="$(
+            gh api "repos/${REPO}/branches/${BASE_BRANCH}/protection/required_status_checks" \
+              --jq 'if ((.checks // []) | length) > 0 then ((.checks // []) | length) else ((.contexts // []) | length) end' 2>"${legacy_error}"
+          )" || legacy_status=$?
+          legacy_status="${legacy_status:-0}"
+
+          if [ "${legacy_status}" -eq 0 ]; then
+            legacy_required_count="${legacy_output}"
+          elif printf '%s\n%s\n' "${legacy_output}" "$(cat "${legacy_error}")" | grep -Eq '"status":"404"|Branch not protected|Required status checks not enabled'; then
+            legacy_required_count=0
+          else
+            legacy_read_error=true
+          fi
+
+          required_count=$((legacy_required_count + ruleset_required_count))
+          if [ "${required_count}" -eq 0 ]; then
+            if [ "${ruleset_read_error}" = "true" ]; then
+              echo "::error::Unable to read active branch rules for ${BASE_BRANCH}, and no required checks were found in classic branch protection. Refusing to enable Dependabot auto-merge."
+              cat "${ruleset_error}" >&2
+              printf '%s\n' "${ruleset_output}" >&2
+              exit 1
+            fi
+            if [ "${legacy_read_error}" = "true" ]; then
+              echo "::error::Unable to read classic branch-protection required checks for ${BASE_BRANCH}, and no required checks were found in active branch rulesets. If classic branch protection is used, configure DEPENDABOT_AUTOMERGE_TOKEN with Administration: read access. Refusing to enable Dependabot auto-merge."
+              cat "${legacy_error}" >&2
+              printf '%s\n' "${legacy_output}" >&2
+              exit 1
+            fi
+            echo "::error::Dependabot auto-merge is disabled because ${BASE_BRANCH} has no required status checks configured in classic branch protection or active branch rulesets. Configure deterministic required CI checks before re-enabling auto-merge."
             exit 1
           fi
 
       - name: Enable auto-merge for minor and patch updates
-        if: |
-          steps.metadata.outputs.package-ecosystem != 'github_actions' &&
-          (
-            steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-            steps.metadata.outputs.update-type == 'version-update:semver-patch'
-          )
+        if: steps.auto-merge-eligibility.outputs.eligible == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -108,4 +108,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,12 +1,10 @@
 name: Dependabot auto-merge
 
-# Enables GitHub native auto-merge for low-risk Dependabot PRs (minor/patch and
-# GitHub Actions bumps). The PR still merges only once all checks GitHub treats
-# as required have passed. NOTE: `main` currently has no branch protection, so
-# "required" is empty and an enabled PR merges as soon as it is mergeable. Add
-# branch protection on `main` with the real CI checks (unit-tests, e2e-tests,
-# verify-artifacts, the compatibility matrix) marked required — but NOT
-# claude-review — to make this gate on green CI.
+# Enables GitHub native auto-merge for low-risk Dependabot minor/patch package
+# updates. Native auto-merge only waits for checks that branch protection marks
+# required, so this workflow refuses to enable auto-merge when the base branch
+# has no required checks configured. GitHub Actions ecosystem bumps stay
+# maintainer-gated because they edit workflow execution.
 
 on:
   pull_request_target:
@@ -26,10 +24,44 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Hold GitHub Actions updates for workflow audit
+        if: steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: |
+          echo "::notice::GitHub Actions Dependabot updates are not auto-merged. Review workflow permissions, triggers, secrets, and third-party action changes manually."
+
+      - name: Verify required checks protect auto-merge
+        if: |
+          steps.metadata.outputs.package-ecosystem != 'github_actions' &&
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if ! required_count="$(
+            gh api "repos/${REPO}/branches/${BASE_BRANCH}/protection/required_status_checks" \
+              --jq '((.contexts // []) | length) + ((.checks // []) | length)' 2>/dev/null
+          )"; then
+            required_count=0
+          fi
+
+          if [ "${required_count:-0}" -eq 0 ]; then
+            echo "::error::Dependabot auto-merge is disabled because ${BASE_BRANCH} has no required status checks configured. Configure branch protection for the deterministic CI checks before re-enabling auto-merge."
+            exit 1
+          fi
+
       - name: Enable auto-merge for minor and patch updates
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          steps.metadata.outputs.package-ecosystem != 'github_actions' &&
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- Fail closed before enabling Dependabot native auto-merge when the base branch has zero required status checks configured through classic branch protection or active branch rulesets.
- Keep Dependabot `github_actions` ecosystem updates out of auto-merge so workflow changes stay maintainer-audited.
- Skip the Claude review workflow for Dependabot PRs, matching the current Claude action behavior for non-human actors and avoiding late failed advisory checks.

Fixes #161.

## Workflow Change Audit:

- Secret references: added optional `${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}` for the required-check protection probe only, so maintainers can grant classic branch-protection read access without using that token for the merge command. The auto-merge command uses the existing `${{ secrets.GITHUB_TOKEN }}` with the workflow job's write permissions. Existing `${{ secrets.GITHUB_TOKEN }}` and `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` references remain.
- `permissions:`: unchanged in both edited workflows.
- `on:` triggers: unchanged in both edited workflows.
- Third-party actions added or version-changed: none. Existing `dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98` and `anthropics/claude-code-action@fad22eb3fa582b7357fc0ea48af6645851b884fd` pins are unchanged.
- Behavioral change: Dependabot auto-merge now computes eligibility once, refuses GitHub Actions ecosystem auto-merge, counts required checks from active branch rulesets plus readable classic branch protection, fails closed when neither path proves deterministic required checks, and keeps probe authentication separate from merge authentication. Claude Code Review skips Dependabot PRs.

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "parsed #{f}" }'`
- `actionlint .github/workflows/dependabot-auto-merge.yml .github/workflows/claude-code-review.yml`
- `actionlint`
- Branch-protection/ruleset replay against current `main`: `legacy_required_count=0`, `ruleset_required_count=0`, `required_count=0`; fail-closed path would block auto-merge.
- `git diff --check`
- `yarn build`
- `yarn test`
- Local focused review rerun after token split: no actionable blockers.

## Notes

- This is a workflow/process PR and should stay maintainer-gated; do not auto-merge it as a low-risk batch PR.
- Branch protection and ruleset configuration remain external repository settings. This PR prevents the workflow from silently relying on an empty required-check set.
