### PR TITLE
Fix webpack RSC runtime parity gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this package will be documented in this file.
 - Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
 
 ### Fixed
+- Fixed Webpack client-reference string paths to resolve relative to the compiler context and warned when `output.publicPath: "auto"` cannot be serialized into the RSC manifest. ([#171])
 - Fixed Rspack client-reference manifests to emit deterministic chunk pair ordering under Rspack 2 while preserving the full sibling chunk set. ([#140])
 - Fixed `RSCRspackPlugin` runtime injection state to be scoped by compiler, avoiding MultiCompiler and sequential-build cross-talk between rspack client/server builds with different client references or chunk names. ([#168])
 - Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#165])
@@ -78,6 +79,7 @@ All notable changes to this package will be documented in this file.
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151
 [#152]: https://github.com/shakacode/react_on_rails_rsc/pull/152
 [#166]: https://github.com/shakacode/react_on_rails_rsc/pull/166
+[#171]: https://github.com/shakacode/react_on_rails_rsc/pull/171
 [#102]: https://github.com/shakacode/react_on_rails_rsc/pull/102
 [#106]: https://github.com/shakacode/react_on_rails_rsc/pull/106
 [#23]: https://github.com/shakacode/react_on_rails_rsc/pull/23

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -624,7 +624,7 @@ export class RSCWebpackPlugin {
           const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
           const manifest = {
             moduleLoading: {
-              prefix: publicPathIsAuto ? '' : compilation.outputOptions.publicPath || '',
+              prefix: publicPathIsAuto ? '' : configuredPublicPath || '',
               crossOrigin,
             },
             filePathToModuleMetadata,

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -610,10 +610,21 @@ export class RSCWebpackPlugin {
           const resolvedClientFiles = new Set(
             (resolvedClientReferences || []).map((ref) => ref.request),
           );
+          const configuredPublicPath = compilation.outputOptions.publicPath;
+          const publicPathIsAuto = configuredPublicPath === 'auto';
+          if (publicPathIsAuto) {
+            compilation.warnings.push(
+              new webpack.WebpackError(
+                "React Server Components: output.publicPath is 'auto', which cannot be serialized into the RSC manifest. " +
+                  'moduleLoading.prefix will be emitted as an empty string, and CSS files are omitted from the RSC manifest because their final URLs are only known at runtime. ' +
+                  'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.',
+              ),
+            );
+          }
           const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
           const manifest = {
             moduleLoading: {
-              prefix: compilation.outputOptions.publicPath || '',
+              prefix: publicPathIsAuto ? '' : compilation.outputOptions.publicPath || '',
               crossOrigin,
             },
             filePathToModuleMetadata,
@@ -633,9 +644,8 @@ export class RSCWebpackPlugin {
           });
 
           let cssPrefix =
-            typeof compilation.outputOptions.publicPath === 'string' &&
-            compilation.outputOptions.publicPath !== 'auto'
-              ? compilation.outputOptions.publicPath
+            typeof configuredPublicPath === 'string' && configuredPublicPath !== 'auto'
+              ? configuredPublicPath
               : null;
           if (cssPrefix && !cssPrefix.endsWith('/')) {
             cssPrefix += '/';
@@ -1101,8 +1111,11 @@ export class RSCWebpackPlugin {
       this.clientReferences,
       (clientReferencePath, cb) => {
         if (typeof clientReferencePath === 'string') {
-          watchDependencies.files.add(path.resolve(context, clientReferencePath));
-          cb(null, [new ClientReferenceDependency(clientReferencePath)]);
+          const request = path.resolve(context, clientReferencePath);
+          watchDependencies.files.add(request);
+          const clientRefDep = new ClientReferenceDependency(request);
+          clientRefDep.userRequest = clientReferencePath;
+          cb(null, [clientRefDep]);
           return;
         }
         contextResolver.resolve(

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -82,6 +82,19 @@ const splitStaticIslandVendors = {
 };
 
 describe('ReactFlightWebpackPlugin (real webpack)', () => {
+  describe('clientReferences string entries', () => {
+    it('resolves relative string entries from the compiler context', () => {
+      const result = run('split-shared', {
+        chunkName: 'client-[request]',
+        clientReferences: ['./Button.js'],
+      });
+
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(chunkFiles(button)).toEqual(['client-Button-js.chunk.js']);
+      expectNoWarnings(result);
+    });
+  });
+
   describe('static island diagnostics', () => {
     const diagnosticsFilename = 'rsc-client-reference-diagnostics.json';
 
@@ -523,6 +536,21 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
       );
       expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
       expectNoWarnings(result);
+    });
+
+    it('warns and avoids emitting literal auto as moduleLoading.prefix', () => {
+      const result = run('css-import', {
+        chunkName: 'client-[request]',
+        publicPath: 'auto',
+        withCss: true,
+      });
+
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(button.css).toEqual([]);
+      expect(result.manifest.moduleLoading.prefix).toBe('');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("output.publicPath is 'auto'");
+      expect(result.warnings[0]).toContain('CSS files are omitted from the RSC manifest');
     });
   });
 


### PR DESCRIPTION
## Summary

- Resolve webpack string `clientReferences` relative to the compiler context while preserving the configured request for `[request]` chunk names.
- Warn when webpack `output.publicPath` is `auto`, serialize `moduleLoading.prefix` as an empty string instead of literal `auto`, and leave CSS omitted because runtime public paths cannot be serialized safely.
- Add real webpack integration coverage for #159 and the webpack side of #158.
- Add the required changelog entry after rebasing onto the merged #140 dependency update.

Fixes #159.
Part of #158.

## Status

Ready-no-merge-authority on current head `d1b8fdb`. Local validation is green, full hosted checks are green or intentionally skipped, CodeRabbit and Greptile completed, Claude review completed, and current-head review threads are resolved. Merge authority remains `ask`.

The rspack side of #158 and issues #157/#160 continue in the separate rspack-assets lane.

## Codex Decision Log

- **Non-blocking:** How should webpack serialize `moduleLoading.prefix` when `output.publicPath` is `auto`?
  - **Decision:** Emit an empty string and warn.
  - **Why:** React Flight concatenates `moduleLoading.prefix + chunkFile`; the literal string `auto` is never a usable URL prefix, while the plugin cannot know webpack runtime public path values at manifest-build time.
  - **Review later:** Mirror or adjust the same policy in rspack while evaluating #158's rspack side.
- **Non-blocking:** Should #171 also normalize function-valued `output.publicPath`?
  - **Decision:** Leave it out of this PR.
  - **Why:** Claude identified it as pre-existing and non-blocking; #171 is scoped to the reproduced `auto` behavior and #159 path resolution.
  - **Review later:** Consider a broader publicPath normalization follow-up if maintainers want that behavior.

## Verification

- Red repro for #159: `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand` failed before the fix with webpack resolving `./Button.js` from `node_modules/react-server-dom-webpack` and warning that no manifest entry could be created.
- Red repro for #158: `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand --testNamePattern "warns and avoids emitting literal auto"` failed before the fix because `moduleLoading.prefix` was `"auto"`.
- After rebase onto current `origin/main`: `yarn install --frozen-lockfile`
- `yarn build`
- `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand`
- `yarn test`
- `git diff --check`
- `codex review --uncommitted` returned no correctness issues before the original push.

## Review / Churn Notes

- Pre-push review gate: manual self-review plus `codex review --uncommitted`.
- Current-head review threads: all resolved after the ready-state Greptile and Claude passes.
- Optional Claude/Greptile nits were either addressed or explicitly triaged in thread replies with address-review summary checkpoints.
- Merge authority: ask. Runtime/build behavior remains maintainer-gated.
