### PR TITLE
Update post-final RSC release docs

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,7 +14,7 @@ release PR merges. Publish from the GitHub Actions release workflow; the local
    ```
 
    Use `/update-changelog release`, `/update-changelog beta`, or an explicit
-   version such as `/update-changelog 19.2.0-rc.4` when that is the intended
+   version such as `/update-changelog 19.2.1-rc.1` when that is the intended
    release type.
 
 2. Review the stamped `CHANGELOG.md` and matching `package.json`, do a final


### PR DESCRIPTION
## Summary
- updates the release docs so the next example changelog command points at `19.2.1-rc.1` instead of the now-final `19.2.0-rc.4`

## Rationale
`19.2.0` has been promoted to final, so the package release instructions should no longer use the old RC as the next prerelease example.

## Verification
- `git diff --check`
- `rg -n "19\\.2\\.0-rc\\.4" docs/releasing.md` returned no matches
