### PR TITLE
Stop rspack client discovery from disabling cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this package will be documented in this file.
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
 ### Changed
+- Stopped `RSCRspackPlugin` from injecting a no-op `"use client"` tagging loader into every first-party module, preserving rspack incremental caching while keeping filesystem-based client-reference discovery. ([#167])
 - Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
 
 ### Fixed
@@ -67,6 +68,7 @@ All notable changes to this package will be documented in this file.
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
+[#167]: https://github.com/shakacode/react_on_rails_rsc/pull/167
 [#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151

--- a/src/react-server-dom-rspack/loader.ts
+++ b/src/react-server-dom-rspack/loader.ts
@@ -1,68 +1,13 @@
 /**
- * "use client" detector loader.
+ * Backward-compatible no-op for the historical RspackLoader export.
  *
- * Attached by RSCRspackPlugin to every JS/TS module during compilation.
- * Reads the source, checks if the file starts with a `"use client"`
- * directive (accounting for BOM, shebangs, and leading comments), and if
- * so adds the module's resourcePath to a per-compilation Set keyed by the
- * `CLIENT_MODULES_KEY` Symbol. The plugin consumes that Set at
- * `processAssets` time to emit the manifest.
- *
- * The loader passes the source through unchanged — it is purely a reporter.
- *
- * IMPORTANT: communication with the plugin goes via a Symbol-keyed
- * property on the compilation object (`compilation[CLIENT_MODULES_KEY]`).
- * The plugin eagerly creates the Set in `thisCompilation` so the loader
- * never races on initialization.
+ * RSCRspackPlugin now discovers `"use client"` files through its filesystem
+ * walk and no longer injects this loader into every application module.
  */
 
 import type { LoaderDefinition } from 'webpack';
-import { CLIENT_MODULES_KEY, hasUseClientDirective } from './shared';
 
 const RSCRspackLoader: LoaderDefinition = function RSCRspackLoader(source) {
-  // Our loader has a side effect: it mutates the compilation via
-  // `compilation[CLIENT_MODULES_KEY]`. That side effect must happen on
-  // EVERY build, including incremental rebuilds — but rspack's default
-  // loader caching would skip re-executing on cache hits, leaving the
-  // tag-set stale or empty across watch-mode rebuilds. Declaring the
-  // loader non-cacheable forces re-execution every time, which restores
-  // a correct manifest on incremental builds.
-  //
-  // The loader is effectively free (one regex test on source text), so
-  // the caching cost is negligible compared to the correctness win.
-  this.cacheable(false);
-
-  // Defensive: if another `pre` loader runs before ours and returns a
-  // Buffer (e.g., a binary loader or an ill-behaved plugin), `source`
-  // could arrive as Buffer instead of string. `charCodeAt` + `startsWith`
-  // would throw. Coerce to string so the detector is always safe.
-  const text = typeof source === 'string' ? source : String(source);
-
-  // Report the module if it has "use client" at the top.
-  if (hasUseClientDirective(text)) {
-    // `this._compilation` is the rspack/webpack Compilation object. It is a
-    // loader-context private but both rspack and webpack expose it reliably.
-    // We guard with optional chaining in case the loader gets called outside
-    // a regular compilation (e.g., loader tests).
-    const compilation = (this as unknown as { _compilation?: unknown })._compilation as
-      | Record<string | symbol, unknown>
-      | undefined;
-    if (compilation) {
-      // Plugin eagerly initializes the Set in its `thisCompilation` hook,
-      // which always runs before any loader. If the Set is missing here,
-      // the plugin wasn't applied to this compiler — skip silently (the
-      // loader is harmless on its own).
-      //
-      // Guard an empty / missing resourcePath (virtual modules synthesized
-      // by other plugins have no physical file and may report `undefined`
-      // or `""`). Tagging an empty string would pollute the manifest.
-      const set = compilation[CLIENT_MODULES_KEY] as Set<string> | undefined;
-      if (set && typeof this.resourcePath === 'string' && this.resourcePath.length > 0) {
-        set.add(this.resourcePath);
-      }
-    }
-  }
-
   return source;
 };
 

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -230,6 +230,16 @@ export interface Options {
   clientReferenceDiagnosticsFilename?: string | false;
 }
 
+// Legacy rule export kept for consumers that imported the historical symbol.
+// RSCRspackPlugin no longer injects this rule; the loader it references is a
+// no-op compatibility pass-through and does not disable rspack caching.
+export const RSC_LOADER_RULE = {
+  test: /\.[cm]?[jt]sx?$/,
+  exclude: /node_modules/,
+  enforce: 'pre' as const,
+  use: [{ loader: require.resolve('./loader') }],
+};
+
 export class RSCRspackPlugin {
   private readonly options: Options;
   private readonly clientReferences: (string | ClientReferenceSearchPath)[];

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -6,13 +6,12 @@
  * system (`rspackExperiments.reactServerComponents`, `experiments.rsc`,
  * `react-server-dom-rspack`).
  *
- * Discovery technique: a small loader (`loader.ts`) tags modules containing
- * a `"use client"` directive during parse by adding the module's resource
- * path to a per-compilation Set keyed under the `CLIENT_MODULES_KEY`
- * Symbol. A second loader prepends dynamic imports to the Flight client
- * runtime so file-system-discovered client references become async chunk
- * groups. At `processAssets`, the plugin walks chunk groups and emits the
- * React on Rails client-manifest JSON schema.
+ * Discovery technique: the plugin walks configured client-reference paths
+ * before compilation and finds files with a `"use client"` directive. A loader
+ * then prepends dynamic imports to the Flight client runtime so those
+ * file-system-discovered references become async chunk groups. At
+ * `processAssets`, the plugin walks chunk groups and emits the React on Rails
+ * client-manifest JSON schema.
  *
  * Output schema matches RoR's existing webpack-side plugin so
  * `buildServerRenderer` / `buildClientRenderer` in server.node.ts /
@@ -26,7 +25,7 @@ import {
   DEFAULT_CLIENT_REFERENCES_EXCLUDE,
   DEFAULT_CLIENT_REFERENCES_INCLUDE,
 } from '../clientReferences';
-import { CLIENT_MODULES_KEY, getGeneratedChunkName, hasUseClientDirective } from './shared';
+import { getGeneratedChunkName, hasUseClientDirective } from './shared';
 import type {} from './injection-loader';
 
 function setInjectionState(files: string[], chunkName: string): void {
@@ -151,17 +150,6 @@ function addClientReferenceWatchDependencies(
   }
 }
 
-// Helper to read/write our private Symbol key on the compilation. Using a
-// symbol requires a cast because TS structural types can't easily express
-// "indexable by this specific symbol." All accesses funnel through this
-// pair so the cast is isolated.
-type SymbolIndexable = Record<symbol, unknown>;
-const getTagSet = (compilation: AnyCompilation): Set<string> | undefined =>
-  (compilation as unknown as SymbolIndexable)[CLIENT_MODULES_KEY] as Set<string> | undefined;
-const setTagSet = (compilation: AnyCompilation, set: Set<string>): void => {
-  (compilation as unknown as SymbolIndexable)[CLIENT_MODULES_KEY] = set;
-};
-
 type AnyModule = {
   resource?: string;
   modules?: AnyModule[]; // for ConcatenatedModule
@@ -242,18 +230,6 @@ export interface Options {
   clientReferenceDiagnosticsFilename?: string | false;
 }
 
-// Default loader rule — applied to all JS/TS files so our directive detector
-// sees every user module.
-export const RSC_LOADER_RULE = {
-  test: /\.[cm]?[jt]sx?$/,
-  exclude: /node_modules/,
-  // `enforce: 'pre'` ensures we run before any transpiling loader, so we see
-  // the original source text and can detect "use client" even in TS/JSX files
-  // that other loaders will later transform.
-  enforce: 'pre' as const,
-  use: [{ loader: require.resolve('./loader') }],
-};
-
 export class RSCRspackPlugin {
   private readonly options: Options;
   private readonly clientReferences: (string | ClientReferenceSearchPath)[];
@@ -306,9 +282,6 @@ export class RSCRspackPlugin {
     const manifestFilename = this.options.clientManifestFilename ?? defaultFilename;
 
     const bundler = this.resolveBundler(compiler);
-
-    // Inject the tagging loader so every JS/TS module passes through it.
-    this.ensureLoaderRule(compiler);
 
     // ── Phase 1: FS-walk discovery (before compilation starts) ──────
     // Mirrors the webpack plugin's `beforeCompile` / `resolveAllClientFiles`.
@@ -432,15 +405,10 @@ export class RSCRspackPlugin {
       }
     }
 
-    // ── Phase 3: tag set + manifest emission ────────────────────────
+    // ── Phase 3: manifest emission ──────────────────────────────────
     compiler.hooks.thisCompilation.tap('RSCRspackPlugin', (compilationUnknown) => {
       const compilation = compilationUnknown as AnyCompilation;
       addClientReferenceWatchDependencies(compilation, clientReferenceWatchDependencies);
-
-      // Eagerly create the shared Set so the loader never races on init.
-      if (!getTagSet(compilation)) {
-        setTagSet(compilation, new Set<string>());
-      }
 
       compilation.hooks.processAssets.tap(
         {
@@ -607,20 +575,6 @@ export class RSCRspackPlugin {
     return require('webpack') as Bundler;
   }
 
-  /**
-   * Injects the tagging loader rule into compiler.options.module.rules at
-   * position 0 (so it runs `pre` relative to user rules). Idempotent — if
-   * the rule is already present, do nothing.
-   */
-  private ensureLoaderRule(compiler: AnyCompiler): void {
-    const moduleConfig = (compiler.options.module ??= {}) as { rules?: unknown[] };
-    const rules = (moduleConfig.rules ??= []) as unknown[];
-    // Detect duplicate injection by checking for our loader path.
-    const ourLoaderPath = require.resolve('./loader');
-    const alreadyInjected = this.hasLoaderRule(rules, ourLoaderPath);
-    if (!alreadyInjected) rules.unshift(RSC_LOADER_RULE);
-  }
-
   private hasLoaderRule(rules: unknown[], loaderPath: string, test?: RegExp): boolean {
     return rules.some((r) => {
       if (!r || typeof r !== 'object') return false;
@@ -641,7 +595,7 @@ export class RSCRspackPlugin {
   }
 
   /**
-   * Build the RoR-shape manifest from the tagged module set.
+   * Build the RoR-shape manifest from filesystem-discovered client references.
    *
    * Iterates `compilation.chunkGroups` (matching the webpack plugin's
    * pattern) so the `chunks` array for each module reflects ALL chunks

--- a/src/react-server-dom-rspack/shared.ts
+++ b/src/react-server-dom-rspack/shared.ts
@@ -1,21 +1,7 @@
-/**
- * Shared constants between loader and plugin.
- *
- * A globally-registered Symbol (via `Symbol.for`) is used instead of a
- * plain string so other plugins stashing arbitrary properties on the
- * compilation cannot collide with our channel. `Symbol.for` also round-
- * trips across module-instance boundaries — if the plugin is loaded twice
- * (e.g. once via `react-on-rails-rsc/RspackPlugin` and once via a
- * monorepo workspace alias), both copies see the same Symbol and share
- * state correctly.
- */
-
-export const CLIENT_MODULES_KEY: symbol = Symbol.for('react-on-rails-rsc.clientModules');
-
 export const getGeneratedChunkName = (chunkName: string, file: string, index: number): string =>
   chunkName
     .replace(/\[index\]/g, String(index))
     .replace(/\[request\]/g, file.replace(/[^a-zA-Z0-9_]/g, '_'));
 
-// ── directive detection (shared between loader + plugin FS walk) ──
+// ── directive detection (shared with the plugin FS walk) ──
 export { hasUseClientDirective } from '../clientReferences';

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -73,6 +73,10 @@ const DIST_INJECTION_LOADER = path.resolve(
   __dirname,
   '../../dist/react-server-dom-rspack/injection-loader.js',
 );
+const DIST_RSPACK_LOADER = path.resolve(
+  __dirname,
+  '../../dist/react-server-dom-rspack/loader.js',
+);
 
 describe('RSCRspackPlugin', () => {
   beforeAll(() => {
@@ -851,7 +855,7 @@ describe('RSCRspackPlugin', () => {
   describe('plugin option validation', () => {
     // Importing from dist so we don't need TS types here.
     // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-    const { RSC_LOADER_RULE, RSCRspackPlugin } = require(DIST_PLUGIN);
+    const { RSCRspackPlugin } = require(DIST_PLUGIN);
 
     it('throws when options is null', () => {
       expect(() => new RSCRspackPlugin(null)).toThrow(/isServer/);
@@ -891,8 +895,33 @@ describe('RSCRspackPlugin', () => {
       ).not.toThrow();
     });
 
-    it('does not attach the directive detector to node_modules', () => {
-      expect(RSC_LOADER_RULE.exclude.test('/app/node_modules/pkg/index.ts')).toBe(true);
+    it('injects only the runtime loader needed for filesystem-discovered client references', () => {
+      const compiler = {
+        context: path.resolve(__dirname, 'fixtures/basic-client'),
+        options: { module: {} as { rules?: unknown[] } },
+        hooks: {
+          beforeCompile: { tapAsync: jest.fn() },
+          environment: { tap: jest.fn() },
+          afterEnvironment: { tap: jest.fn() },
+          thisCompilation: { tap: jest.fn() },
+        },
+      };
+
+      new RSCRspackPlugin({ isServer: false }).apply(compiler);
+
+      const rules = (compiler.options.module.rules ?? []) as Array<{ use?: unknown }>;
+      const ruleLoaders = rules.flatMap((rule: { use?: unknown }) =>
+        Array.isArray(rule.use)
+          ? rule.use.map((entry) =>
+              typeof entry === 'string'
+                ? entry
+                : (entry as { loader?: string } | undefined)?.loader,
+            )
+          : [],
+      );
+
+      expect(ruleLoaders).not.toContain(DIST_RSPACK_LOADER);
+      expect(ruleLoaders).toContain(DIST_INJECTION_LOADER);
     });
   });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -855,7 +855,7 @@ describe('RSCRspackPlugin', () => {
   describe('plugin option validation', () => {
     // Importing from dist so we don't need TS types here.
     // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-    const { RSCRspackPlugin } = require(DIST_PLUGIN);
+    const { RSC_LOADER_RULE, RSCRspackPlugin } = require(DIST_PLUGIN);
 
     it('throws when options is null', () => {
       expect(() => new RSCRspackPlugin(null)).toThrow(/isServer/);
@@ -893,6 +893,11 @@ describe('RSCRspackPlugin', () => {
             clientManifestFilename: 'custom.json',
           }),
       ).not.toThrow();
+    });
+
+    it('keeps the historical loader rule export as a no-op compatibility rule', () => {
+      expect(RSC_LOADER_RULE.exclude.test('/app/node_modules/pkg/index.ts')).toBe(true);
+      expect(RSC_LOADER_RULE.use).toEqual([{ loader: DIST_RSPACK_LOADER }]);
     });
 
     it('injects only the runtime loader needed for filesystem-discovered client references', () => {


### PR DESCRIPTION
## Summary
- remove the RSCRspackPlugin-wide directive detector rule that ran on every first-party JS/TS module
- keep the historical RspackLoader export as a no-op compatibility pass-through
- assert the plugin now injects only the Flight runtime injection loader while filesystem discovery still drives manifests

Fixes #155

## Test plan
- yarn build
- yarn jest tests/rspack-plugin/plugin.test.ts --runInBand
- worker-reported: yarn test

## Codex Decision Log
- **Non-blocking:** Keep `src/react-server-dom-rspack/loader.ts` instead of deleting it outright.
  - **Decision:** Leave a no-op default export for compatibility with the historical RspackLoader path while removing plugin injection of the loader.
  - **Why:** The package introduced an RspackLoader export in the 19.0.5 line; preserving the file avoids breaking consumers that imported the path directly while still removing the cache-disabling app-wide rule.
  - **Review later:** Delete the compatibility shim only in a breaking-release cleanup.

## Coordination
- Batch: justin808-ge134-a
- Lane: rspack-loader-cleanup
- Agent id: codex-b450-rspack-loader-cleanup
- Local validation passed before push.
- merge_authority: ask