### PR TITLE
Install rspack splitChunks guard after defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this package will be documented in this file.
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
 ### Fixed
-- Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#153])
+- Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#165])
 
 ## [19.2.0] - 2026-06-28
 
@@ -61,7 +61,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
-[#153]: https://github.com/shakacode/react_on_rails_rsc/issues/153
+[#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this package will be documented in this file.
 - Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
+### Fixed
+- Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#153])
+
 ## [19.2.0] - 2026-06-28
 
 ### Breaking Changes
@@ -58,6 +61,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
+[#153]: https://github.com/shakacode/react_on_rails_rsc/issues/153
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -341,9 +341,12 @@ export class RSCRspackPlugin {
       // webpack's AsyncDependenciesBlock behavior where splitChunks does
       // not extract from block-created async chunks.
       if (!this.options.isServer) {
+        const guardedSplitChunks = new WeakSet<{ chunks?: unknown }>();
         const installSplitChunksGuard = () => {
           const splitChunks = compiler.options.optimization?.splitChunks;
           if (!splitChunks) return;
+          if (guardedSplitChunks.has(splitChunks)) return;
+          guardedSplitChunks.add(splitChunks);
 
           const origChunks = splitChunks.chunks ?? 'async';
           splitChunks.chunks = (chunk: { name?: string }) => {
@@ -360,7 +363,11 @@ export class RSCRspackPlugin {
 
         if (compiler.hooks.environment) {
           compiler.hooks.environment.tap('RSCRspackPlugin', installSplitChunksGuard);
-        } else {
+        }
+        if (compiler.hooks.afterEnvironment) {
+          compiler.hooks.afterEnvironment.tap('RSCRspackPlugin', installSplitChunksGuard);
+        }
+        if (!compiler.hooks.environment && !compiler.hooks.afterEnvironment) {
           installSplitChunksGuard();
         }
       }

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -387,7 +387,12 @@ export class RSCRspackPlugin {
         const installSplitChunksGuard = () => {
           const splitChunks = compiler.options.optimization?.splitChunks;
           if (!splitChunks) return;
-          if (guardedSplitChunks.get(splitChunks) === splitChunks.chunks) return;
+          if (
+            guardedSplitChunks.has(splitChunks) &&
+            guardedSplitChunks.get(splitChunks) === splitChunks.chunks
+          ) {
+            return;
+          }
 
           const origChunks = splitChunks.chunks ?? 'async';
           const guardedChunks = (chunk: { name?: string }) => {

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -49,6 +49,8 @@ type AnyLogger = {
   debug(...args: unknown[]): void;
 };
 
+type TapName = string | { name: string; stage?: number };
+
 type AnyCompiler = {
   options: {
     module?: { rules?: unknown[] };
@@ -58,10 +60,12 @@ type AnyCompiler = {
   context: string;
   hooks: {
     beforeCompile: { tapAsync: (name: string, fn: (params: unknown, cb: (err?: Error | null) => void) => void) => void };
-    environment?: { tap: (name: string, fn: () => void) => void };
-    afterEnvironment?: { tap: (name: string, fn: () => void) => void };
+    environment?: { tap: (name: TapName, fn: () => void) => void };
+    afterEnvironment?: {
+      tap: (name: TapName, fn: () => void) => void;
+    };
     thisCompilation: {
-      tap: (name: string | { name: string; stage?: number }, fn: (compilation: unknown) => void) => void;
+      tap: (name: TapName, fn: (compilation: unknown) => void) => void;
     };
   };
   rspack?: { version?: string };
@@ -411,19 +415,20 @@ export class RSCRspackPlugin {
           splitChunks.chunks = guardedChunks;
         };
 
-        // Rspack may attach optimization defaults after plugin apply(); retry
-        // before compilation starts and reinstall if a later normalizer/plugin
-        // overwrites splitChunks.chunks on the same object.
+        // Rspack attaches optimization defaults after user plugin apply() and
+        // before RspackOptionsApply constructs the native SplitChunksPlugin.
+        // Install late in those pre-options hooks so SplitChunksPlugin snapshots
+        // the guarded selector, and reinstall if an earlier hook overwrote it.
+        const splitChunksGuardTap = {
+          name: 'RSCRspackPlugin.splitChunksGuard',
+          stage: Number.MAX_SAFE_INTEGER,
+        };
         if (compiler.hooks.environment) {
-          compiler.hooks.environment.tap('RSCRspackPlugin', installSplitChunksGuard);
+          compiler.hooks.environment.tap(splitChunksGuardTap, installSplitChunksGuard);
         }
         if (compiler.hooks.afterEnvironment) {
-          compiler.hooks.afterEnvironment.tap('RSCRspackPlugin', installSplitChunksGuard);
+          compiler.hooks.afterEnvironment.tap(splitChunksGuardTap, installSplitChunksGuard);
         }
-        compiler.hooks.thisCompilation.tap(
-          { name: 'RSCRspackPlugin.splitChunksGuard', stage: Number.MAX_SAFE_INTEGER },
-          installSplitChunksGuard,
-        );
       }
     }
 

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -52,11 +52,14 @@ type AnyLogger = {
 type AnyCompiler = {
   options: {
     module?: { rules?: unknown[] };
+    optimization?: { splitChunks?: { chunks?: unknown } | false };
     context?: string;
   };
   context: string;
   hooks: {
     beforeCompile: { tapAsync: (name: string, fn: (params: unknown, cb: (err?: Error | null) => void) => void) => void };
+    environment?: { tap: (name: string, fn: () => void) => void };
+    afterEnvironment?: { tap: (name: string, fn: () => void) => void };
     thisCompilation: { tap: (name: string, fn: (compilation: unknown) => void) => void };
   };
   rspack?: { version?: string };
@@ -338,10 +341,10 @@ export class RSCRspackPlugin {
       // webpack's AsyncDependenciesBlock behavior where splitChunks does
       // not extract from block-created async chunks.
       if (!this.options.isServer) {
-        type SplitChunksConfig = { chunks?: unknown };
-        const optimization = (compiler.options as { optimization?: { splitChunks?: SplitChunksConfig } }).optimization;
-        const splitChunks = optimization?.splitChunks;
-        if (splitChunks) {
+        const installSplitChunksGuard = () => {
+          const splitChunks = compiler.options.optimization?.splitChunks;
+          if (!splitChunks) return;
+
           const origChunks = splitChunks.chunks ?? 'async';
           splitChunks.chunks = (chunk: { name?: string }) => {
             if (chunk.name != null && getGeneratedChunkNames().has(chunk.name)) return false;
@@ -353,6 +356,12 @@ export class RSCRspackPlugin {
             if (origChunks === 'async') return !canBeInitial;
             return true; // origChunks === 'all': include every non-generated chunk.
           };
+        };
+
+        if (compiler.hooks.environment) {
+          compiler.hooks.environment.tap('RSCRspackPlugin', installSplitChunksGuard);
+        } else {
+          installSplitChunksGuard();
         }
       }
     }

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -60,7 +60,9 @@ type AnyCompiler = {
     beforeCompile: { tapAsync: (name: string, fn: (params: unknown, cb: (err?: Error | null) => void) => void) => void };
     environment?: { tap: (name: string, fn: () => void) => void };
     afterEnvironment?: { tap: (name: string, fn: () => void) => void };
-    thisCompilation: { tap: (name: string, fn: (compilation: unknown) => void) => void };
+    thisCompilation: {
+      tap: (name: string | { name: string; stage?: number }, fn: (compilation: unknown) => void) => void;
+    };
   };
   rspack?: { version?: string };
   webpack?: { version?: string };
@@ -409,15 +411,19 @@ export class RSCRspackPlugin {
           splitChunks.chunks = guardedChunks;
         };
 
-        // Rspack may attach optimization defaults after plugin apply(); retry in
-        // both hooks and reinstall if a later normalizer/plugin overwrites
-        // splitChunks.chunks on the same object.
+        // Rspack may attach optimization defaults after plugin apply(); retry
+        // before compilation starts and reinstall if a later normalizer/plugin
+        // overwrites splitChunks.chunks on the same object.
         if (compiler.hooks.environment) {
           compiler.hooks.environment.tap('RSCRspackPlugin', installSplitChunksGuard);
         }
         if (compiler.hooks.afterEnvironment) {
           compiler.hooks.afterEnvironment.tap('RSCRspackPlugin', installSplitChunksGuard);
         }
+        compiler.hooks.thisCompilation.tap(
+          { name: 'RSCRspackPlugin.splitChunksGuard', stage: Number.MAX_SAFE_INTEGER },
+          installSplitChunksGuard,
+        );
         if (!compiler.hooks.environment && !compiler.hooks.afterEnvironment) {
           installSplitChunksGuard();
         }

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -361,6 +361,9 @@ export class RSCRspackPlugin {
           };
         };
 
+        // Rspack may attach optimization defaults after plugin apply(); retry in
+        // both hooks and rely on the WeakSet above to keep installation
+        // idempotent for whichever splitChunks object is present.
         if (compiler.hooks.environment) {
           compiler.hooks.environment.tap('RSCRspackPlugin', installSplitChunksGuard);
         }

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -424,9 +424,6 @@ export class RSCRspackPlugin {
           { name: 'RSCRspackPlugin.splitChunksGuard', stage: Number.MAX_SAFE_INTEGER },
           installSplitChunksGuard,
         );
-        if (!compiler.hooks.environment && !compiler.hooks.afterEnvironment) {
-          installSplitChunksGuard();
-        }
       }
     }
 

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -341,15 +341,14 @@ export class RSCRspackPlugin {
       // webpack's AsyncDependenciesBlock behavior where splitChunks does
       // not extract from block-created async chunks.
       if (!this.options.isServer) {
-        const guardedSplitChunks = new WeakSet<{ chunks?: unknown }>();
+        const guardedSplitChunks = new WeakMap<{ chunks?: unknown }, unknown>();
         const installSplitChunksGuard = () => {
           const splitChunks = compiler.options.optimization?.splitChunks;
           if (!splitChunks) return;
-          if (guardedSplitChunks.has(splitChunks)) return;
-          guardedSplitChunks.add(splitChunks);
+          if (guardedSplitChunks.get(splitChunks) === splitChunks.chunks) return;
 
           const origChunks = splitChunks.chunks ?? 'async';
-          splitChunks.chunks = (chunk: { name?: string }) => {
+          const guardedChunks = (chunk: { name?: string }) => {
             if (chunk.name != null && getGeneratedChunkNames().has(chunk.name)) return false;
             if (typeof origChunks === 'function') return origChunks(chunk);
             // Rspack/Webpack chunks expose canBeInitial(); keep the historical
@@ -359,11 +358,13 @@ export class RSCRspackPlugin {
             if (origChunks === 'async') return !canBeInitial;
             return true; // origChunks === 'all': include every non-generated chunk.
           };
+          guardedSplitChunks.set(splitChunks, guardedChunks);
+          splitChunks.chunks = guardedChunks;
         };
 
         // Rspack may attach optimization defaults after plugin apply(); retry in
-        // both hooks and rely on the WeakSet above to keep installation
-        // idempotent for whichever splitChunks object is present.
+        // both hooks and reinstall if a later normalizer/plugin overwrites
+        // splitChunks.chunks on the same object.
         if (compiler.hooks.environment) {
           compiler.hooks.environment.tap('RSCRspackPlugin', installSplitChunksGuard);
         }

--- a/tests/rspack-plugin/fixtures/default-splitchunks/clientlib.js
+++ b/tests/rspack-plugin/fixtures/default-splitchunks/clientlib.js
@@ -1,1 +1,3 @@
-export const clientLabel = 'clientlib';
+import { version as reactDomVersion } from 'react-dom';
+
+export const clientLabel = `clientlib:${reactDomVersion}`;

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -423,24 +423,29 @@ describe('RSCRspackPlugin', () => {
         },
       };
 
-      injectionLoader._generatedChunkNames = new Set(['client0']);
+      const originalGeneratedChunkNames = injectionLoader._generatedChunkNames;
+      try {
+        injectionLoader._generatedChunkNames = new Set(['client0']);
 
-      new RSCRspackPlugin({ isServer: false }).apply(compiler);
-      for (const callback of environmentTaps) callback();
-      compiler.options.optimization.splitChunks = splitChunks;
-      for (const callback of afterEnvironmentTaps) callback();
+        new RSCRspackPlugin({ isServer: false }).apply(compiler);
+        for (const callback of environmentTaps) callback();
+        compiler.options.optimization.splitChunks = splitChunks;
+        for (const callback of afterEnvironmentTaps) callback();
 
-      expect(environmentTaps.length).toBeGreaterThan(0);
-      expect(afterEnvironmentTaps.length).toBeGreaterThan(0);
-      expect(typeof splitChunks.chunks).toBe('function');
+        expect(environmentTaps.length).toBeGreaterThan(0);
+        expect(afterEnvironmentTaps.length).toBeGreaterThan(0);
+        expect(typeof splitChunks.chunks).toBe('function');
 
-      const chunks = splitChunks.chunks as (chunk: {
-        name?: string;
-        canBeInitial?: () => boolean;
-      }) => boolean;
-      expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
-      expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
-      expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(false);
+        const chunks = splitChunks.chunks as (chunk: {
+          name?: string;
+          canBeInitial?: () => boolean;
+        }) => boolean;
+        expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
+        expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
+        expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(false);
+      } finally {
+        injectionLoader._generatedChunkNames = originalGeneratedChunkNames;
+      }
     });
 
     it('preserves default async chunk selection while excluding generated client-reference chunks', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -448,12 +448,12 @@ describe('RSCRspackPlugin', () => {
       }
     });
 
-    it('reinstalls the splitChunks guard if the chunks selector is overwritten between hooks', () => {
+    it('installs the splitChunks guard before chunks is defaulted and reinstalls after overwrite', () => {
       const { RSCRspackPlugin } = require(DIST_PLUGIN);
       const injectionLoader = require(DIST_INJECTION_LOADER);
       const environmentTaps: Array<() => void> = [];
       const afterEnvironmentTaps: Array<() => void> = [];
-      const splitChunks: { chunks?: unknown } = { chunks: 'all' };
+      const splitChunks: { chunks?: unknown } = {};
       const compiler = {
         context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
         options: { module: {}, optimization: { splitChunks } },

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -402,10 +402,11 @@ describe('RSCRspackPlugin', () => {
   });
 
   describe('splitChunks integration', () => {
-    it('installs the default splitChunks guard after rspack option defaults are available', () => {
+    it('retries the default splitChunks guard after rspack option defaults are available', () => {
       const { RSCRspackPlugin } = require(DIST_PLUGIN);
       const injectionLoader = require(DIST_INJECTION_LOADER);
-      const defaultPhaseTaps: Array<() => void> = [];
+      const environmentTaps: Array<() => void> = [];
+      const afterEnvironmentTaps: Array<() => void> = [];
       const splitChunks: { chunks?: unknown } = { chunks: 'async' };
       const compiler = {
         context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
@@ -413,10 +414,10 @@ describe('RSCRspackPlugin', () => {
         hooks: {
           beforeCompile: { tapAsync: jest.fn() },
           environment: {
-            tap: (_name: string, callback: () => void) => defaultPhaseTaps.push(callback),
+            tap: (_name: string, callback: () => void) => environmentTaps.push(callback),
           },
           afterEnvironment: {
-            tap: (_name: string, callback: () => void) => defaultPhaseTaps.push(callback),
+            tap: (_name: string, callback: () => void) => afterEnvironmentTaps.push(callback),
           },
           thisCompilation: { tap: jest.fn() },
         },
@@ -425,10 +426,12 @@ describe('RSCRspackPlugin', () => {
       injectionLoader._generatedChunkNames = new Set(['client0']);
 
       new RSCRspackPlugin({ isServer: false }).apply(compiler);
+      for (const callback of environmentTaps) callback();
       compiler.options.optimization.splitChunks = splitChunks;
-      for (const callback of defaultPhaseTaps) callback();
+      for (const callback of afterEnvironmentTaps) callback();
 
-      expect(defaultPhaseTaps.length).toBeGreaterThan(0);
+      expect(environmentTaps.length).toBeGreaterThan(0);
+      expect(afterEnvironmentTaps.length).toBeGreaterThan(0);
       expect(typeof splitChunks.chunks).toBe('function');
 
       const chunks = splitChunks.chunks as (chunk: {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -453,6 +453,7 @@ describe('RSCRspackPlugin', () => {
       const injectionLoader = require(DIST_INJECTION_LOADER);
       const environmentTaps: Array<() => void> = [];
       const afterEnvironmentTaps: Array<() => void> = [];
+      const splitChunksGuardTaps: Array<() => void> = [];
       const splitChunks: { chunks?: unknown } = {};
       const compiler = {
         context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
@@ -465,7 +466,14 @@ describe('RSCRspackPlugin', () => {
           afterEnvironment: {
             tap: (_name: string, callback: () => void) => afterEnvironmentTaps.push(callback),
           },
-          thisCompilation: { tap: jest.fn() },
+          thisCompilation: {
+            tap: (name: string | { name: string }, callback: () => void) => {
+              const tapName = typeof name === 'string' ? name : name.name;
+              if (tapName === 'RSCRspackPlugin.splitChunksGuard') {
+                splitChunksGuardTaps.push(callback);
+              }
+            },
+          },
         },
       };
 
@@ -480,6 +488,10 @@ describe('RSCRspackPlugin', () => {
         splitChunks.chunks = 'async';
         for (const callback of afterEnvironmentTaps) callback();
 
+        expect(splitChunksGuardTaps.length).toBeGreaterThan(0);
+        splitChunks.chunks = 'all';
+        for (const callback of splitChunksGuardTaps) callback();
+
         expect(typeof splitChunks.chunks).toBe('function');
         const chunks = splitChunks.chunks as (chunk: {
           name?: string;
@@ -487,7 +499,7 @@ describe('RSCRspackPlugin', () => {
         }) => boolean;
         expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
         expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
-        expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(false);
+        expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(true);
       } finally {
         injectionLoader._generatedChunkNames = originalGeneratedChunkNames;
       }

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -56,6 +56,10 @@ const splitStaticIslandVendors = {
 afterAll(() => cleanupOutputDirs(created));
 
 const DIST_PLUGIN = path.resolve(__dirname, '../../dist/react-server-dom-rspack/plugin.js');
+const DIST_INJECTION_LOADER = path.resolve(
+  __dirname,
+  '../../dist/react-server-dom-rspack/injection-loader.js',
+);
 
 describe('RSCRspackPlugin', () => {
   beforeAll(() => {
@@ -398,6 +402,44 @@ describe('RSCRspackPlugin', () => {
   });
 
   describe('splitChunks integration', () => {
+    it('installs the default splitChunks guard after rspack option defaults are available', () => {
+      const { RSCRspackPlugin } = require(DIST_PLUGIN);
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const defaultPhaseTaps: Array<() => void> = [];
+      const splitChunks: { chunks?: unknown } = { chunks: 'async' };
+      const compiler = {
+        context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
+        options: { module: {}, optimization: {} as { splitChunks?: typeof splitChunks } },
+        hooks: {
+          beforeCompile: { tapAsync: jest.fn() },
+          environment: {
+            tap: (_name: string, callback: () => void) => defaultPhaseTaps.push(callback),
+          },
+          afterEnvironment: {
+            tap: (_name: string, callback: () => void) => defaultPhaseTaps.push(callback),
+          },
+          thisCompilation: { tap: jest.fn() },
+        },
+      };
+
+      injectionLoader._generatedChunkNames = new Set(['client0']);
+
+      new RSCRspackPlugin({ isServer: false }).apply(compiler);
+      compiler.options.optimization.splitChunks = splitChunks;
+      for (const callback of defaultPhaseTaps) callback();
+
+      expect(defaultPhaseTaps.length).toBeGreaterThan(0);
+      expect(typeof splitChunks.chunks).toBe('function');
+
+      const chunks = splitChunks.chunks as (chunk: {
+        name?: string;
+        canBeInitial?: () => boolean;
+      }) => boolean;
+      expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
+      expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
+      expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(false);
+    });
+
     it('preserves default async chunk selection while excluding generated client-reference chunks', () => {
       const result = run('default-splitchunks', {
         configExtra: {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -448,6 +448,28 @@ describe('RSCRspackPlugin', () => {
       }
     });
 
+    it('keeps generated client chunks isolated with rspack default optimization config', () => {
+      const result = run('default-splitchunks');
+      const jsAssets = result.assets.filter((asset) => asset.endsWith('.js')).sort();
+
+      expect(jsAssets).toContain('main.js');
+      expect(jsAssets.some((asset) => /^client\d+\.chunk\.js$/.test(asset))).toBe(true);
+      expect(jsAssets.filter((asset) => /vendors|biglib|clientlib/.test(asset))).toEqual([]);
+
+      const clientEntryKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientWidget.js'),
+      );
+      expect(clientEntryKey).toBeTruthy();
+
+      const clientChunkFiles = manifestChunkFiles(
+        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks,
+      );
+      expect(clientChunkFiles).toEqual(
+        expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)]),
+      );
+      expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
+    });
+
     it('preserves default async chunk selection while excluding generated client-reference chunks', () => {
       const result = run('default-splitchunks', {
         configExtra: {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -402,22 +402,28 @@ describe('RSCRspackPlugin', () => {
   });
 
   describe('splitChunks integration', () => {
-    it('retries the default splitChunks guard after rspack option defaults are available', () => {
+    it('installs the default splitChunks guard before RspackOptionsApply snapshots options', () => {
       const { RSCRspackPlugin } = require(DIST_PLUGIN);
       const injectionLoader = require(DIST_INJECTION_LOADER);
-      const environmentTaps: Array<() => void> = [];
-      const afterEnvironmentTaps: Array<() => void> = [];
-      const splitChunks: { chunks?: unknown } = { chunks: 'async' };
+      const splitChunks: { chunks?: unknown } = {};
+      type CapturedTap = {
+        name: string | { name: string; stage?: number };
+        callback: () => void;
+      };
+      const environmentTaps: CapturedTap[] = [];
+      const afterEnvironmentTaps: CapturedTap[] = [];
       const compiler = {
         context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
         options: { module: {}, optimization: {} as { splitChunks?: typeof splitChunks } },
         hooks: {
           beforeCompile: { tapAsync: jest.fn() },
           environment: {
-            tap: (_name: string, callback: () => void) => environmentTaps.push(callback),
+            tap: (name: CapturedTap['name'], callback: () => void) =>
+              environmentTaps.push({ name, callback }),
           },
           afterEnvironment: {
-            tap: (_name: string, callback: () => void) => afterEnvironmentTaps.push(callback),
+            tap: (name: CapturedTap['name'], callback: () => void) =>
+              afterEnvironmentTaps.push({ name, callback }),
           },
           thisCompilation: { tap: jest.fn() },
         },
@@ -428,78 +434,42 @@ describe('RSCRspackPlugin', () => {
         injectionLoader._generatedChunkNames = new Set(['client0']);
 
         new RSCRspackPlugin({ isServer: false }).apply(compiler);
-        for (const callback of environmentTaps) callback();
         compiler.options.optimization.splitChunks = splitChunks;
-        for (const callback of afterEnvironmentTaps) callback();
-
-        expect(environmentTaps.length).toBeGreaterThan(0);
-        expect(afterEnvironmentTaps.length).toBeGreaterThan(0);
-        expect(typeof splitChunks.chunks).toBe('function');
-
-        const chunks = splitChunks.chunks as (chunk: {
-          name?: string;
-          canBeInitial?: () => boolean;
-        }) => boolean;
-        expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
-        expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
-        expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(false);
-      } finally {
-        injectionLoader._generatedChunkNames = originalGeneratedChunkNames;
-      }
-    });
-
-    it('installs the splitChunks guard before chunks is defaulted and reinstalls after overwrite', () => {
-      const { RSCRspackPlugin } = require(DIST_PLUGIN);
-      const injectionLoader = require(DIST_INJECTION_LOADER);
-      const environmentTaps: Array<() => void> = [];
-      const afterEnvironmentTaps: Array<() => void> = [];
-      const splitChunksGuardTaps: Array<() => void> = [];
-      const splitChunks: { chunks?: unknown } = {};
-      const compiler = {
-        context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
-        options: { module: {}, optimization: { splitChunks } },
-        hooks: {
-          beforeCompile: { tapAsync: jest.fn() },
-          environment: {
-            tap: (_name: string, callback: () => void) => environmentTaps.push(callback),
-          },
-          afterEnvironment: {
-            tap: (_name: string, callback: () => void) => afterEnvironmentTaps.push(callback),
-          },
-          thisCompilation: {
-            tap: (name: string | { name: string }, callback: () => void) => {
-              const tapName = typeof name === 'string' ? name : name.name;
-              if (tapName === 'RSCRspackPlugin.splitChunksGuard') {
-                splitChunksGuardTaps.push(callback);
-              }
-            },
-          },
-        },
-      };
-
-      const originalGeneratedChunkNames = injectionLoader._generatedChunkNames;
-      try {
-        injectionLoader._generatedChunkNames = new Set(['client0']);
-
-        new RSCRspackPlugin({ isServer: false }).apply(compiler);
-        for (const callback of environmentTaps) callback();
-        expect(typeof splitChunks.chunks).toBe('function');
-
         splitChunks.chunks = 'async';
-        for (const callback of afterEnvironmentTaps) callback();
 
-        expect(splitChunksGuardTaps.length).toBeGreaterThan(0);
-        splitChunks.chunks = 'all';
-        for (const callback of splitChunksGuardTaps) callback();
-
+        for (const { callback } of environmentTaps) callback();
         expect(typeof splitChunks.chunks).toBe('function');
-        const chunks = splitChunks.chunks as (chunk: {
+
+        // A later environment-stage tap can still replace the selector; the
+        // afterEnvironment tap runs late enough to reinstall before
+        // RspackOptionsApply snapshots splitChunks for the native plugin.
+        splitChunks.chunks = 'all';
+        for (const { callback } of afterEnvironmentTaps) callback();
+
+        expect(environmentTaps).toHaveLength(1);
+        expect(afterEnvironmentTaps).toHaveLength(1);
+        expect(environmentTaps[0]!.name).toEqual({
+          name: 'RSCRspackPlugin.splitChunksGuard',
+          stage: Number.MAX_SAFE_INTEGER,
+        });
+        expect(afterEnvironmentTaps[0]!.name).toEqual({
+          name: 'RSCRspackPlugin.splitChunksGuard',
+          stage: Number.MAX_SAFE_INTEGER,
+        });
+
+        const chunksCapturedByRspackOptionsApply = splitChunks.chunks as (chunk: {
           name?: string;
           canBeInitial?: () => boolean;
         }) => boolean;
-        expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
-        expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
-        expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(true);
+        expect(chunksCapturedByRspackOptionsApply({ name: 'client0', canBeInitial: () => false })).toBe(
+          false,
+        );
+        expect(chunksCapturedByRspackOptionsApply({ name: 'client99', canBeInitial: () => false })).toBe(
+          true,
+        );
+        expect(chunksCapturedByRspackOptionsApply({ name: 'main', canBeInitial: () => true })).toBe(
+          true,
+        );
       } finally {
         injectionLoader._generatedChunkNames = originalGeneratedChunkNames;
       }

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -448,6 +448,51 @@ describe('RSCRspackPlugin', () => {
       }
     });
 
+    it('reinstalls the splitChunks guard if the chunks selector is overwritten between hooks', () => {
+      const { RSCRspackPlugin } = require(DIST_PLUGIN);
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const environmentTaps: Array<() => void> = [];
+      const afterEnvironmentTaps: Array<() => void> = [];
+      const splitChunks: { chunks?: unknown } = { chunks: 'all' };
+      const compiler = {
+        context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
+        options: { module: {}, optimization: { splitChunks } },
+        hooks: {
+          beforeCompile: { tapAsync: jest.fn() },
+          environment: {
+            tap: (_name: string, callback: () => void) => environmentTaps.push(callback),
+          },
+          afterEnvironment: {
+            tap: (_name: string, callback: () => void) => afterEnvironmentTaps.push(callback),
+          },
+          thisCompilation: { tap: jest.fn() },
+        },
+      };
+
+      const originalGeneratedChunkNames = injectionLoader._generatedChunkNames;
+      try {
+        injectionLoader._generatedChunkNames = new Set(['client0']);
+
+        new RSCRspackPlugin({ isServer: false }).apply(compiler);
+        for (const callback of environmentTaps) callback();
+        expect(typeof splitChunks.chunks).toBe('function');
+
+        splitChunks.chunks = 'async';
+        for (const callback of afterEnvironmentTaps) callback();
+
+        expect(typeof splitChunks.chunks).toBe('function');
+        const chunks = splitChunks.chunks as (chunk: {
+          name?: string;
+          canBeInitial?: () => boolean;
+        }) => boolean;
+        expect(chunks({ name: 'client0', canBeInitial: () => false })).toBe(false);
+        expect(chunks({ name: 'client99', canBeInitial: () => false })).toBe(true);
+        expect(chunks({ name: 'main', canBeInitial: () => true })).toBe(false);
+      } finally {
+        injectionLoader._generatedChunkNames = originalGeneratedChunkNames;
+      }
+    });
+
     it('keeps generated client chunks isolated with rspack default optimization config', () => {
       const result = run('default-splitchunks');
       const jsAssets = result.assets.filter((asset) => asset.endsWith('.js')).sort();


### PR DESCRIPTION
## Summary
- Move the RSCRspackPlugin generated-client splitChunks guard into Rspack's `environment` hook so it runs after option defaults are available and before `RspackOptionsApply` consumes `optimization.splitChunks`.
- Keep the existing async/all/initial/function chunk-selection semantics while excluding generated client-reference chunks.
- Add a regression that simulates Rspack adding default `splitChunks` after plugin `apply()`.

Fixes #153

## Test plan
- `yarn build`
- `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand`
- `codex review --base origin/main`

## Proof-first notes
- Red before the fix: the new targeted regression failed because no default-phase hook was registered (`defaultPhaseTaps.length` was `0`).
- Green after the fix: the same regression passes and verifies generated chunks return `false` while default async selection is preserved for non-generated chunks.
- The emitted-asset default-config probe did not fail on local `@rspack/core@1.7.11` because the installed normalizer seeds a partial `splitChunks` object early; the committed regression pins the delayed-default timing directly.

## Codex Decision Log
- **Non-blocking:** Whether to prove the bug with emitted assets or direct hook timing.
  - **Decision:** Use direct hook-timing coverage.
  - **Why:** Local emitted assets did not reproduce with the installed Rspack normalizer, but the issue is specifically about defaults arriving after `apply()`, and the regression exercises that contract.
  - **Review later:** None.

## Review notes
- `codex review --base origin/main` found no actionable issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured generated client chunks remain self-contained under default optimization settings by installing the split-chunk protection after rspack applies option defaults.
  * Improved split-chunk guard behavior across lifecycle phases and resiliently handles later `splitChunks` overrides.
* **Tests**
  * Expanded integration tests to verify guard installation during `environment`/`afterEnvironment`, including overwrite scenarios.
  * Updated the default split-chunks fixture assertions to validate client chunk isolation and manifest contents.
* **Documentation**
  * Updated the changelog with a new “Fixed” entry and refreshed PR reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->