### PR TITLE
Refresh client references during watch rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this package will be documented in this file.
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
 ### Fixed
-- Fixed watch rebuilds so rspack and webpack refresh client-reference runtime injections when `"use client"` files are added or removed without restarting the dev server. ([#154])
+- Fixed watch rebuilds so rspack and webpack refresh client-reference runtime injections when `"use client"` files are added or removed without restarting the dev server. ([#164])
 
 ## [19.2.0] - 2026-06-28
 
@@ -61,7 +61,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
-[#154]: https://github.com/shakacode/react_on_rails_rsc/issues/154
+[#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this package will be documented in this file.
 - Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
+### Fixed
+- Fixed watch rebuilds so rspack and webpack refresh client-reference runtime injections when `"use client"` files are added or removed without restarting the dev server. ([#154])
+
 ## [19.2.0] - 2026-06-28
 
 ### Breaking Changes
@@ -58,6 +61,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
+[#154]: https://github.com/shakacode/react_on_rails_rsc/issues/154
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -21,6 +21,12 @@ export let _chunkName = 'client[index]';
 export let _generatedChunkNames: Set<string> = new Set();
 
 const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
+  // The injected import list comes from the plugin's latest FS walk, not from
+  // the runtime file itself. Re-run on every watch rebuild so added/removed
+  // client references refresh the runtime module instead of reusing stale
+  // loader output.
+  this.cacheable(false);
+
   if (!_discoveredClientFiles.length) return source;
 
   const names: string[] = [];

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -98,6 +98,9 @@ type AnyCompilation = {
   getAsset?: (filename: string) => { source?: AssetSource } | undefined;
   warnings: unknown[];
   compiler: AnyCompiler;
+  fileDependencies?: WatchDependencySet;
+  contextDependencies?: WatchDependencySet;
+  missingDependencies?: WatchDependencySet;
   getLogger?(name: string): AnyLogger;
 };
 
@@ -105,6 +108,39 @@ type AssetSource = {
   size?: () => number;
   source?: () => string | Buffer;
 };
+
+type WatchDependencySet = {
+  add(dependency: string): unknown;
+};
+
+type ClientReferenceWatchDependencies = {
+  files: Set<string>;
+  contexts: Set<string>;
+  missing: Set<string>;
+};
+
+function createClientReferenceWatchDependencies(): ClientReferenceWatchDependencies {
+  return {
+    files: new Set<string>(),
+    contexts: new Set<string>(),
+    missing: new Set<string>(),
+  };
+}
+
+function addClientReferenceWatchDependencies(
+  compilation: AnyCompilation,
+  dependencies: ClientReferenceWatchDependencies,
+): void {
+  for (const file of dependencies.files) {
+    compilation.fileDependencies?.add(file);
+  }
+  for (const context of dependencies.contexts) {
+    compilation.contextDependencies?.add(context);
+  }
+  for (const missing of dependencies.missing) {
+    compilation.missingDependencies?.add(missing);
+  }
+}
 
 // Helper to read/write our private Symbol key on the compilation. Using a
 // symbol requires a cast because TS structural types can't easily express
@@ -271,12 +307,18 @@ export class RSCRspackPlugin {
     // from disk, check for a `"use client"` directive, and stash the
     // absolute paths.  This list is used in Phase 2 to inject async chunks.
     let discoveredClientFiles: string[] = [];
+    let clientReferenceWatchDependencies = createClientReferenceWatchDependencies();
 
     compiler.hooks.beforeCompile.tapAsync(
       'RSCRspackPlugin',
       (_params: unknown, callback: (err?: Error | null) => void) => {
         try {
-          discoveredClientFiles = this.resolveAllClientFiles(compiler.context);
+          const nextWatchDependencies = createClientReferenceWatchDependencies();
+          discoveredClientFiles = this.resolveAllClientFiles(
+            compiler.context,
+            nextWatchDependencies,
+          );
+          clientReferenceWatchDependencies = nextWatchDependencies;
           this._resolvedClientFiles = discoveredClientFiles;
           setInjectionState(discoveredClientFiles, this.chunkName);
           callback();
@@ -360,6 +402,7 @@ export class RSCRspackPlugin {
     // ── Phase 3: tag set + manifest emission ────────────────────────
     compiler.hooks.thisCompilation.tap('RSCRspackPlugin', (compilationUnknown) => {
       const compilation = compilationUnknown as AnyCompilation;
+      addClientReferenceWatchDependencies(compilation, clientReferenceWatchDependencies);
 
       // Eagerly create the shared Set so the loader never races on init.
       if (!getTagSet(compilation)) {
@@ -415,7 +458,10 @@ export class RSCRspackPlugin {
   //   - string → direct file reference (unconditionally included, matching
   //     the webpack plugin's behavior — no "use client" check)
   //   - search descriptor → walk directory, read files, check for directive
-  private resolveAllClientFiles(compilerContext: string): string[] {
+  private resolveAllClientFiles(
+    compilerContext: string,
+    watchDependencies: ClientReferenceWatchDependencies,
+  ): string[] {
     const results = new Set<string>();
     for (const ref of this.clientReferences) {
       if (typeof ref === 'string') {
@@ -423,16 +469,23 @@ export class RSCRspackPlugin {
         // a ClientReferenceDependency unconditionally (line 337). We do
         // the same: include it without checking for "use client".
         const resolved = path.resolve(compilerContext, ref);
+        watchDependencies.files.add(resolved);
         try {
           if (fs.statSync(resolved).isFile()) this.addResolvedClientFile(results, resolved);
-        } catch { /* not found — skip */ }
+        } catch {
+          watchDependencies.missing.add(resolved);
+        }
         continue;
       }
       const dir = path.resolve(compilerContext, ref.directory);
       try {
         if (!fs.statSync(dir).isDirectory()) continue;
-      } catch { continue; }
-      this.walkDir(dir, dir, ref, results);
+      } catch {
+        watchDependencies.missing.add(dir);
+        continue;
+      }
+      watchDependencies.contexts.add(dir);
+      this.walkDir(dir, dir, ref, results, watchDependencies);
     }
     return [...results];
   }
@@ -442,11 +495,14 @@ export class RSCRspackPlugin {
     walkRoot: string,
     ref: ClientReferenceSearchPath,
     out: Set<string>,
+    watchDependencies = createClientReferenceWatchDependencies(),
   ): void {
+    watchDependencies.contexts.add(dir);
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
+      watchDependencies.missing.add(dir);
       return;
     }
     for (const entry of entries) {
@@ -460,7 +516,7 @@ export class RSCRspackPlugin {
       if (stat.isDirectory()) {
         const relPath = './' + path.relative(walkRoot, full).replace(/\\/g, '/');
         if (ref.exclude && ref.exclude.test(relPath)) continue;
-        if (ref.recursive !== false) this.walkDir(full, walkRoot, ref, out);
+        if (ref.recursive !== false) this.walkDir(full, walkRoot, ref, out, watchDependencies);
       } else if (stat.isFile()) {
         // Test include/exclude against the RELATIVE path from the walk
         // root (e.g. "./components/Button.tsx"), matching the webpack
@@ -469,6 +525,7 @@ export class RSCRspackPlugin {
         const relPath = './' + path.relative(walkRoot, full).replace(/\\/g, '/');
         if (!ref.include.test(relPath)) continue;
         if (ref.exclude && ref.exclude.test(relPath)) continue;
+        watchDependencies.files.add(full);
         try {
           const source = fs.readFileSync(full, 'utf-8');
           if (hasUseClientDirective(source)) this.addResolvedClientFile(out, full);

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -482,6 +482,14 @@ export class RSCWebpackPlugin {
             return;
           }
           clientFileNameFound = true;
+          // The block list below depends on the latest client-reference
+          // discovery result, not on the Flight runtime file contents. Force
+          // webpack to rebuild this single runtime module in watch mode so the
+          // parser hook re-attaches blocks after client files are added or
+          // removed.
+          const buildInfo = (module as unknown as { buildInfo?: { cacheable?: boolean } })
+            .buildInfo;
+          if (buildInfo) buildInfo.cacheable = false;
           if (!resolvedClientReferences) return;
           for (let i = 0; i < resolvedClientReferences.length; i++) {
             const dep = resolvedClientReferences[i]!;

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -421,6 +421,11 @@ type WatchInputFileSystem = ReadFileFs & {
 
 const PLUGIN_NAME = 'React Server Plugin';
 
+const toClientReferenceRelativePath = (rootDirectory: string, childPath: string): string => {
+  const relativePath = path.relative(rootDirectory, childPath).replace(/\\/g, '/');
+  return relativePath ? `./${relativePath}` : '.';
+};
+
 export class RSCWebpackPlugin {
   readonly isServer: boolean;
 
@@ -1195,12 +1200,8 @@ export class RSCWebpackPlugin {
 
         inputFs.readdir(directory, (readErr, files) => {
           if (readErr) {
-            if (readErr.code === 'ENOENT') {
-              watchDependencies.missing.add(directory);
-              done();
-              return;
-            }
-            done(readErr);
+            watchDependencies.missing.add(directory);
+            done();
             return;
           }
 
@@ -1208,18 +1209,16 @@ export class RSCWebpackPlugin {
             (files ?? []).filter((file) => file.indexOf('.') !== 0),
             (segment, mapDone) => {
               const child = path.join(directory, segment);
-              if (clientReferencePath.exclude?.test(child)) {
+              const relativeChild = toClientReferenceRelativePath(rootDirectory, child);
+              if (clientReferencePath.exclude?.test(relativeChild)) {
                 mapDone(null);
                 return;
               }
 
               inputFs.stat(child, (statErr, stats) => {
                 if (statErr) {
-                  if (statErr.code === 'ENOENT') {
-                    mapDone(null);
-                    return;
-                  }
-                  mapDone(statErr);
+                  watchDependencies.missing.add(child);
+                  mapDone(null);
                   return;
                 }
 
@@ -1243,12 +1242,8 @@ export class RSCWebpackPlugin {
 
       inputFs.realpath(directory, (realpathErr, realPath) => {
         if (realpathErr) {
-          if (realpathErr.code === 'ENOENT') {
-            watchDependencies.missing.add(directory);
-            done();
-            return;
-          }
-          done(realpathErr);
+          watchDependencies.missing.add(directory);
+          done();
           return;
         }
         visit(realPath ?? directory);

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -233,6 +233,7 @@ type FlightModule = {
   /** Inner modules of a ConcatenatedModule. */
   modules?: FlightModule[];
   addBlock?: (block: unknown) => void;
+  buildInfo?: { cacheable?: boolean };
 };
 
 type FlightChunk = {
@@ -523,6 +524,7 @@ export class RSCWebpackPlugin {
     // named AsyncDependenciesBlock per resolved client reference, creating
     // the chunk groups the manifest is later built from.
     flightCompiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation, params) => {
+      clientFileNameFound = false;
       addClientReferenceWatchDependencies(compilation, clientReferenceWatchDependencies);
 
       const normalModuleFactory = params.normalModuleFactory;
@@ -544,8 +546,7 @@ export class RSCWebpackPlugin {
           // webpack to rebuild this single runtime module in watch mode so the
           // parser hook re-attaches blocks after client files are added or
           // removed.
-          const buildInfo = (module as unknown as { buildInfo?: { cacheable?: boolean } })
-            .buildInfo;
+          const buildInfo = module.buildInfo;
           if (buildInfo) buildInfo.cacheable = false;
           if (!resolvedClientReferences) return;
           for (let i = 0; i < resolvedClientReferences.length; i++) {

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -258,6 +258,9 @@ type FlightCompilation = {
   dependencyFactories: Map<unknown, unknown>;
   dependencyTemplates: Map<unknown, unknown>;
   warnings: Error[];
+  fileDependencies?: WatchDependencySet;
+  contextDependencies?: WatchDependencySet;
+  missingDependencies?: WatchDependencySet;
   outputOptions: {
     publicPath?: string;
     crossOriginLoading?: false | 'anonymous' | 'use-credentials';
@@ -294,6 +297,39 @@ type FlightParser = {
     program: { tap(name: string, fn: () => void): void };
   };
 };
+
+type WatchDependencySet = {
+  add(dependency: string): unknown;
+};
+
+type ClientReferenceWatchDependencies = {
+  files: Set<string>;
+  contexts: Set<string>;
+  missing: Set<string>;
+};
+
+function createClientReferenceWatchDependencies(): ClientReferenceWatchDependencies {
+  return {
+    files: new Set<string>(),
+    contexts: new Set<string>(),
+    missing: new Set<string>(),
+  };
+}
+
+function addClientReferenceWatchDependencies(
+  compilation: FlightCompilation,
+  dependencies: ClientReferenceWatchDependencies,
+): void {
+  for (const file of dependencies.files) {
+    compilation.fileDependencies?.add(file);
+  }
+  for (const context of dependencies.contexts) {
+    compilation.contextDependencies?.add(context);
+  }
+  for (const missing of dependencies.missing) {
+    compilation.missingDependencies?.add(missing);
+  }
+}
 
 type FlightNormalModuleFactory = {
   hooks: {
@@ -364,6 +400,21 @@ type ReadFileFs = {
     filePath: string,
     encoding: string,
     callback: (err: Error | null, content?: string) => void,
+  ): void;
+};
+
+type WatchInputFileSystem = ReadFileFs & {
+  readdir(
+    filePath: string,
+    callback: (err: NodeJS.ErrnoException | null, files?: string[]) => void,
+  ): void;
+  realpath?(
+    filePath: string,
+    callback: (err: NodeJS.ErrnoException | null, realPath?: string) => void,
+  ): void;
+  stat(
+    filePath: string,
+    callback: (err: NodeJS.ErrnoException | null, stats?: { isDirectory(): boolean }) => void,
   ): void;
 };
 
@@ -439,6 +490,7 @@ export class RSCWebpackPlugin {
   apply(compiler: webpack.Compiler): void {
     const flightCompiler = compiler as unknown as FlightCompiler;
     let resolvedClientReferences: ClientReferenceDependency[] | undefined;
+    let clientReferenceWatchDependencies = createClientReferenceWatchDependencies();
     let clientFileNameFound = false;
 
     // Phase 1: resolve every configured client reference before the
@@ -447,6 +499,7 @@ export class RSCWebpackPlugin {
     flightCompiler.hooks.beforeCompile.tapAsync(PLUGIN_NAME, (params, callback) => {
       const contextResolver = flightCompiler.resolverFactory.get('context', {});
       const normalResolver = flightCompiler.resolverFactory.get('normal');
+      const nextWatchDependencies = createClientReferenceWatchDependencies();
       this.resolveAllClientFiles(
         flightCompiler.context,
         contextResolver,
@@ -458,9 +511,11 @@ export class RSCWebpackPlugin {
             callback(err);
             return;
           }
+          clientReferenceWatchDependencies = nextWatchDependencies;
           resolvedClientReferences = resolvedClientRefs;
           callback();
         },
+        nextWatchDependencies,
       );
     });
 
@@ -468,6 +523,8 @@ export class RSCWebpackPlugin {
     // named AsyncDependenciesBlock per resolved client reference, creating
     // the chunk groups the manifest is later built from.
     flightCompiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation, params) => {
+      addClientReferenceWatchDependencies(compilation, clientReferenceWatchDependencies);
+
       const normalModuleFactory = params.normalModuleFactory;
       compilation.dependencyFactories.set(ClientReferenceDependency, normalModuleFactory);
       compilation.dependencyTemplates.set(
@@ -1018,11 +1075,13 @@ export class RSCWebpackPlugin {
     fs: unknown,
     contextModuleFactory: FlightContextModuleFactory,
     callback: (err: Error | null, result?: ClientReferenceDependency[]) => void,
+    watchDependencies = createClientReferenceWatchDependencies(),
   ): void {
     asyncLib.map<ClientReferencePath, ClientReferenceDependency[]>(
       this.clientReferences,
       (clientReferencePath, cb) => {
         if (typeof clientReferencePath === 'string') {
+          watchDependencies.files.add(path.resolve(context, clientReferencePath));
           cb(null, [new ClientReferenceDependency(clientReferencePath)]);
           return;
         }
@@ -1032,50 +1091,70 @@ export class RSCWebpackPlugin {
           clientReferencePath.directory,
           {},
           (err, resolvedDirectory) => {
-            if (err) return cb(err);
-            contextModuleFactory.resolveDependencies(
+            if (err) {
+              watchDependencies.missing.add(path.resolve(context, clientReferencePath.directory));
+              return cb(err);
+            }
+            const resolvedDirectoryPath = resolvedDirectory as string;
+            watchDependencies.contexts.add(resolvedDirectoryPath);
+            this.collectClientReferenceContextDependencies(
               fs,
-              {
-                resource: resolvedDirectory as string,
-                resourceQuery: '',
-                recursive:
-                  clientReferencePath.recursive === undefined
-                    ? true
-                    : clientReferencePath.recursive,
-                regExp: clientReferencePath.include,
-                include: undefined,
-                exclude: clientReferencePath.exclude,
-              },
-              (err2, deps) => {
-                if (err2) return cb(err2);
-                const clientRefDeps = (deps || []).map((dep) => {
-                  const request = path.join(resolvedDirectory as string, dep.userRequest);
-                  const clientRefDep = new ClientReferenceDependency(request);
-                  clientRefDep.userRequest = dep.userRequest;
-                  return clientRefDep;
-                });
-                asyncLib.filter(
-                  clientRefDeps,
-                  (clientRefDep, filterCb) => {
-                    normalResolver.resolve(
-                      {},
-                      context,
-                      clientRefDep.request,
-                      {},
-                      (err3, resolvedPath) => {
-                        if (err3 || typeof resolvedPath !== 'string') {
-                          return filterCb(null, false);
-                        }
-                        (fs as ReadFileFs).readFile(resolvedPath, 'utf-8', (err4, content) => {
-                          if (err4 || typeof content !== 'string') {
-                            return filterCb(null, false);
-                          }
-                          filterCb(null, hasUseClientDirective(content));
-                        });
+              resolvedDirectoryPath,
+              clientReferencePath,
+              watchDependencies,
+              (contextDependencyErr) => {
+                if (contextDependencyErr) return cb(contextDependencyErr);
+                contextModuleFactory.resolveDependencies(
+                  fs,
+                  {
+                    resource: resolvedDirectoryPath,
+                    resourceQuery: '',
+                    recursive:
+                      clientReferencePath.recursive === undefined
+                        ? true
+                        : clientReferencePath.recursive,
+                    regExp: clientReferencePath.include,
+                    include: undefined,
+                    exclude: clientReferencePath.exclude,
+                  },
+                  (err2, deps) => {
+                    if (err2) return cb(err2);
+                    const clientRefDeps = (deps || []).map((dep) => {
+                      const request = path.join(resolvedDirectoryPath, dep.userRequest);
+                      watchDependencies.files.add(request);
+                      const clientRefDep = new ClientReferenceDependency(request);
+                      clientRefDep.userRequest = dep.userRequest;
+                      return clientRefDep;
+                    });
+                    asyncLib.filter(
+                      clientRefDeps,
+                      (clientRefDep, filterCb) => {
+                        normalResolver.resolve(
+                          {},
+                          context,
+                          clientRefDep.request,
+                          {},
+                          (err3, resolvedPath) => {
+                            if (err3 || typeof resolvedPath !== 'string') {
+                              return filterCb(null, false);
+                            }
+                            watchDependencies.files.add(resolvedPath);
+                            (fs as ReadFileFs).readFile(
+                              resolvedPath,
+                              'utf-8',
+                              (err4, content) => {
+                                if (err4 || typeof content !== 'string') {
+                                  return filterCb(null, false);
+                                }
+                                filterCb(null, hasUseClientDirective(content));
+                              },
+                            );
+                          },
+                        );
                       },
+                      cb,
                     );
                   },
-                  cb,
                 );
               },
             );
@@ -1091,6 +1170,91 @@ export class RSCWebpackPlugin {
         callback(null, flattened);
       },
     );
+  }
+
+  private collectClientReferenceContextDependencies(
+    fs: unknown,
+    rootDirectory: string,
+    clientReferencePath: ClientReferenceSearchPath,
+    watchDependencies: ClientReferenceWatchDependencies,
+    callback: (err: Error | null) => void,
+  ): void {
+    const inputFs = fs as WatchInputFileSystem;
+    const recursive = clientReferencePath.recursive !== false;
+    const visited = new Set<string>();
+
+    const walk = (directory: string, done: (err?: Error | null) => void): void => {
+      const visit = (canonicalDirectory: string): void => {
+        if (visited.has(canonicalDirectory)) {
+          done();
+          return;
+        }
+        visited.add(canonicalDirectory);
+        watchDependencies.contexts.add(directory);
+
+        inputFs.readdir(directory, (readErr, files) => {
+          if (readErr) {
+            if (readErr.code === 'ENOENT') {
+              watchDependencies.missing.add(directory);
+              done();
+              return;
+            }
+            done(readErr);
+            return;
+          }
+
+          asyncLib.map<string, void>(
+            (files ?? []).filter((file) => file.indexOf('.') !== 0),
+            (segment, mapDone) => {
+              const child = path.join(directory, segment);
+              if (clientReferencePath.exclude?.test(child)) {
+                mapDone(null);
+                return;
+              }
+
+              inputFs.stat(child, (statErr, stats) => {
+                if (statErr) {
+                  if (statErr.code === 'ENOENT') {
+                    mapDone(null);
+                    return;
+                  }
+                  mapDone(statErr);
+                  return;
+                }
+
+                if (recursive && stats?.isDirectory()) {
+                  walk(child, (walkErr) => mapDone(walkErr ?? null));
+                  return;
+                }
+
+                mapDone(null);
+              });
+            },
+            (err) => done(err),
+          );
+        });
+      };
+
+      if (!inputFs.realpath) {
+        visit(directory);
+        return;
+      }
+
+      inputFs.realpath(directory, (realpathErr, realPath) => {
+        if (realpathErr) {
+          if (realpathErr.code === 'ENOENT') {
+            watchDependencies.missing.add(directory);
+            done();
+            return;
+          }
+          done(realpathErr);
+          return;
+        }
+        visit(realPath ?? directory);
+      });
+    };
+
+    walk(rootDirectory, (err) => callback(err ?? null));
   }
 }
 

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -47,6 +47,12 @@ const asyncLib = require('neo-async') as {
     iterator: (item: T, callback: (err: Error | null, result?: R) => void) => void,
     callback: (err: Error | null, results?: R[]) => void,
   ): void;
+  mapLimit<T, R>(
+    arr: ReadonlyArray<T>,
+    limit: number,
+    iterator: (item: T, callback: (err: Error | null, result?: R) => void) => void,
+    callback: (err: Error | null, results?: R[]) => void,
+  ): void;
   filter<T>(
     arr: ReadonlyArray<T>,
     iterator: (item: T, callback: (err: Error | null, keep?: boolean) => void) => void,
@@ -421,11 +427,7 @@ type WatchInputFileSystem = ReadFileFs & {
 };
 
 const PLUGIN_NAME = 'React Server Plugin';
-
-const toClientReferenceRelativePath = (rootDirectory: string, childPath: string): string => {
-  const relativePath = path.relative(rootDirectory, childPath).replace(/\\/g, '/');
-  return relativePath ? `./${relativePath}` : '.';
-};
+const WATCH_TRAVERSAL_CONCURRENCY = 32;
 
 export class RSCWebpackPlugin {
   readonly isServer: boolean;
@@ -1217,12 +1219,12 @@ export class RSCWebpackPlugin {
             return;
           }
 
-          asyncLib.map<string, void>(
+          asyncLib.mapLimit<string, void>(
             (files ?? []).filter((file) => file.indexOf('.') !== 0),
+            WATCH_TRAVERSAL_CONCURRENCY,
             (segment, mapDone) => {
               const child = path.join(directory, segment);
-              const relativeChild = toClientReferenceRelativePath(rootDirectory, child);
-              if (clientReferencePath.exclude?.test(relativeChild)) {
+              if (clientReferencePath.exclude?.test(child)) {
                 mapDone(null);
                 return;
               }

--- a/tests/client-reference-watch-refresh.test.ts
+++ b/tests/client-reference-watch-refresh.test.ts
@@ -9,6 +9,7 @@ const DIST_RSPACK_PLUGIN = path.resolve(
   '../dist/react-server-dom-rspack/plugin.js'
 );
 const DIST_WEBPACK_PLUGIN = path.resolve(__dirname, '../dist/webpack/RSCWebpackPlugin.js');
+const DIST_PLUGINS = [DIST_RSPACK_PLUGIN, DIST_WEBPACK_PLUGIN];
 
 type Bundler = 'rspack' | 'webpack';
 type Scenario = 'add' | 'remove';
@@ -81,8 +82,28 @@ const expectNoManifestEntry = (
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+const ensureDistPluginsBuilt = (): void => {
+  if (DIST_PLUGINS.every((pluginPath) => fs.existsSync(pluginPath))) return;
+
+  try {
+    execFileSync('yarn', ['build-if-needed'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    });
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message: string };
+    throw new Error(
+      `Failed to build dist artifacts for watch refresh tests:\n${
+        err.stderr || err.stdout || err.message
+      }`
+    );
+  }
+};
+
 describe.each(['rspack', 'webpack'] as const)('%s client-reference watch refresh', (bundler) => {
   beforeAll(() => {
+    ensureDistPluginsBuilt();
     const distPlugin = bundler === 'rspack' ? DIST_RSPACK_PLUGIN : DIST_WEBPACK_PLUGIN;
     if (!fs.existsSync(distPlugin)) {
       throw new Error(`Precondition: ${distPlugin} does not exist. Run \`yarn build\` first.`);

--- a/tests/client-reference-watch-refresh.test.ts
+++ b/tests/client-reference-watch-refresh.test.ts
@@ -63,7 +63,9 @@ const expectManifestEntry = (
   filename: string
 ): void => {
   const keys = result.snapshots[snapshotIndex]!.manifestKeys;
-  expect(keys).toEqual(expect.arrayContaining([expect.stringMatching(`/${filename}$`)]));
+  expect(keys).toEqual(
+    expect.arrayContaining([expect.stringMatching(`/${escapeRegExp(filename)}$`)])
+  );
 };
 
 const expectNoManifestEntry = (
@@ -72,8 +74,12 @@ const expectNoManifestEntry = (
   filename: string
 ): void => {
   const keys = result.snapshots[snapshotIndex]!.manifestKeys;
-  expect(keys).not.toEqual(expect.arrayContaining([expect.stringMatching(`/${filename}$`)]));
+  expect(keys).not.toEqual(
+    expect.arrayContaining([expect.stringMatching(`/${escapeRegExp(filename)}$`)])
+  );
 };
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 describe.each(['rspack', 'webpack'] as const)('%s client-reference watch refresh', (bundler) => {
   beforeAll(() => {

--- a/tests/client-reference-watch-refresh.test.ts
+++ b/tests/client-reference-watch-refresh.test.ts
@@ -1,0 +1,105 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const RUNNER = path.resolve(__dirname, 'helpers/runClientReferenceWatchRefresh.js');
+const DIST_RSPACK_PLUGIN = path.resolve(
+  __dirname,
+  '../dist/react-server-dom-rspack/plugin.js'
+);
+const DIST_WEBPACK_PLUGIN = path.resolve(__dirname, '../dist/webpack/RSCWebpackPlugin.js');
+
+type Bundler = 'rspack' | 'webpack';
+type Scenario = 'add' | 'remove';
+
+type WatchRefreshResult = {
+  ok: boolean;
+  bundler: Bundler;
+  scenario: Scenario;
+  errors?: string[];
+  snapshots: Array<{
+    errors: string[];
+    warnings: string[];
+    assets: string[];
+    manifestKeys: string[];
+  }>;
+};
+
+const runWatchRefresh = (bundler: Bundler, scenario: Scenario): WatchRefreshResult => {
+  const argsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ror-rsc-watch-refresh-args-'));
+  const argsFile = path.join(argsDir, 'args.json');
+  fs.writeFileSync(argsFile, JSON.stringify({ bundler, scenario }));
+  try {
+    const out = execFileSync('node', [RUNNER, argsFile], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 90_000,
+    });
+    return JSON.parse(out) as WatchRefreshResult;
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message: string };
+    const details = err.stdout || err.stderr || err.message;
+    throw new Error(`Watch refresh runner failed for ${bundler} ${scenario}:\n${details}`);
+  } finally {
+    fs.rmSync(argsDir, { recursive: true, force: true });
+  }
+};
+
+const expectSuccessfulWatch = (result: WatchRefreshResult): void => {
+  if (!result.ok) {
+    throw new Error(
+      `${result.bundler} ${result.scenario} watch refresh failed:\n` +
+        `Errors:\n${(result.errors ?? []).join('\n')}\n` +
+        `Snapshots:\n${JSON.stringify(result.snapshots, null, 2)}`
+    );
+  }
+  expect(result.snapshots).toHaveLength(2);
+};
+
+const expectManifestEntry = (
+  result: WatchRefreshResult,
+  snapshotIndex: number,
+  filename: string
+): void => {
+  const keys = result.snapshots[snapshotIndex]!.manifestKeys;
+  expect(keys).toEqual(expect.arrayContaining([expect.stringMatching(`/${filename}$`)]));
+};
+
+const expectNoManifestEntry = (
+  result: WatchRefreshResult,
+  snapshotIndex: number,
+  filename: string
+): void => {
+  const keys = result.snapshots[snapshotIndex]!.manifestKeys;
+  expect(keys).not.toEqual(expect.arrayContaining([expect.stringMatching(`/${filename}$`)]));
+};
+
+describe.each(['rspack', 'webpack'] as const)('%s client-reference watch refresh', (bundler) => {
+  beforeAll(() => {
+    const distPlugin = bundler === 'rspack' ? DIST_RSPACK_PLUGIN : DIST_WEBPACK_PLUGIN;
+    if (!fs.existsSync(distPlugin)) {
+      throw new Error(`Precondition: ${distPlugin} does not exist. Run \`yarn build\` first.`);
+    }
+  });
+
+  it('adds newly discovered client references on the next rebuild', () => {
+    const result = runWatchRefresh(bundler, 'add');
+
+    expectSuccessfulWatch(result);
+    expectManifestEntry(result, 0, 'InitialClient.js');
+    expectNoManifestEntry(result, 0, 'AddedClient.js');
+    expectManifestEntry(result, 1, 'InitialClient.js');
+    expectManifestEntry(result, 1, 'AddedClient.js');
+  });
+
+  it('drops removed client references on the next rebuild', () => {
+    const result = runWatchRefresh(bundler, 'remove');
+
+    expectSuccessfulWatch(result);
+    expectManifestEntry(result, 0, 'InitialClient.js');
+    expectManifestEntry(result, 0, 'RemovedClient.js');
+    expectManifestEntry(result, 1, 'InitialClient.js');
+    expectNoManifestEntry(result, 1, 'RemovedClient.js');
+  });
+});

--- a/tests/helpers/runClientReferenceWatchRefresh.js
+++ b/tests/helpers/runClientReferenceWatchRefresh.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const argsFile = process.argv[2];
+if (!argsFile) {
+  process.stderr.write('Usage: node runClientReferenceWatchRefresh.js <args.json>\n');
+  process.exit(2);
+}
+
+const args = JSON.parse(fs.readFileSync(argsFile, 'utf8'));
+const projectRoot = path.resolve(__dirname, '../..');
+const context = fs.realpathSync.native(
+  fs.mkdtempSync(path.join(os.tmpdir(), `ror-rsc-${args.bundler}-${args.scenario}-`))
+);
+const outputPath = fs.realpathSync.native(
+  fs.mkdtempSync(path.join(os.tmpdir(), `ror-rsc-${args.bundler}-${args.scenario}-out-`))
+);
+
+const indexPath = path.join(context, 'index.js');
+const clientPath = (name) => path.join(context, `${name}.js`);
+
+const writeIndex = (label) => {
+  fs.writeFileSync(indexPath, `export const marker = ${JSON.stringify(label)};\n`);
+};
+
+const writeClient = (name) => {
+  fs.writeFileSync(
+    clientPath(name),
+    `'use client';\nexport default function ${name}() {\n  return ${JSON.stringify(name)};\n}\n`
+  );
+};
+
+writeIndex('initial');
+writeClient('InitialClient');
+if (args.scenario === 'remove') {
+  writeClient('RemovedClient');
+}
+
+runWatch()
+  .then((result) => {
+    process.stdout.write(JSON.stringify(result));
+  })
+  .catch((error) => {
+    process.stdout.write(
+      JSON.stringify({
+        ok: false,
+        bundler: args.bundler,
+        scenario: args.scenario,
+        errors: [error && error.stack ? error.stack : String(error)],
+        snapshots: [],
+      })
+    );
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    fs.rmSync(context, { recursive: true, force: true });
+    fs.rmSync(outputPath, { recursive: true, force: true });
+  });
+
+function runWatch() {
+  return new Promise((resolve) => {
+    const { compiler, manifestFilename } = createCompiler(args.bundler);
+    const snapshots = [];
+    let finished = false;
+    let watching;
+
+    const timeout = setTimeout(() => {
+      finish({
+        ok: false,
+        errors: [`Timed out waiting for ${args.bundler} ${args.scenario} watch rebuild`],
+      });
+    }, 60_000);
+
+    const finish = (partial) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeout);
+      const result = {
+        ok: partial.ok,
+        bundler: args.bundler,
+        scenario: args.scenario,
+        errors: partial.errors,
+        snapshots,
+      };
+
+      const closeCompiler = () => {
+        if (typeof compiler.close === 'function') {
+          compiler.close(() => resolve(result));
+          return;
+        }
+        resolve(result);
+      };
+
+      if (watching) {
+        watching.close(closeCompiler);
+      } else {
+        closeCompiler();
+      }
+    };
+
+    watching = compiler.watch({ aggregateTimeout: 20, poll: 50 }, (err, stats) => {
+      if (finished) return;
+      if (err) {
+        finish({ ok: false, errors: [err.stack || String(err)] });
+        return;
+      }
+      if (!stats) {
+        finish({ ok: false, errors: ['watch callback did not receive stats'] });
+        return;
+      }
+
+      const snapshot = createSnapshot(stats, manifestFilename);
+      snapshots.push(snapshot);
+
+      if (snapshot.errors.length > 0) {
+        finish({ ok: false, errors: snapshot.errors });
+        return;
+      }
+
+      if (snapshots.length === 1) {
+        if (args.scenario === 'add') {
+          writeClient('AddedClient');
+          writeIndex('after-add');
+        } else if (args.scenario === 'remove') {
+          fs.rmSync(clientPath('RemovedClient'), { force: true });
+          writeIndex('after-remove');
+        } else {
+          finish({ ok: false, errors: [`Unknown scenario: ${args.scenario}`] });
+        }
+        return;
+      }
+
+      finish({ ok: true });
+    });
+  });
+}
+
+function createCompiler(bundler) {
+  if (bundler === 'rspack') {
+    const { rspack } = require('@rspack/core');
+    const { RSCRspackPlugin } = require(path.join(
+      projectRoot,
+      'dist/react-server-dom-rspack/plugin.js'
+    ));
+    const runtimeEntry = path.join(projectRoot, 'dist/client.browser.js');
+    const manifestFilename = 'react-client-manifest.json';
+    return {
+      manifestFilename,
+      compiler: rspack({
+        mode: 'development',
+        target: 'web',
+        context,
+        entry: [runtimeEntry, './index.js'],
+        output: {
+          path: outputPath,
+          filename: '[name].js',
+          chunkFilename: '[name].chunk.js',
+          publicPath: '',
+          crossOriginLoading: false,
+        },
+        optimization: {
+          chunkIds: 'named',
+          moduleIds: 'named',
+          minimize: false,
+        },
+        devtool: false,
+        plugins: [new RSCRspackPlugin({ isServer: false })],
+      }),
+    };
+  }
+
+  if (bundler === 'webpack') {
+    const webpack = require('webpack');
+    const { RSCWebpackPlugin } = require(path.join(
+      projectRoot,
+      'dist/webpack/RSCWebpackPlugin.js'
+    ));
+    const runtimeEntry = require.resolve('react-server-dom-webpack/client.browser');
+    const manifestFilename = 'react-client-manifest.json';
+    return {
+      manifestFilename,
+      compiler: webpack({
+        mode: 'development',
+        target: 'web',
+        context,
+        entry: { main: [runtimeEntry, './index.js'] },
+        output: {
+          path: outputPath,
+          filename: '[name].js',
+          chunkFilename: '[name].chunk.js',
+          publicPath: '',
+          crossOriginLoading: false,
+        },
+        optimization: {
+          chunkIds: 'named',
+          moduleIds: 'named',
+          minimize: false,
+        },
+        devtool: false,
+        plugins: [new RSCWebpackPlugin({ isServer: false })],
+      }),
+    };
+  }
+
+  throw new Error(`Unknown bundler: ${bundler}`);
+}
+
+function createSnapshot(stats, manifestFilename) {
+  const info = stats.toJson({ errors: true, warnings: true, assets: true });
+  const manifestPath = path.join(outputPath, manifestFilename);
+  const manifest = fs.existsSync(manifestPath)
+    ? JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    : undefined;
+
+  return {
+    errors: (info.errors || []).map(formatProblem),
+    warnings: (info.warnings || []).map(formatProblem),
+    assets: (info.assets || []).map((asset) => asset.name),
+    manifestKeys: manifest ? Object.keys(manifest.filePathToModuleMetadata) : [],
+  };
+}
+
+function formatProblem(problem) {
+  return [problem.moduleName, problem.message, problem.details].filter(Boolean).join('\n');
+}

--- a/tests/helpers/runClientReferenceWatchRefresh.js
+++ b/tests/helpers/runClientReferenceWatchRefresh.js
@@ -21,7 +21,8 @@ const outputPath = fs.realpathSync.native(
 );
 
 const indexPath = path.join(context, 'index.js');
-const clientPath = (name) => path.join(context, `${name}.js`);
+const clientsDir = path.join(context, 'components');
+const clientPath = (name) => path.join(clientsDir, `${name}.js`);
 
 const writeIndex = (label) => {
   fs.writeFileSync(indexPath, `export const marker = ${JSON.stringify(label)};\n`);
@@ -35,6 +36,7 @@ const writeClient = (name) => {
 };
 
 writeIndex('initial');
+fs.mkdirSync(clientsDir);
 writeClient('InitialClient');
 if (args.scenario === 'remove') {
   writeClient('RemovedClient');
@@ -124,10 +126,8 @@ function runWatch() {
       if (snapshots.length === 1) {
         if (args.scenario === 'add') {
           writeClient('AddedClient');
-          writeIndex('after-add');
         } else if (args.scenario === 'remove') {
           fs.rmSync(clientPath('RemovedClient'), { force: true });
-          writeIndex('after-remove');
         } else {
           finish({ ok: false, errors: [`Unknown scenario: ${args.scenario}`] });
         }

--- a/tests/webpack-plugin-context-dependencies.test.ts
+++ b/tests/webpack-plugin-context-dependencies.test.ts
@@ -55,8 +55,10 @@ const collectContextDependencies = async (
 const fsError = (code: string): NodeJS.ErrnoException =>
   Object.assign(new Error(code), { code });
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 describe('RSCWebpackPlugin context watch dependency collection', () => {
-  it('tests excluded directories against relative client-reference paths', async () => {
+  it('tests excluded directories against the same absolute paths webpack uses', async () => {
     const root = path.resolve('/project');
     const appDir = path.join(root, 'app');
     const vendorDir = path.join(root, 'vendor');
@@ -77,7 +79,7 @@ describe('RSCWebpackPlugin context watch dependency collection', () => {
       directory: '.',
       recursive: true,
       include: /\.js$/,
-      exclude: /^\.\/vendor(?:\/|$)/,
+      exclude: new RegExp(`^${escapeRegExp(vendorDir)}(?:[/\\\\]|$)`),
     });
 
     expect(watchDependencies.contexts.has(root)).toBe(true);

--- a/tests/webpack-plugin-context-dependencies.test.ts
+++ b/tests/webpack-plugin-context-dependencies.test.ts
@@ -1,0 +1,145 @@
+import * as path from 'path';
+import { RSCWebpackPlugin } from '../src/webpack/RSCWebpackPlugin';
+
+type WatchDependencies = {
+  files: Set<string>;
+  contexts: Set<string>;
+  missing: Set<string>;
+};
+
+type ClientReferenceSearchPath = {
+  directory: string;
+  recursive?: boolean;
+  include: RegExp;
+  exclude?: RegExp;
+};
+
+type CollectCapable = {
+  collectClientReferenceContextDependencies(
+    fs: unknown,
+    rootDirectory: string,
+    clientReferencePath: ClientReferenceSearchPath,
+    watchDependencies: WatchDependencies,
+    callback: (err: Error | null) => void
+  ): void;
+};
+
+const createWatchDependencies = (): WatchDependencies => ({
+  files: new Set<string>(),
+  contexts: new Set<string>(),
+  missing: new Set<string>(),
+});
+
+const collectContextDependencies = async (
+  fs: unknown,
+  rootDirectory: string,
+  clientReferencePath: ClientReferenceSearchPath
+): Promise<WatchDependencies> => {
+  const plugin = new RSCWebpackPlugin({ isServer: false }) as unknown as CollectCapable;
+  const watchDependencies = createWatchDependencies();
+  await new Promise<void>((resolve, reject) => {
+    plugin.collectClientReferenceContextDependencies(
+      fs,
+      rootDirectory,
+      clientReferencePath,
+      watchDependencies,
+      (err) => {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+  return watchDependencies;
+};
+
+const fsError = (code: string): NodeJS.ErrnoException =>
+  Object.assign(new Error(code), { code });
+
+describe('RSCWebpackPlugin context watch dependency collection', () => {
+  it('tests excluded directories against relative client-reference paths', async () => {
+    const root = path.resolve('/project');
+    const appDir = path.join(root, 'app');
+    const vendorDir = path.join(root, 'vendor');
+    const visitedDirectories: string[] = [];
+
+    const inputFs = {
+      readdir: (directory: string, callback: (err: Error | null, files?: string[]) => void) => {
+        visitedDirectories.push(directory);
+        callback(null, directory === root ? ['app', 'vendor'] : []);
+      },
+      stat: (
+        _filePath: string,
+        callback: (err: Error | null, stats?: { isDirectory(): boolean }) => void
+      ) => callback(null, { isDirectory: () => true }),
+    };
+
+    const watchDependencies = await collectContextDependencies(inputFs, root, {
+      directory: '.',
+      recursive: true,
+      include: /\.js$/,
+      exclude: /^\.\/vendor(?:\/|$)/,
+    });
+
+    expect(watchDependencies.contexts.has(root)).toBe(true);
+    expect(watchDependencies.contexts.has(appDir)).toBe(true);
+    expect(visitedDirectories).not.toContain(vendorDir);
+  });
+
+  it('records missing dependencies instead of failing on filesystem traversal errors', async () => {
+    const root = path.resolve('/project');
+    const blockedDir = path.join(root, 'blocked-dir');
+    const brokenFile = path.join(root, 'broken-file.js');
+
+    const inputFs = {
+      readdir: (
+        directory: string,
+        callback: (err: NodeJS.ErrnoException | null, files?: string[]) => void
+      ) => {
+        if (directory === blockedDir) {
+          callback(fsError('EACCES'));
+          return;
+        }
+        callback(null, ['blocked-dir', 'broken-file.js']);
+      },
+      stat: (
+        filePath: string,
+        callback: (err: NodeJS.ErrnoException | null, stats?: { isDirectory(): boolean }) => void
+      ) => {
+        if (filePath === blockedDir) {
+          callback(null, { isDirectory: () => true });
+          return;
+        }
+        callback(fsError('ELOOP'));
+      },
+    };
+
+    const watchDependencies = await collectContextDependencies(inputFs, root, {
+      directory: '.',
+      recursive: true,
+      include: /\.js$/,
+    });
+
+    expect(watchDependencies.missing.has(blockedDir)).toBe(true);
+    expect(watchDependencies.missing.has(brokenFile)).toBe(true);
+  });
+
+  it('records a missing dependency instead of failing on realpath errors', async () => {
+    const root = path.resolve('/project');
+    const inputFs = {
+      readdir: jest.fn(),
+      realpath: (_directory: string, callback: (err: NodeJS.ErrnoException | null) => void) => {
+        callback(fsError('ELOOP'));
+      },
+      stat: jest.fn(),
+    };
+
+    const watchDependencies = await collectContextDependencies(inputFs, root, {
+      directory: '.',
+      recursive: true,
+      include: /\.js$/,
+    });
+
+    expect(watchDependencies.missing.has(root)).toBe(true);
+    expect(inputFs.readdir).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Mark the Rspack Flight runtime injection loader non-cacheable so watch rebuilds re-run the injected `import()` list after client-reference discovery changes.
- Mark the Webpack Flight runtime module non-cacheable when the parser hook attaches client-reference blocks, so watch rebuilds re-parse the runtime module and refresh those blocks.
- Add a watch-mode regression runner covering add and remove flows for both rspack and webpack.

Fixes #154

## Test plan
- `yarn build`
- `yarn jest tests/client-reference-watch-refresh.test.ts tests/rspack-plugin/plugin.test.ts tests/webpack-plugin/plugin-integration.test.ts --runInBand --forceExit`
- `codex review --base origin/main`

## Proof-first notes
- Red before the fix: the new watch-refresh coverage demonstrates that cached runtime injection/block state can miss add/remove client-reference changes.
- Green after the fix: the watch-refresh test passes for both rspack and webpack add/remove scenarios.
- Webpack scope was kept narrow: the fix uses the runtime module's cacheability rather than adding a broader invalidation design.

## Codex Decision Log
- **Non-blocking:** Whether webpack required a larger invalidation design.
  - **Decision:** Ship the narrow webpack runtime-module cacheability fix with watch coverage.
  - **Why:** The parser hook has direct access to the runtime module whose blocks depend on fresh discovery; marking only that module non-cacheable forces the necessary re-parse without broad graph invalidation.
  - **Review later:** None.

## Review notes
- `codex review --base origin/main` found no actionable issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch mode so client-side file changes are picked up more reliably during development.
  * Added support for refreshing builds when client files are added or removed, helping keep manifests up to date.
  * Better handling of directory-based client file discovery, including skipped paths and filesystem errors, to reduce missed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->