### PR TITLE
Scope rspack diagnostics CSS to owner chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file.
 
 ### Fixed
 - Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#151])
+- Scoped Rspack diagnostics CSS to the generated chunk group for the reported client reference, avoiding importer-island CSS being counted against an imported child reference. ([#166])
 
 ## [19.2.0] - 2026-06-28
 
@@ -62,6 +63,7 @@ All notable changes to this package will be documented in this file.
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151
+[#166]: https://github.com/shakacode/react_on_rails_rsc/pull/166
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -58,10 +58,10 @@ the bundler exposes them:
 manifest emission. `totalChunkBytes` counts each emitted JS or CSS asset file
 once even when multiple client references share that asset.
 
-On client builds, CSS entries are reported from the generated chunk group for
-the listed client reference. If one island imports another client reference, the
-imported child reference keeps its own diagnostics CSS instead of inheriting the
-importing island's CSS.
+On client and server builds, CSS entries are reported from the generated chunk
+group for the listed client reference. If one island imports another client
+reference, the imported child reference keeps its own diagnostics CSS instead of
+inheriting the importing island's CSS.
 
 ## Static Page Patterns
 

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -58,6 +58,11 @@ the bundler exposes them:
 manifest emission. `totalChunkBytes` counts each emitted JS or CSS asset file
 once even when multiple client references share that asset.
 
+On client builds, CSS entries are reported from the generated chunk group for
+the listed client reference. If one island imports another client reference, the
+imported child reference keeps its own diagnostics CSS instead of inheriting the
+importing island's CSS.
+
 ## Static Page Patterns
 
 For a server-only static RSC entry, use an explicit empty client reference list

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -58,10 +58,15 @@ the bundler exposes them:
 manifest emission. `totalChunkBytes` counts each emitted JS or CSS asset file
 once even when multiple client references share that asset.
 
-On client and server builds, CSS entries are reported from the generated chunk
-group for the listed client reference. If one island imports another client
-reference, the imported child reference keeps its own diagnostics CSS instead of
-inheriting the importing island's CSS.
+On client and server builds, CSS entries are reported from the emitted CSS
+assets for the generated chunk group for the listed client reference. If one
+island imports another client reference, the imported child reference does not
+inherit a separate CSS asset that belongs only to the importing island.
+
+This diagnostics view is chunk-asset scoped, not selector scoped. If the bundler
+emits an owner island's CSS asset with selectors from a statically imported child
+in the same physical CSS file, the owner reference still reports that combined
+asset.
 
 ## Static Page Patterns
 

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -15,6 +15,7 @@
  */
 
 import type { LoaderDefinition } from 'webpack';
+import { getGeneratedChunkName } from './shared';
 
 export let _discoveredClientFiles: string[] = [];
 export let _chunkName = 'client[index]';
@@ -25,9 +26,7 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
 
   const names: string[] = [];
   const imports = _discoveredClientFiles.map((file, i) => {
-    const name = _chunkName
-      .replace(/\[index\]/g, String(i))
-      .replace(/\[request\]/g, file.replace(/[^a-zA-Z0-9_]/g, '_'));
+    const name = getGeneratedChunkName(_chunkName, file, i);
     names.push(name);
     return `import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(file)});`;
   });

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -636,11 +636,13 @@ export class RSCRspackPlugin {
     let clientFileNameFound = false;
 
     const resolvedClientFiles = new Set(this._resolvedClientFiles ?? []);
-    const generatedChunkNamesByResource = this.getGeneratedChunkNamesByResource();
+    const diagnosticsEnabled = typeof this.options.clientReferenceDiagnosticsFilename === 'string';
+    const generatedChunkNamesByResource = diagnosticsEnabled
+      ? this.getGeneratedChunkNamesByResource()
+      : undefined;
     const initialChunks = this.getInitialChunks(compilation);
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
-    const diagnosticsEnabled = typeof this.options.clientReferenceDiagnosticsFilename === 'string';
     const isResolvedClientReference = (resource: string | undefined): resource is string =>
       !!resource && resolvedClientFiles.has(resource);
     let cssPrefix =
@@ -852,9 +854,9 @@ export class RSCRspackPlugin {
     resource: string | undefined,
     chunkGroup: AnyChunkGroup,
     css: string[],
-    generatedChunkNamesByResource: ReadonlyMap<string, string>,
+    generatedChunkNamesByResource: ReadonlyMap<string, string> | undefined,
   ): string[] {
-    if (!resource || css.length === 0) return css;
+    if (!resource || css.length === 0 || !generatedChunkNamesByResource) return css;
     const generatedChunkName = generatedChunkNamesByResource.get(resource);
     if (!generatedChunkName) return css;
     return this.chunkGroupHasName(chunkGroup, generatedChunkName) ? css : [];

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -641,6 +641,8 @@ export class RSCRspackPlugin {
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
     const diagnosticsEnabled = typeof this.options.clientReferenceDiagnosticsFilename === 'string';
+    const isResolvedClientReference = (resource: string | undefined): resource is string =>
+      !!resource && resolvedClientFiles.has(resource);
     let cssPrefix =
       diagnosticsEnabled &&
       typeof compilation.outputOptions.publicPath === 'string' &&
@@ -666,24 +668,27 @@ export class RSCRspackPlugin {
           if (isRuntimeResource(mod.resource, this.options.isServer)) clientFileNameFound = true;
 
           const moduleId = compilation.chunkGraph.getModuleId(mod);
-          const diagnosticsCss = this.getDiagnosticsCssForModule(
-            mod.resource,
-            chunkGroup,
-            groupAssets.css,
-            generatedChunkNamesByResource,
-          );
-          this.recordModule(
-            mod,
-            moduleId,
-            groupAssets.chunks,
-            diagnosticsCss,
-            resolvedClientFiles,
-            filePathToModuleMetadata,
-            diagnosticsCssFiles,
-          );
+          if (isResolvedClientReference(mod.resource)) {
+            const diagnosticsCss = this.getDiagnosticsCssForModule(
+              mod.resource,
+              chunkGroup,
+              groupAssets.css,
+              generatedChunkNamesByResource,
+            );
+            this.recordModule(
+              mod,
+              moduleId,
+              groupAssets.chunks,
+              diagnosticsCss,
+              resolvedClientFiles,
+              filePathToModuleMetadata,
+              diagnosticsCssFiles,
+            );
+          }
           if (mod.modules) {
             for (const inner of mod.modules) {
               if (isRuntimeResource(inner.resource, this.options.isServer)) clientFileNameFound = true;
+              if (!isResolvedClientReference(inner.resource)) continue;
               const diagnosticsCss = this.getDiagnosticsCssForModule(
                 inner.resource,
                 chunkGroup,
@@ -816,7 +821,8 @@ export class RSCRspackPlugin {
     const css: string[] = [];
     for (const chunkUnknown of chunkGroup.chunks) {
       const c = chunkUnknown as AnyChunk;
-      if (this.isInitialChunk(c, initialChunks)) continue;
+      const isInitial = this.isInitialChunk(c, initialChunks);
+      if (isInitial && !this.options.isServer) continue;
       const files = c.files instanceof Set ? c.files : new Set(c.files);
       let recordedJs = false;
       for (const file of files) {
@@ -824,6 +830,7 @@ export class RSCRspackPlugin {
           css.push(cssPrefix + file);
           continue;
         }
+        if (isInitial) continue;
         if (recordedJs || !file.endsWith('.js') || file.endsWith('.hot-update.js')) continue;
         chunks.push(c.id, file);
         recordedJs = true;

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -80,8 +80,8 @@ type AnyCompilation = {
   hooks: {
     processAssets: {
       tap: (opts: { name: string; stage: number }, fn: () => void) => void;
-    };
-  };
+	  };
+	};
   chunkGraph: {
     getModuleChunks(module: unknown): Iterable<unknown>;
     getModuleId(module: unknown): string | number | null;
@@ -579,6 +579,7 @@ export class RSCRspackPlugin {
     let clientFileNameFound = false;
 
     const resolvedClientFiles = new Set(this._resolvedClientFiles ?? []);
+    const generatedChunkNamesByResource = this.getGeneratedChunkNamesByResource();
     const initialChunks = this.getInitialChunks(compilation);
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
@@ -606,11 +607,17 @@ export class RSCRspackPlugin {
           if (isRuntimeResource(mod.resource, this.options.isServer)) clientFileNameFound = true;
 
           const moduleId = compilation.chunkGraph.getModuleId(mod);
+          const diagnosticsCss = this.getDiagnosticsCssForModule(
+            mod.resource,
+            chunkGroup,
+            groupAssets.css,
+            generatedChunkNamesByResource,
+          );
           this.recordModule(
             mod,
             moduleId,
             groupAssets.chunks,
-            groupAssets.css,
+            diagnosticsCss,
             resolvedClientFiles,
             filePathToModuleMetadata,
             diagnosticsCssFiles,
@@ -618,11 +625,17 @@ export class RSCRspackPlugin {
           if (mod.modules) {
             for (const inner of mod.modules) {
               if (isRuntimeResource(inner.resource, this.options.isServer)) clientFileNameFound = true;
+              const diagnosticsCss = this.getDiagnosticsCssForModule(
+                inner.resource,
+                chunkGroup,
+                groupAssets.css,
+                generatedChunkNamesByResource,
+              );
               this.recordModule(
                 inner,
                 moduleId,
                 groupAssets.chunks,
-                groupAssets.css,
+                diagnosticsCss,
                 resolvedClientFiles,
                 filePathToModuleMetadata,
                 diagnosticsCssFiles,
@@ -758,6 +771,42 @@ export class RSCRspackPlugin {
       }
     }
     return { chunks, css };
+  }
+
+  private getGeneratedChunkNamesByResource(): ReadonlyMap<string, string> {
+    return new Map(
+      (this._resolvedClientFiles ?? []).map((file, index) => [
+        file,
+        this.getGeneratedChunkName(file, index),
+      ]),
+    );
+  }
+
+  private getGeneratedChunkName(file: string, index: number): string {
+    return this.chunkName
+      .replace(/\[index\]/g, String(index))
+      .replace(/\[request\]/g, file.replace(/[^a-zA-Z0-9_]/g, '_'));
+  }
+
+  private getDiagnosticsCssForModule(
+    resource: string | undefined,
+    chunkGroup: AnyChunkGroup,
+    css: string[],
+    generatedChunkNamesByResource: ReadonlyMap<string, string>,
+  ): string[] {
+    if (this.options.isServer || !resource || css.length === 0) return css;
+    const generatedChunkName = generatedChunkNamesByResource.get(resource);
+    if (!generatedChunkName) return css;
+    return this.chunkGroupHasName(chunkGroup, generatedChunkName) ? css : [];
+  }
+
+  private chunkGroupHasName(chunkGroup: AnyChunkGroup, generatedChunkName: string): boolean {
+    if (chunkGroup.name === generatedChunkName) return true;
+    for (const chunkUnknown of chunkGroup.chunks) {
+      const chunk = chunkUnknown as { name?: string };
+      if (chunk.name === generatedChunkName) return true;
+    }
+    return false;
   }
 
   private getInitialChunks(compilation: AnyCompilation): Set<unknown> {

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -26,7 +26,7 @@ import {
   DEFAULT_CLIENT_REFERENCES_EXCLUDE,
   DEFAULT_CLIENT_REFERENCES_INCLUDE,
 } from '../clientReferences';
-import { CLIENT_MODULES_KEY, hasUseClientDirective } from './shared';
+import { CLIENT_MODULES_KEY, getGeneratedChunkName, hasUseClientDirective } from './shared';
 import type {} from './injection-loader';
 
 function setInjectionState(files: string[], chunkName: string): void {
@@ -80,8 +80,8 @@ type AnyCompilation = {
   hooks: {
     processAssets: {
       tap: (opts: { name: string; stage: number }, fn: () => void) => void;
-	  };
-	};
+    };
+  };
   chunkGraph: {
     getModuleChunks(module: unknown): Iterable<unknown>;
     getModuleId(module: unknown): string | number | null;
@@ -777,15 +777,9 @@ export class RSCRspackPlugin {
     return new Map(
       (this._resolvedClientFiles ?? []).map((file, index) => [
         file,
-        this.getGeneratedChunkName(file, index),
+        getGeneratedChunkName(this.chunkName, file, index),
       ]),
     );
-  }
-
-  private getGeneratedChunkName(file: string, index: number): string {
-    return this.chunkName
-      .replace(/\[index\]/g, String(index))
-      .replace(/\[request\]/g, file.replace(/[^a-zA-Z0-9_]/g, '_'));
   }
 
   private getDiagnosticsCssForModule(
@@ -794,7 +788,7 @@ export class RSCRspackPlugin {
     css: string[],
     generatedChunkNamesByResource: ReadonlyMap<string, string>,
   ): string[] {
-    if (this.options.isServer || !resource || css.length === 0) return css;
+    if (!resource || css.length === 0) return css;
     const generatedChunkName = generatedChunkNamesByResource.get(resource);
     if (!generatedChunkName) return css;
     return this.chunkGroupHasName(chunkGroup, generatedChunkName) ? css : [];

--- a/src/react-server-dom-rspack/shared.ts
+++ b/src/react-server-dom-rspack/shared.ts
@@ -12,5 +12,10 @@
 
 export const CLIENT_MODULES_KEY: symbol = Symbol.for('react-on-rails-rsc.clientModules');
 
+export const getGeneratedChunkName = (chunkName: string, file: string, index: number): string =>
+  chunkName
+    .replace(/\[index\]/g, String(index))
+    .replace(/\[request\]/g, file.replace(/[^a-zA-Z0-9_]/g, '_'));
+
 // ── directive detection (shared between loader + plugin FS walk) ──
 export { hasUseClientDirective } from '../clientReferences';

--- a/tests/rspack-plugin/fixtures/static-islands/ParentStyledIsland.css
+++ b/tests/rspack-plugin/fixtures/static-islands/ParentStyledIsland.css
@@ -1,0 +1,3 @@
+.parent-styled-island {
+  background: peachpuff;
+}

--- a/tests/rspack-plugin/fixtures/static-islands/ParentStyledIsland.js
+++ b/tests/rspack-plugin/fixtures/static-islands/ParentStyledIsland.js
@@ -1,0 +1,8 @@
+'use client';
+
+import './ParentStyledIsland.css';
+import StyledIsland from './StyledIsland';
+
+export default function ParentStyledIsland() {
+  return `parent styled island:${StyledIsland()}`;
+}

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -24,6 +24,8 @@ export interface CompileOptions {
   crossOriginLoading?: false | 'anonymous' | 'use-credentials';
   clientReferences?: unknown;
   withCss?: boolean;
+  /** Applies rspack.optimize.LimitChunkCountPlugin({ maxChunks }). */
+  maxChunks?: number;
   /** Additional rspack config to merge. Use sparingly. */
   configExtra?: Record<string, unknown>;
 }
@@ -78,6 +80,7 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     publicPath: options.publicPath,
     crossOriginLoading: options.crossOriginLoading,
     withCss: options.withCss,
+    maxChunks: options.maxChunks,
     configExtra: serializeForRunner(options.configExtra ?? {}),
   };
   const argsFile = path.join(outputPath, '__args__.json');

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -16,6 +16,7 @@
  *     publicPath?: string,
  *     crossOriginLoading?: false|'anonymous'|'use-credentials',
  *     withCss?: boolean,
+ *     maxChunks?: number,
  *     configExtra?: object,
  *   }
  *
@@ -48,6 +49,7 @@ const {
   publicPath,
   crossOriginLoading,
   withCss,
+  maxChunks,
   configExtra,
 } = args;
 
@@ -89,6 +91,9 @@ if (withCss) {
       chunkFilename: '[name].chunk.css',
     }),
   );
+}
+if (typeof maxChunks === 'number') {
+  plugins.push(new rspack.optimize.LimitChunkCountPlugin({ maxChunks }));
 }
 
 const config = {

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -97,7 +97,7 @@ if (typeof maxChunks === 'number') {
 }
 
 const config = {
-  mode: 'development',
+  mode: typeof maxChunks === 'number' ? 'none' : 'development',
   target: isServer ? 'node' : 'web',
   context,
   entry: [runtimeEntry, './index.js'],

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -221,6 +221,26 @@ describe('RSCRspackPlugin', () => {
       expect(childCss).not.toContain('.parent-styled-island');
       expect(parentCss).toContain('.parent-styled-island');
     });
+
+    it("scopes server diagnostics CSS to the referenced island's chunk group", () => {
+      const result = run('static-islands', {
+        isServer: true,
+        clientReferences: staticIslandClientReferences(
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+        ),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        publicPath: '/assets',
+        withCss: true,
+      });
+
+      const childCss = readDiagnosticCss(result, '/StyledIsland.js');
+      const parentCss = readDiagnosticCss(result, '/ParentStyledIsland.js');
+
+      expect(childCss).toContain('.styled-island');
+      expect(childCss).not.toContain('.parent-styled-island');
+      expect(parentCss).toContain('.parent-styled-island');
+      expect(result.clientReferenceDiagnostics?.isServer).toBe(true);
+    });
   });
 
   describe('top-level manifest shape', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -26,6 +26,19 @@ type ManifestChunks =
 const manifestChunkFiles = (chunks: ManifestChunks): string[] =>
   chunks.filter((_chunk, index) => index % 2 === 1).map(String);
 
+const readDiagnosticCss = (result: CompileResult, entryFileSuffix: string): string => {
+  const entry = result.clientReferenceDiagnostics?.clientReferences.find((reference) =>
+    reference.file.endsWith(entryFileSuffix),
+  );
+  expect(entry).toBeTruthy();
+  return (entry!.css ?? [])
+    .map(({ file }) => {
+      const assetName = file.replace(/^\/assets\//, '');
+      return fs.readFileSync(path.join(result.outputPath, assetName), 'utf8');
+    })
+    .join('\n');
+};
+
 const staticIslandClientReferences = (include: RegExp) => [
   { directory: '.', recursive: false, include },
 ];
@@ -164,7 +177,7 @@ describe('RSCRspackPlugin', () => {
 
     it('includes CSS asset bytes in static island diagnostics', () => {
       const result = run('static-islands', {
-        clientReferences: staticIslandClientReferences(/StyledIsland\.js$/),
+        clientReferences: staticIslandClientReferences(/^\.\/StyledIsland\.js$/),
         clientReferenceDiagnosticsFilename: diagnosticsFilename,
         publicPath: '/assets',
         withCss: true,
@@ -189,6 +202,24 @@ describe('RSCRspackPlugin', () => {
         diagnosticEntry.chunks[0]!.bytes! + diagnosticEntry.css![0]!.bytes!,
       );
       expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
+    });
+
+    it("does not attach an importing island's CSS to an imported client reference", () => {
+      const result = run('static-islands', {
+        clientReferences: staticIslandClientReferences(
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+        ),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        publicPath: '/assets',
+        withCss: true,
+      });
+
+      const childCss = readDiagnosticCss(result, '/StyledIsland.js');
+      const parentCss = readDiagnosticCss(result, '/ParentStyledIsland.js');
+
+      expect(childCss).toContain('.styled-island');
+      expect(childCss).not.toContain('.parent-styled-island');
+      expect(parentCss).toContain('.parent-styled-island');
     });
   });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -283,6 +283,28 @@ describe('RSCRspackPlugin', () => {
       expect(result.clientReferenceDiagnostics?.isServer).toBe(true);
     });
 
+    it('keeps server diagnostics CSS when chunks merge into the initial bundle', () => {
+      const result = run('static-islands', {
+        isServer: true,
+        clientReferences: staticIslandClientReferences(
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+        ),
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+        publicPath: '/assets',
+        withCss: true,
+        maxChunks: 1,
+      });
+
+      expect(result.assets).toContain('main.css');
+
+      const childCss = readDiagnosticCss(result, '/StyledIsland.js');
+      const parentCss = readDiagnosticCss(result, '/ParentStyledIsland.js');
+
+      expect(childCss).toContain('.styled-island');
+      expect(parentCss).toContain('.parent-styled-island');
+      expect(result.clientReferenceDiagnostics?.isServer).toBe(true);
+    });
+
     it('skips CSS asset collection when diagnostics are disabled', () => {
       expect(captureBuildManifestCssPrefixes()).toEqual([null]);
     });
@@ -293,6 +315,33 @@ describe('RSCRspackPlugin', () => {
           clientReferenceDiagnosticsFilename: diagnosticsFilename,
         }),
       ).toEqual(['/assets/']);
+    });
+
+    it('keeps server diagnostics CSS from merged initial chunks without initial JS', () => {
+      const { RSCRspackPlugin } = require(DIST_PLUGIN);
+      const plugin = new RSCRspackPlugin({
+        isServer: true,
+        clientReferenceDiagnosticsFilename: diagnosticsFilename,
+      });
+      const internals = plugin as {
+        getGroupAssets: (
+          chunkGroup: unknown,
+          initialChunks: Set<unknown>,
+          cssPrefix: string | null,
+        ) => { chunks: (string | number | null)[]; css: string[] };
+      };
+      const initialChunk = {
+        id: 'server',
+        files: new Set(['server-bundle.js', 'server-bundle.css']),
+        canBeInitial: () => true,
+      };
+
+      expect(
+        internals.getGroupAssets({ chunks: [initialChunk] }, new Set([initialChunk]), '/assets/'),
+      ).toEqual({
+        chunks: [],
+        css: ['/assets/server-bundle.css'],
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes Rspack diagnostics CSS attribution so an imported child client reference does not inherit CSS from the importing island's generated chunk group.
- Applies the same diagnostics CSS scoping to server builds and adds a server diagnostics regression test.
- Shares the generated chunk-name helper between the injection loader and plugin so diagnostics matching cannot silently drift from the actual dynamic-import chunk names.
- Documents the diagnostics CSS scoping behavior and adds the changelog entry.

Fixes #162.

## Reproduction Evidence

Before the source fix, the new regression test failed in `tests/rspack-plugin/plugin.test.ts` because `/StyledIsland.js` diagnostics included CSS containing `.parent-styled-island` from `ParentStyledIsland.js`. After the review-fix pass, the same failure was reproduced for `isServer: true` before removing the server diagnostics bypass.

## Validation

- `yarn build`
- `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand --testNamePattern "scopes server diagnostics CSS"` failed before the server fix, then passed after the fix.
- `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand`
- `yarn test`
- `git diff --check`
- Autoreview: earlier `codex review --uncommitted` attempts terminated with SIGTERM before producing a final finding summary.
- Fallback review: focused `claude -p` static review after the review-fix batch found no functional blockers.

## Codex Decision Log

- **Non-blocking:** Broader shared/common CSS chunk attribution may still need deeper webpack-parity diagnostics work.
  - **Decision:** Do not expand this PR beyond the reproduced owner-chunk attribution bug and the confirmed server-build gap.
  - **Why:** The current patch leaves group-wide shared CSS behavior unchanged and fixes the specific parent/child over-attribution regression with client and server coverage.
  - **Review later:** Track as a separate diagnostics-parity/product-scope item if maintainers want rspack diagnostics to match webpack's direct-CSS graph walk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS diagnostics scoping for static islands so imported client references no longer include styles from the importing island.
  * Server diagnostics now reflect the emitted CSS for the correct generated chunk group, including cases where chunks merge into the initial bundle.
* **Documentation**
  * Clarified how client and server CSS diagnostics are derived from emitted CSS assets in static-island diagnostics.
  * Updated `CHANGELOG.md` with the new `[Unreleased]` fix entry and PR link.
* **Tests**
  * Expanded static-islands diagnostics assertions and added coverage for server-scoped behavior with merged chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->