### PR TITLE
Scope rspack injection state by compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this package will be documented in this file.
 - Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
 
 ### Fixed
+- Fixed `RSCRspackPlugin` runtime injection state to be scoped by compiler, avoiding MultiCompiler and sequential-build cross-talk between rspack client/server builds with different client references or chunk names. ([#168])
 - Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#165])
 - Fixed watch rebuilds so rspack and webpack refresh client-reference runtime injections when `"use client"` files are added or removed without restarting the dev server. ([#164])
 - Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#151])
@@ -69,6 +70,7 @@ All notable changes to this package will be documented in this file.
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
 [#167]: https://github.com/shakacode/react_on_rails_rsc/pull/167
+[#168]: https://github.com/shakacode/react_on_rails_rsc/pull/168
 [#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -110,8 +110,12 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   // loader output.
   this.cacheable(false);
 
+  // Rspack follows webpack's loader-context convention here: `_compiler` is
+  // the same Compiler object passed to plugin.apply(). The MultiCompiler
+  // integration test exercises that identity against real rspack compilers.
   const compiler = (this as unknown as { _compiler?: CompilerKey })._compiler;
-  const emitWarning = (this as unknown as { emitWarning?: (warning: Error) => void }).emitWarning;
+  const emitWarning = (this as unknown as { emitWarning?: (warning: Error) => void })
+    .emitWarning;
   if (!compiler) {
     if (!warnedMissingCompilerContext) {
       warnedMissingCompilerContext = true;

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -31,6 +31,7 @@ export type InjectionState = {
 
 const compilerInjectionState = new WeakMap<CompilerKey, InjectionState>();
 const warnedMissingCompilerState = new WeakSet<CompilerKey>();
+let warnedMissingCompilerContext = false;
 
 const emptyInjectionState = (): InjectionState => ({
   discoveredClientFiles: [],
@@ -116,12 +117,15 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   const emitWarning = (this as unknown as { emitWarning?: (warning: Error) => void })
     .emitWarning;
   if (!compiler) {
-    emitWarning?.(
-      new Error(
-        'RSCRspackPlugin injection loader ran without a compiler context; ' +
-          'falling back to the latest legacy injection state.',
-      ),
-    );
+    if (!warnedMissingCompilerContext && emitWarning) {
+      warnedMissingCompilerContext = true;
+      emitWarning(
+        new Error(
+          'RSCRspackPlugin injection loader ran without a compiler context; ' +
+            'falling back to the latest legacy injection state.',
+        ),
+      );
+    }
   } else if (!hasInjectionStateForCompiler(compiler) && !warnedMissingCompilerState.has(compiler)) {
     warnedMissingCompilerState.add(compiler);
     emitWarning?.(

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -48,8 +48,13 @@ export function setInjectionStateForCompiler(
   discoveredClientFiles: string[],
   chunkName: string,
 ): void {
+  const nextDiscoveredClientFiles = discoveredClientFiles.slice();
+  _discoveredClientFiles = nextDiscoveredClientFiles;
+  _chunkName = chunkName;
+  _generatedChunkNames = new Set();
+
   compilerInjectionState.set(compiler, {
-    discoveredClientFiles: discoveredClientFiles.slice(),
+    discoveredClientFiles: nextDiscoveredClientFiles,
     chunkName,
     generatedChunkNames: new Set(),
   });
@@ -75,9 +80,11 @@ export function setGeneratedChunkNamesForCompiler(
   const state = compilerInjectionState.get(compiler);
   if (state) {
     state.generatedChunkNames = nextGeneratedChunkNames;
+    _generatedChunkNames = nextGeneratedChunkNames;
     return;
   }
 
+  _generatedChunkNames = nextGeneratedChunkNames;
   compilerInjectionState.set(compiler, {
     discoveredClientFiles: [],
     chunkName: _chunkName,

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -9,9 +9,9 @@
  * AsyncDependenciesBlock from JS, so dynamic imports are the only way to
  * create proper async chunks.
  *
- * The loader reads the discovered file list from module-level variables
- * set by the plugin during `beforeCompile`. The plugin and loader run
- * in the same Node process, so direct assignment works.
+ * The loader reads the discovered file list from state keyed by its compiler.
+ * A Shakapacker RSC build can run client and server compilers in the same Node
+ * process, so process-global state would make the last compiler win.
  */
 
 import type { LoaderDefinition } from 'webpack';
@@ -21,6 +21,76 @@ export let _discoveredClientFiles: string[] = [];
 export let _chunkName = 'client[index]';
 export let _generatedChunkNames: Set<string> = new Set();
 
+type CompilerKey = object;
+
+export type InjectionState = {
+  discoveredClientFiles: string[];
+  chunkName: string;
+  generatedChunkNames: Set<string>;
+};
+
+const compilerInjectionState = new WeakMap<CompilerKey, InjectionState>();
+
+const emptyInjectionState = (): InjectionState => ({
+  discoveredClientFiles: [],
+  chunkName: _chunkName,
+  generatedChunkNames: new Set(),
+});
+
+const fallbackInjectionState = (): InjectionState => ({
+  discoveredClientFiles: _discoveredClientFiles,
+  chunkName: _chunkName,
+  generatedChunkNames: _generatedChunkNames,
+});
+
+export function setInjectionStateForCompiler(
+  compiler: CompilerKey,
+  discoveredClientFiles: string[],
+  chunkName: string,
+): void {
+  compilerInjectionState.set(compiler, {
+    discoveredClientFiles: discoveredClientFiles.slice(),
+    chunkName,
+    generatedChunkNames: new Set(),
+  });
+}
+
+export function getInjectionStateForCompiler(
+  compiler: CompilerKey | undefined,
+): InjectionState {
+  if (!compiler) return fallbackInjectionState();
+  return compilerInjectionState.get(compiler) ?? emptyInjectionState();
+}
+
+export function setGeneratedChunkNamesForCompiler(
+  compiler: CompilerKey | undefined,
+  generatedChunkNames: Iterable<string>,
+): void {
+  const nextGeneratedChunkNames = new Set(generatedChunkNames);
+  if (!compiler) {
+    _generatedChunkNames = nextGeneratedChunkNames;
+    return;
+  }
+
+  const state = compilerInjectionState.get(compiler);
+  if (state) {
+    state.generatedChunkNames = nextGeneratedChunkNames;
+    return;
+  }
+
+  compilerInjectionState.set(compiler, {
+    discoveredClientFiles: [],
+    chunkName: _chunkName,
+    generatedChunkNames: nextGeneratedChunkNames,
+  });
+}
+
+export function getGeneratedChunkNamesForCompiler(
+  compiler: CompilerKey | undefined,
+): Set<string> {
+  return getInjectionStateForCompiler(compiler).generatedChunkNames;
+}
+
 const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   // The injected import list comes from the plugin's latest FS walk, not from
   // the runtime file itself. Re-run on every watch rebuild so added/removed
@@ -28,16 +98,22 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   // loader output.
   this.cacheable(false);
 
-  if (!_discoveredClientFiles.length) return source;
+  const compiler = (this as unknown as { _compiler?: CompilerKey })._compiler;
+  const { discoveredClientFiles, chunkName } = getInjectionStateForCompiler(compiler);
+
+  if (!discoveredClientFiles.length) {
+    setGeneratedChunkNamesForCompiler(compiler, []);
+    return source;
+  }
 
   const names: string[] = [];
-  const imports = _discoveredClientFiles.map((file, i) => {
-    const name = getGeneratedChunkName(_chunkName, file, i);
+  const imports = discoveredClientFiles.map((file, i) => {
+    const name = getGeneratedChunkName(chunkName, file, i);
     names.push(name);
     return `import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(file)});`;
   });
 
-  _generatedChunkNames = new Set(names);
+  setGeneratedChunkNamesForCompiler(compiler, names);
   return imports.join('\n') + '\n' + source;
 };
 

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -30,8 +30,7 @@ export type InjectionState = {
 };
 
 const compilerInjectionState = new WeakMap<CompilerKey, InjectionState>();
-let warnedMissingCompilerContext = false;
-let warnedMissingCompilerState = false;
+const warnedMissingCompilerState = new WeakSet<CompilerKey>();
 
 const emptyInjectionState = (): InjectionState => ({
   discoveredClientFiles: [],
@@ -117,17 +116,14 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   const emitWarning = (this as unknown as { emitWarning?: (warning: Error) => void })
     .emitWarning;
   if (!compiler) {
-    if (!warnedMissingCompilerContext) {
-      warnedMissingCompilerContext = true;
-      emitWarning?.(
-        new Error(
-          'RSCRspackPlugin injection loader ran without a compiler context; ' +
-            'falling back to the latest legacy injection state.',
-        ),
-      );
-    }
-  } else if (!hasInjectionStateForCompiler(compiler) && !warnedMissingCompilerState) {
-    warnedMissingCompilerState = true;
+    emitWarning?.(
+      new Error(
+        'RSCRspackPlugin injection loader ran without a compiler context; ' +
+          'falling back to the latest legacy injection state.',
+      ),
+    );
+  } else if (!hasInjectionStateForCompiler(compiler) && !warnedMissingCompilerState.has(compiler)) {
+    warnedMissingCompilerState.add(compiler);
     emitWarning?.(
       new Error(
         'RSCRspackPlugin injection loader received an unknown compiler context; ' +

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -30,6 +30,8 @@ export type InjectionState = {
 };
 
 const compilerInjectionState = new WeakMap<CompilerKey, InjectionState>();
+let warnedMissingCompilerContext = false;
+let warnedMissingCompilerState = false;
 
 const emptyInjectionState = (): InjectionState => ({
   discoveredClientFiles: [],
@@ -66,6 +68,9 @@ export function getInjectionStateForCompiler(
   if (!compiler) return fallbackInjectionState();
   return compilerInjectionState.get(compiler) ?? emptyInjectionState();
 }
+
+const hasInjectionStateForCompiler = (compiler: CompilerKey): boolean =>
+  compilerInjectionState.has(compiler);
 
 export function setGeneratedChunkNamesForCompiler(
   compiler: CompilerKey | undefined,
@@ -106,6 +111,27 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   this.cacheable(false);
 
   const compiler = (this as unknown as { _compiler?: CompilerKey })._compiler;
+  const emitWarning = (this as unknown as { emitWarning?: (warning: Error) => void }).emitWarning;
+  if (!compiler) {
+    if (!warnedMissingCompilerContext) {
+      warnedMissingCompilerContext = true;
+      emitWarning?.(
+        new Error(
+          'RSCRspackPlugin injection loader ran without a compiler context; ' +
+            'falling back to the latest legacy injection state.',
+        ),
+      );
+    }
+  } else if (!hasInjectionStateForCompiler(compiler) && !warnedMissingCompilerState) {
+    warnedMissingCompilerState = true;
+    emitWarning?.(
+      new Error(
+        'RSCRspackPlugin injection loader received an unknown compiler context; ' +
+          'client reference imports were not injected for this loader run.',
+      ),
+    );
+  }
+
   const { discoveredClientFiles, chunkName } = getInjectionStateForCompiler(compiler);
 
   if (!discoveredClientFiles.length) {

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -25,19 +25,11 @@ import {
   DEFAULT_CLIENT_REFERENCES_EXCLUDE,
   DEFAULT_CLIENT_REFERENCES_INCLUDE,
 } from '../clientReferences';
+import {
+  getGeneratedChunkNamesForCompiler,
+  setInjectionStateForCompiler,
+} from './injection-loader';
 import { getGeneratedChunkName, hasUseClientDirective } from './shared';
-import type {} from './injection-loader';
-
-function setInjectionState(files: string[], chunkName: string): void {
-  const injLoader = require('./injection-loader') as { _discoveredClientFiles: string[]; _chunkName: string };
-  injLoader._discoveredClientFiles = files;
-  injLoader._chunkName = chunkName;
-}
-
-function getGeneratedChunkNames(): Set<string> {
-  const injLoader = require('./injection-loader') as { _generatedChunkNames: Set<string> };
-  return injLoader._generatedChunkNames;
-}
 
 // Accept any bundler that looks compatible — webpack 5 or rspack. Typed loose
 // because we cannot depend on `@rspack/core` types without making it a hard
@@ -312,7 +304,7 @@ export class RSCRspackPlugin {
           );
           clientReferenceWatchDependencies = nextWatchDependencies;
           this._resolvedClientFiles = discoveredClientFiles;
-          setInjectionState(discoveredClientFiles, this.chunkName);
+          setInjectionStateForCompiler(compiler, discoveredClientFiles, this.chunkName);
           callback();
         } catch (err) {
           callback(err instanceof Error ? err : new Error(String(err)));
@@ -385,7 +377,9 @@ export class RSCRspackPlugin {
 
           const origChunks = splitChunks.chunks ?? 'async';
           const guardedChunks = (chunk: { name?: string }) => {
-            if (chunk.name != null && getGeneratedChunkNames().has(chunk.name)) return false;
+            if (chunk.name != null && getGeneratedChunkNamesForCompiler(compiler).has(chunk.name)) {
+              return false;
+            }
             if (typeof origChunks === 'function') return origChunks(chunk);
             // Rspack/Webpack chunks expose canBeInitial(); keep the historical
             // fallback for non-standard chunk shapes explicit.

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -9,6 +9,8 @@
  */
 
 import * as fs from 'fs';
+import { execFileSync } from 'child_process';
+import * as os from 'os';
 import * as path from 'path';
 import { compile, cleanupOutputDirs, type CompileResult } from './helpers/compile';
 
@@ -604,6 +606,150 @@ describe('RSCRspackPlugin', () => {
 
       return loader.call({ cacheable: jest.fn(), _compiler: compiler }, source);
     };
+
+    it('keeps client-reference injection scoped in a real rspack MultiCompiler build', () => {
+      const outputRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'ror-rsc-rspack-plugin-multicompiler-'),
+      );
+
+      try {
+        const firstOutput = path.join(outputRoot, 'first');
+        const secondOutput = path.join(outputRoot, 'second');
+        const runtimeEntry = path.resolve(__dirname, '../../dist/client.browser.js');
+        const staticIslandsFixture = path.resolve(__dirname, 'fixtures/static-islands');
+        const script = `
+          const fs = require('fs');
+          const path = require('path');
+          const { rspack } = require('@rspack/core');
+          const { RSCRspackPlugin } = require(${JSON.stringify(DIST_PLUGIN)});
+
+          const firstOutput = ${JSON.stringify(firstOutput)};
+          const secondOutput = ${JSON.stringify(secondOutput)};
+          for (const outputPath of [firstOutput, secondOutput]) {
+            fs.mkdirSync(outputPath, { recursive: true });
+          }
+
+          const makeConfig = (name, context, outputPath, include, chunkName) => ({
+            name,
+            mode: 'development',
+            target: 'web',
+            context,
+            entry: [${JSON.stringify(runtimeEntry)}, './index.js'],
+            output: {
+              path: outputPath,
+              filename: '[name].js',
+              chunkFilename: '[name].chunk.js',
+              publicPath: '',
+            },
+            optimization: {
+              chunkIds: 'named',
+              moduleIds: 'named',
+              minimize: false,
+            },
+            devtool: false,
+            plugins: [
+              new RSCRspackPlugin({
+                isServer: false,
+                clientReferences: [{ directory: '.', recursive: false, include }],
+                chunkName,
+              }),
+            ],
+          });
+
+          const readOutput = (outputPath) => ({
+            assets: fs.readdirSync(outputPath).sort(),
+            manifest: JSON.parse(
+              fs.readFileSync(path.join(outputPath, 'react-client-manifest.json'), 'utf8'),
+            ),
+          });
+
+          rspack([
+            makeConfig(
+              'first',
+              ${JSON.stringify(staticIslandsFixture)},
+              firstOutput,
+              /TinyIsland\\.js$/,
+              'first-[index]',
+            ),
+            makeConfig(
+              'second',
+              ${JSON.stringify(staticIslandsFixture)},
+              secondOutput,
+              /HeavyIsland\\.js$/,
+              'second-[index]',
+            ),
+          ], (err, stats) => {
+            const finish = (result) => {
+              process.stdout.write(JSON.stringify(result));
+              process.exit(result.ok ? 0 : 1);
+            };
+
+            if (err) {
+              finish({ ok: false, errors: [String(err)] });
+              return;
+            }
+            if (!stats) {
+              finish({ ok: false, errors: ['no stats returned'] });
+              return;
+            }
+
+            const info = stats.toJson({
+              errors: true,
+              warnings: true,
+              assets: true,
+              children: true,
+            });
+            const warnings = (info.children || [])
+              .flatMap((child) => child.warnings || [])
+              .map((warning) => warning.message || String(warning));
+
+            if (stats.hasErrors()) {
+              finish({
+                ok: false,
+                errors: (info.children || [])
+                  .flatMap((child) => child.errors || [])
+                  .map((error) => error.message || String(error)),
+                warnings,
+              });
+              return;
+            }
+
+            finish({
+              ok: true,
+              first: readOutput(firstOutput),
+              second: readOutput(secondOutput),
+              warnings,
+            });
+          });
+        `;
+
+        const raw = execFileSync(process.execPath, ['-e', script], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const result = JSON.parse(raw) as {
+          ok: true;
+          first: { assets: string[]; manifest: CompileResult['manifest'] };
+          second: { assets: string[]; manifest: CompileResult['manifest'] };
+          warnings: string[];
+        };
+        const firstFiles = Object.keys(result.first.manifest.filePathToModuleMetadata);
+        const secondFiles = Object.keys(result.second.manifest.filePathToModuleMetadata);
+
+        expect(result.ok).toBe(true);
+        expect(result.warnings.join('\n')).not.toContain('RSCRspackPlugin injection loader');
+        expect(firstFiles.some((file) => file.endsWith('/TinyIsland.js'))).toBe(true);
+        expect(firstFiles.join('\n')).not.toContain('/HeavyIsland.js');
+        expect(secondFiles.some((file) => file.endsWith('/HeavyIsland.js'))).toBe(true);
+        expect(secondFiles.join('\n')).not.toContain('/TinyIsland.js');
+        expect(result.first.assets).toContain('first-0.chunk.js');
+        expect(result.first.assets).not.toContain('second-0.chunk.js');
+        expect(result.second.assets).toContain('second-0.chunk.js');
+        expect(result.second.assets).not.toContain('first-0.chunk.js');
+      } finally {
+        fs.rmSync(outputRoot, { recursive: true, force: true });
+      }
+    });
 
     it('scopes injected files and chunk names to the loader compiler context', () => {
       const injectionLoader = require(DIST_INJECTION_LOADER);

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -594,7 +594,7 @@ describe('RSCRspackPlugin', () => {
 
     const runInjectionLoaderForCompiler = (
       injectionLoader: { default?: unknown },
-      compiler: object,
+      compiler: object | undefined,
       source = 'runtime();',
     ): string => {
       const loader = (injectionLoader.default ?? injectionLoader) as (
@@ -630,6 +630,22 @@ describe('RSCRspackPlugin', () => {
       expect(
         Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(secondCompiler)),
       ).toEqual(['second-0']);
+    });
+
+    it('keeps legacy fallback state populated when the loader has no compiler context', () => {
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const compiler = {};
+      const clientFile = path.join(__dirname, 'fixtures/basic-client/ClientButton.js');
+
+      injectionLoader.setInjectionStateForCompiler(compiler, [clientFile], 'fallback-[index]');
+
+      const source = runInjectionLoaderForCompiler(injectionLoader, undefined);
+
+      expect(source).toContain('webpackChunkName: "fallback-0"');
+      expect(source).toContain(JSON.stringify(clientFile));
+      expect(Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(undefined))).toEqual([
+        'fallback-0',
+      ]);
     });
 
     it('keeps splitChunks generated chunk filters scoped by compiler', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -819,16 +819,18 @@ describe('RSCRspackPlugin', () => {
     });
 
     it('warns once for compiler-less fallback invocations', () => {
-      const injectionLoader = require(DIST_INJECTION_LOADER);
-      const emitWarning = jest.fn();
+      jest.isolateModules(() => {
+        const injectionLoader = require(DIST_INJECTION_LOADER);
+        const emitWarning = jest.fn();
 
-      runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
-      runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
+        runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
+        runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
 
-      expect(emitWarning).toHaveBeenCalledTimes(1);
-      expect((emitWarning.mock.calls[0]![0] as Error).message).toContain(
-        'without a compiler context',
-      );
+        expect(emitWarning).toHaveBeenCalledTimes(1);
+        expect((emitWarning.mock.calls[0]![0] as Error).message).toContain(
+          'without a compiler context',
+        );
+      });
     });
 
     it('warns once per unknown compiler context', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -598,13 +598,18 @@ describe('RSCRspackPlugin', () => {
       injectionLoader: { default?: unknown },
       compiler: object | undefined,
       source = 'runtime();',
+      context: { emitWarning?: (warning: Error) => void } = {},
     ): string => {
       const loader = (injectionLoader.default ?? injectionLoader) as (
-        this: { cacheable: (flag: boolean) => void; _compiler?: object },
+        this: {
+          cacheable: (flag: boolean) => void;
+          _compiler?: object;
+          emitWarning?: (warning: Error) => void;
+        },
         source: string,
       ) => string;
 
-      return loader.call({ cacheable: jest.fn(), _compiler: compiler }, source);
+      return loader.call({ cacheable: jest.fn(), _compiler: compiler, ...context }, source);
     };
 
     it('keeps client-reference injection scoped in a real rspack MultiCompiler build', () => {
@@ -792,6 +797,46 @@ describe('RSCRspackPlugin', () => {
       expect(Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(undefined))).toEqual([
         'fallback-0',
       ]);
+    });
+
+    it('warns for every compiler-less fallback invocation', () => {
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const emitWarning = jest.fn();
+
+      runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
+      runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
+
+      expect(emitWarning).toHaveBeenCalledTimes(2);
+      expect((emitWarning.mock.calls[0]![0] as Error).message).toContain(
+        'without a compiler context',
+      );
+    });
+
+    it('warns once per unknown compiler context', () => {
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const firstCompiler = {};
+      const secondCompiler = {};
+      const firstEmitWarning = jest.fn();
+      const secondEmitWarning = jest.fn();
+
+      runInjectionLoaderForCompiler(injectionLoader, firstCompiler, 'runtime();', {
+        emitWarning: firstEmitWarning,
+      });
+      runInjectionLoaderForCompiler(injectionLoader, firstCompiler, 'runtime();', {
+        emitWarning: firstEmitWarning,
+      });
+      runInjectionLoaderForCompiler(injectionLoader, secondCompiler, 'runtime();', {
+        emitWarning: secondEmitWarning,
+      });
+
+      expect(firstEmitWarning).toHaveBeenCalledTimes(1);
+      expect((firstEmitWarning.mock.calls[0]![0] as Error).message).toContain(
+        'unknown compiler context',
+      );
+      expect(secondEmitWarning).toHaveBeenCalledTimes(1);
+      expect((secondEmitWarning.mock.calls[0]![0] as Error).message).toContain(
+        'unknown compiler context',
+      );
     });
 
     it('keeps splitChunks generated chunk filters scoped by compiler', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -79,6 +79,8 @@ const DIST_RSPACK_LOADER = path.resolve(
   __dirname,
   '../../dist/react-server-dom-rspack/loader.js',
 );
+const MULTICOMPILER_CHILD_TIMEOUT_MS = 30_000;
+const MULTICOMPILER_JEST_TIMEOUT_MS = MULTICOMPILER_CHILD_TIMEOUT_MS + 5_000;
 
 describe('RSCRspackPlugin', () => {
   beforeAll(() => {
@@ -728,10 +730,27 @@ describe('RSCRspackPlugin', () => {
           });
         `;
 
-        const raw = execFileSync(process.execPath, ['-e', script], {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
-        });
+        let raw: string;
+        try {
+          raw = execFileSync(process.execPath, ['-e', script], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: MULTICOMPILER_CHILD_TIMEOUT_MS,
+          });
+        } catch (error) {
+          const childError = error as Error & { stdout?: string | Buffer; stderr?: string | Buffer };
+          const stdout = childError.stdout?.toString() ?? '';
+          const stderr = childError.stderr?.toString() ?? '';
+          throw new Error(
+            [
+              `rspack MultiCompiler child process failed: ${childError.message}`,
+              stdout && `stdout:\n${stdout}`,
+              stderr && `stderr:\n${stderr}`,
+            ]
+              .filter(Boolean)
+              .join('\n\n'),
+          );
+        }
         const result = JSON.parse(raw) as {
           ok: true;
           first: { assets: string[]; manifest: CompileResult['manifest'] };
@@ -754,7 +773,7 @@ describe('RSCRspackPlugin', () => {
       } finally {
         fs.rmSync(outputRoot, { recursive: true, force: true });
       }
-    });
+    }, MULTICOMPILER_JEST_TIMEOUT_MS);
 
     it('scopes injected files and chunk names to the loader compiler context', () => {
       const injectionLoader = require(DIST_INJECTION_LOADER);
@@ -799,14 +818,14 @@ describe('RSCRspackPlugin', () => {
       ]);
     });
 
-    it('warns for every compiler-less fallback invocation', () => {
+    it('warns once for compiler-less fallback invocations', () => {
       const injectionLoader = require(DIST_INJECTION_LOADER);
       const emitWarning = jest.fn();
 
       runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
       runInjectionLoaderForCompiler(injectionLoader, undefined, 'runtime();', { emitWarning });
 
-      expect(emitWarning).toHaveBeenCalledTimes(2);
+      expect(emitWarning).toHaveBeenCalledTimes(1);
       expect((emitWarning.mock.calls[0]![0] as Error).message).toContain(
         'without a compiler context',
       );

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -559,77 +559,156 @@ describe('RSCRspackPlugin', () => {
   });
 
   describe('splitChunks integration', () => {
+    type CapturedTap = {
+      name: string | { name: string; stage?: number };
+      callback: () => void;
+    };
+
+    const createSplitChunksCompiler = (initialSplitChunks?: { chunks?: unknown }) => {
+      const environmentTaps: CapturedTap[] = [];
+      const afterEnvironmentTaps: CapturedTap[] = [];
+      const optimization = {} as { splitChunks?: { chunks?: unknown } };
+      if (initialSplitChunks) optimization.splitChunks = initialSplitChunks;
+
+      return {
+        compiler: {
+          context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
+          options: { module: {}, optimization },
+          hooks: {
+            beforeCompile: { tapAsync: jest.fn() },
+            environment: {
+              tap: (name: CapturedTap['name'], callback: () => void) =>
+                environmentTaps.push({ name, callback }),
+            },
+            afterEnvironment: {
+              tap: (name: CapturedTap['name'], callback: () => void) =>
+                afterEnvironmentTaps.push({ name, callback }),
+            },
+            thisCompilation: { tap: jest.fn() },
+          },
+        },
+        environmentTaps,
+        afterEnvironmentTaps,
+      };
+    };
+
+    const runInjectionLoaderForCompiler = (
+      injectionLoader: { default?: unknown },
+      compiler: object,
+      source = 'runtime();',
+    ): string => {
+      const loader = (injectionLoader.default ?? injectionLoader) as (
+        this: { cacheable: (flag: boolean) => void; _compiler?: object },
+        source: string,
+      ) => string;
+
+      return loader.call({ cacheable: jest.fn(), _compiler: compiler }, source);
+    };
+
+    it('scopes injected files and chunk names to the loader compiler context', () => {
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const firstCompiler = {};
+      const secondCompiler = {};
+      const firstFile = path.join(__dirname, 'fixtures/basic-client/ClientButton.js');
+      const secondFile = path.join(__dirname, 'fixtures/basic-client/ServerHeader.js');
+
+      injectionLoader.setInjectionStateForCompiler(firstCompiler, [firstFile], 'first-[index]');
+      injectionLoader.setInjectionStateForCompiler(secondCompiler, [secondFile], 'second-[index]');
+
+      const firstSource = runInjectionLoaderForCompiler(injectionLoader, firstCompiler);
+      const secondSource = runInjectionLoaderForCompiler(injectionLoader, secondCompiler);
+
+      expect(firstSource).toContain('webpackChunkName: "first-0"');
+      expect(firstSource).toContain(JSON.stringify(firstFile));
+      expect(firstSource).not.toContain(JSON.stringify(secondFile));
+      expect(secondSource).toContain('webpackChunkName: "second-0"');
+      expect(secondSource).toContain(JSON.stringify(secondFile));
+      expect(secondSource).not.toContain(JSON.stringify(firstFile));
+      expect(
+        Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(firstCompiler)),
+      ).toEqual(['first-0']);
+      expect(
+        Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(secondCompiler)),
+      ).toEqual(['second-0']);
+    });
+
+    it('keeps splitChunks generated chunk filters scoped by compiler', () => {
+      const { RSCRspackPlugin } = require(DIST_PLUGIN);
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const firstSplitChunks: { chunks?: unknown } = { chunks: 'async' };
+      const secondSplitChunks: { chunks?: unknown } = { chunks: 'async' };
+      const first = createSplitChunksCompiler(firstSplitChunks);
+      const second = createSplitChunksCompiler(secondSplitChunks);
+
+      new RSCRspackPlugin({ isServer: false }).apply(first.compiler);
+      new RSCRspackPlugin({ isServer: false }).apply(second.compiler);
+
+      for (const { callback } of first.environmentTaps) callback();
+      for (const { callback } of second.environmentTaps) callback();
+
+      injectionLoader.setGeneratedChunkNamesForCompiler(first.compiler, ['first-client']);
+      injectionLoader.setGeneratedChunkNamesForCompiler(second.compiler, ['second-client']);
+
+      const firstGuard = firstSplitChunks.chunks as (chunk: {
+        name?: string;
+        canBeInitial?: () => boolean;
+      }) => boolean;
+      const secondGuard = secondSplitChunks.chunks as (chunk: {
+        name?: string;
+        canBeInitial?: () => boolean;
+      }) => boolean;
+
+      expect(firstGuard({ name: 'first-client', canBeInitial: () => false })).toBe(false);
+      expect(firstGuard({ name: 'second-client', canBeInitial: () => false })).toBe(true);
+      expect(secondGuard({ name: 'second-client', canBeInitial: () => false })).toBe(false);
+      expect(secondGuard({ name: 'first-client', canBeInitial: () => false })).toBe(true);
+    });
+
     it('installs the default splitChunks guard before RspackOptionsApply snapshots options', () => {
       const { RSCRspackPlugin } = require(DIST_PLUGIN);
       const injectionLoader = require(DIST_INJECTION_LOADER);
       const splitChunks: { chunks?: unknown } = {};
-      type CapturedTap = {
-        name: string | { name: string; stage?: number };
-        callback: () => void;
-      };
-      const environmentTaps: CapturedTap[] = [];
-      const afterEnvironmentTaps: CapturedTap[] = [];
-      const compiler = {
-        context: path.resolve(__dirname, 'fixtures/default-splitchunks'),
-        options: { module: {}, optimization: {} as { splitChunks?: typeof splitChunks } },
-        hooks: {
-          beforeCompile: { tapAsync: jest.fn() },
-          environment: {
-            tap: (name: CapturedTap['name'], callback: () => void) =>
-              environmentTaps.push({ name, callback }),
-          },
-          afterEnvironment: {
-            tap: (name: CapturedTap['name'], callback: () => void) =>
-              afterEnvironmentTaps.push({ name, callback }),
-          },
-          thisCompilation: { tap: jest.fn() },
-        },
-      };
+      const { compiler, environmentTaps, afterEnvironmentTaps } = createSplitChunksCompiler();
 
-      const originalGeneratedChunkNames = injectionLoader._generatedChunkNames;
-      try {
-        injectionLoader._generatedChunkNames = new Set(['client0']);
+      injectionLoader.setGeneratedChunkNamesForCompiler(compiler, ['client0']);
 
-        new RSCRspackPlugin({ isServer: false }).apply(compiler);
-        compiler.options.optimization.splitChunks = splitChunks;
-        splitChunks.chunks = 'async';
+      new RSCRspackPlugin({ isServer: false }).apply(compiler);
+      compiler.options.optimization.splitChunks = splitChunks;
+      splitChunks.chunks = 'async';
 
-        for (const { callback } of environmentTaps) callback();
-        expect(typeof splitChunks.chunks).toBe('function');
+      for (const { callback } of environmentTaps) callback();
+      expect(typeof splitChunks.chunks).toBe('function');
 
-        // A later environment-stage tap can still replace the selector; the
-        // afterEnvironment tap runs late enough to reinstall before
-        // RspackOptionsApply snapshots splitChunks for the native plugin.
-        splitChunks.chunks = 'all';
-        for (const { callback } of afterEnvironmentTaps) callback();
+      // A later environment-stage tap can still replace the selector; the
+      // afterEnvironment tap runs late enough to reinstall before
+      // RspackOptionsApply snapshots splitChunks for the native plugin.
+      splitChunks.chunks = 'all';
+      for (const { callback } of afterEnvironmentTaps) callback();
 
-        expect(environmentTaps).toHaveLength(1);
-        expect(afterEnvironmentTaps).toHaveLength(1);
-        expect(environmentTaps[0]!.name).toEqual({
-          name: 'RSCRspackPlugin.splitChunksGuard',
-          stage: Number.MAX_SAFE_INTEGER,
-        });
-        expect(afterEnvironmentTaps[0]!.name).toEqual({
-          name: 'RSCRspackPlugin.splitChunksGuard',
-          stage: Number.MAX_SAFE_INTEGER,
-        });
+      expect(environmentTaps).toHaveLength(1);
+      expect(afterEnvironmentTaps).toHaveLength(1);
+      expect(environmentTaps[0]!.name).toEqual({
+        name: 'RSCRspackPlugin.splitChunksGuard',
+        stage: Number.MAX_SAFE_INTEGER,
+      });
+      expect(afterEnvironmentTaps[0]!.name).toEqual({
+        name: 'RSCRspackPlugin.splitChunksGuard',
+        stage: Number.MAX_SAFE_INTEGER,
+      });
 
-        const chunksCapturedByRspackOptionsApply = splitChunks.chunks as (chunk: {
-          name?: string;
-          canBeInitial?: () => boolean;
-        }) => boolean;
-        expect(chunksCapturedByRspackOptionsApply({ name: 'client0', canBeInitial: () => false })).toBe(
-          false,
-        );
-        expect(chunksCapturedByRspackOptionsApply({ name: 'client99', canBeInitial: () => false })).toBe(
-          true,
-        );
-        expect(chunksCapturedByRspackOptionsApply({ name: 'main', canBeInitial: () => true })).toBe(
-          true,
-        );
-      } finally {
-        injectionLoader._generatedChunkNames = originalGeneratedChunkNames;
-      }
+      const chunksCapturedByRspackOptionsApply = splitChunks.chunks as (chunk: {
+        name?: string;
+        canBeInitial?: () => boolean;
+      }) => boolean;
+      expect(chunksCapturedByRspackOptionsApply({ name: 'client0', canBeInitial: () => false })).toBe(
+        false,
+      );
+      expect(
+        chunksCapturedByRspackOptionsApply({ name: 'client99', canBeInitial: () => false }),
+      ).toBe(true);
+      expect(chunksCapturedByRspackOptionsApply({ name: 'main', canBeInitial: () => true })).toBe(
+        true,
+      );
     });
 
     it('keeps generated client chunks isolated with rspack default optimization config', () => {


### PR DESCRIPTION
## Summary
- replace process-global rspack runtime injection state with compiler-keyed state
- make the injection loader read discovered client files and generated chunk names from its own compiler context
- add regression coverage for compiler-scoped loader injection and splitChunks guard filtering

Fixes #156
Depends on #167

## Test plan
- yarn build
- yarn jest tests/rspack-plugin/plugin.test.ts --runInBand
- yarn test

## Codex Decision Log
- **Non-blocking:** Keep legacy module-level exports as a fallback while routing plugin-owned state through compiler-scoped helpers.
  - **Decision:** Preserve `_discoveredClientFiles`, `_chunkName`, and `_generatedChunkNames` for compatibility when the loader is called without `_compiler`, but stop using them for plugin-driven compiler state.
  - **Why:** The loader context normally exposes `_compiler`, but the fallback keeps direct loader invocation and historical test/debug imports from failing.
  - **Review later:** Remove the fallback only in a breaking-release cleanup.

## Coordination
- Batch: justin808-ge134-a
- Lane: rspack-compiler-state
- Agent id: codex-b450-rspack-compiler-state
- Base dependency: #167 / jg/155-rspack-loader-cleanup
- Worker validation passed before push.
- merge_authority: ask

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build state isolation so separate client/server builds no longer interfere with each other when run in the same process.
  * Improved generated chunk handling to keep output and metadata scoped to the correct build, reducing cross-build mix-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->