### PR TITLE
Fix rspack runtime manifest parity gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this package will be documented in this file.
 ### Fixed
 - Fixed Webpack client-reference string paths to resolve relative to the compiler context and warned when `output.publicPath: "auto"` cannot be serialized into the RSC manifest. ([#171])
 - Fixed Rspack client-reference manifests to emit deterministic chunk pair ordering under Rspack 2 while preserving the full sibling chunk set. ([#140])
+- Fixed Rspack client manifests to emit stylesheet hints, normalize unserializable `output.publicPath: "auto"`, preserve `.mjs` chunk files, and match webpack split-runtime chunk metadata. ([#172])
 - Fixed `RSCRspackPlugin` runtime injection state to be scoped by compiler, avoiding MultiCompiler and sequential-build cross-talk between rspack client/server builds with different client references or chunk names. ([#168])
 - Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#165])
 - Fixed watch rebuilds so rspack and webpack refresh client-reference runtime injections when `"use client"` files are added or removed without restarting the dev server. ([#164])
@@ -74,6 +75,7 @@ All notable changes to this package will be documented in this file.
 [#144]: https://github.com/shakacode/react_on_rails_rsc/pull/144
 [#167]: https://github.com/shakacode/react_on_rails_rsc/pull/167
 [#168]: https://github.com/shakacode/react_on_rails_rsc/pull/168
+[#172]: https://github.com/shakacode/react_on_rails_rsc/pull/172
 [#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -677,12 +677,8 @@ export class RSCRspackPlugin {
     for (const chunkGroup of compilation.chunkGroups) {
       const groupChunkList = [...chunkGroup.chunks].map((chunk) => chunk as AnyChunk);
       const normalizedChunkGroup = { name: chunkGroup.name, chunks: groupChunkList };
-      const groupAssets = this.getGroupAssets(
-        normalizedChunkGroup,
-        runtimeChunkFiles,
-        cssPrefix,
-      );
-      const groupChunks = new Set<AnyChunk>(groupChunkList);
+      const groupChunks = this.getGroupAssets(normalizedChunkGroup, runtimeChunkFiles);
+      const groupChunkSet = new Set<AnyChunk>(groupChunkList);
       const getOutgoingConnections =
         compilation.moduleGraph?.getOutgoingConnections?.bind(compilation.moduleGraph);
 
@@ -692,7 +688,7 @@ export class RSCRspackPlugin {
         const addCssFromModuleChunks = (cssModule: AnyModule): void => {
           for (const cssChunkUnknown of compilation.chunkGraph.getModuleChunks(cssModule)) {
             const cssChunk = cssChunkUnknown as AnyChunk;
-            if (!groupChunks.has(cssChunk)) continue;
+            if (!groupChunkSet.has(cssChunk)) continue;
             for (const cssFile of this.getChunkCss(cssChunk, runtimeChunkFiles, cssPrefix)) {
               files.add(cssFile);
             }
@@ -745,7 +741,7 @@ export class RSCRspackPlugin {
             this.recordModule(
               mod,
               moduleId,
-              groupAssets.chunks,
+              groupChunks,
               moduleCss,
               resolvedClientFiles,
               filePathToModuleMetadata,
@@ -765,7 +761,7 @@ export class RSCRspackPlugin {
               this.recordModule(
                 inner,
                 moduleId,
-                groupAssets.chunks,
+                groupChunks,
                 moduleCss,
                 resolvedClientFiles,
                 filePathToModuleMetadata,
@@ -886,15 +882,12 @@ export class RSCRspackPlugin {
   private getGroupAssets(
     chunkGroup: AnyChunkGroup,
     runtimeChunkFiles: ReadonlySet<string>,
-    cssPrefix: string | null,
-  ): { chunks: (string | number | null)[]; css: string[] } {
+  ): (string | number | null)[] {
     const chunks: (string | number | null)[] = [];
-    const css: string[] = [];
     for (const chunkUnknown of chunkGroup.chunks) {
       const c = chunkUnknown as AnyChunk;
       const files = c.files instanceof Set ? c.files : new Set(c.files);
       let recordedJs = false;
-      css.push(...this.getChunkCss(c, runtimeChunkFiles, cssPrefix));
       for (const file of files) {
         const isRuntimeFile = runtimeChunkFiles.has(file);
         const isJavaScriptFile = file.endsWith('.js') || file.endsWith('.mjs');
@@ -911,7 +904,7 @@ export class RSCRspackPlugin {
         recordedJs = true;
       }
     }
-    return { chunks: this.sortChunkPairs(chunks), css };
+    return this.sortChunkPairs(chunks);
   }
 
   private getChunkCss(

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -74,6 +74,7 @@ type AnyChunkGroup = {
 type AnyEntrypoint = {
   chunks?: Iterable<unknown>;
   getChunks?: () => Iterable<unknown>;
+  getRuntimeChunk?: () => { files: Iterable<string> } | null;
 };
 
 type AnyCompilation = {
@@ -89,7 +90,7 @@ type AnyCompilation = {
   };
   chunkGroups: Iterable<AnyChunkGroup>;
   outputOptions: {
-    publicPath?: string;
+    publicPath?: string | ((...args: unknown[]) => string);
     crossOriginLoading?: false | 'anonymous' | 'use-credentials';
   };
   entrypoints?: ReadonlyMap<string, AnyEntrypoint>;
@@ -156,6 +157,7 @@ type AnyChunk = {
 type ModuleMetadata = {
   id: string | number | null;
   chunks: (string | number | null)[];
+  css?: string[];
   name: string;
 };
 
@@ -631,16 +633,28 @@ export class RSCRspackPlugin {
     const generatedChunkNamesByResource = diagnosticsEnabled
       ? this.getGeneratedChunkNamesByResource()
       : undefined;
-    const initialChunks = this.getInitialChunks(compilation);
+    const runtimeChunkFiles = this.getRuntimeChunkFiles(compilation);
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
     const isResolvedClientReference = (resource: string | undefined): resource is string =>
       !!resource && resolvedClientFiles.has(resource);
+    const configuredPublicPath = compilation.outputOptions.publicPath;
+    const publicPathIsAuto = configuredPublicPath === 'auto';
+    if (publicPathIsAuto) {
+      const warning = bundler.WebpackError
+        ? new bundler.WebpackError(
+            "React Server Components: output.publicPath is 'auto', which cannot be serialized into the RSC manifest. " +
+              'moduleLoading.prefix will be emitted as an empty string, and CSS files are omitted from the RSC manifest because their final URLs are only known at runtime. ' +
+              'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.',
+          )
+        : new Error(
+            "React Server Components: output.publicPath is 'auto', which cannot be serialized into the RSC manifest.",
+          );
+      compilation.warnings.push(warning);
+    }
     let cssPrefix =
-      diagnosticsEnabled &&
-      typeof compilation.outputOptions.publicPath === 'string' &&
-      compilation.outputOptions.publicPath !== 'auto'
-        ? compilation.outputOptions.publicPath
+      typeof configuredPublicPath === 'string' && !publicPathIsAuto
+        ? configuredPublicPath
         : null;
     if (cssPrefix && !cssPrefix.endsWith('/')) {
       cssPrefix += '/';
@@ -651,7 +665,7 @@ export class RSCRspackPlugin {
     // chunks in its group — this ensures splitChunks dependencies are
     // included.
     for (const chunkGroup of compilation.chunkGroups) {
-      const groupAssets = this.getGroupAssets(chunkGroup, initialChunks, cssPrefix);
+      const groupAssets = this.getGroupAssets(chunkGroup, runtimeChunkFiles, cssPrefix);
 
       for (const chunkUnknown of chunkGroup.chunks) {
         const chunk = chunkUnknown as AnyChunk;
@@ -727,7 +741,11 @@ export class RSCRspackPlugin {
 
     return {
       moduleLoading: {
-        prefix: compilation.outputOptions.publicPath || '',
+        prefix: publicPathIsAuto
+          ? ''
+          : typeof configuredPublicPath === 'string'
+            ? configuredPublicPath
+            : '',
         crossOrigin,
       },
       filePathToModuleMetadata,
@@ -807,24 +825,36 @@ export class RSCRspackPlugin {
   /** Build the chunks array from all async-loadable chunks in a chunk group. */
   private getGroupAssets(
     chunkGroup: AnyChunkGroup,
-    initialChunks: Set<unknown>,
+    runtimeChunkFiles: ReadonlySet<string>,
     cssPrefix: string | null,
   ): { chunks: (string | number | null)[]; css: string[] } {
     const chunks: (string | number | null)[] = [];
     const css: string[] = [];
     for (const chunkUnknown of chunkGroup.chunks) {
       const c = chunkUnknown as AnyChunk;
-      const isInitial = this.isInitialChunk(c, initialChunks);
-      if (isInitial && !this.options.isServer) continue;
       const files = c.files instanceof Set ? c.files : new Set(c.files);
       let recordedJs = false;
       for (const file of files) {
-        if (file.endsWith('.css') && !file.endsWith('.hot-update.css') && cssPrefix !== null) {
+        const isRuntimeFile = runtimeChunkFiles.has(file);
+        if (
+          file.endsWith('.css') &&
+          !file.endsWith('.hot-update.css') &&
+          cssPrefix !== null &&
+          (this.options.isServer || !isRuntimeFile)
+        ) {
           css.push(cssPrefix + file);
           continue;
         }
-        if (isInitial) continue;
-        if (recordedJs || !file.endsWith('.js') || file.endsWith('.hot-update.js')) continue;
+        const isJavaScriptFile = file.endsWith('.js') || file.endsWith('.mjs');
+        const isHotUpdateFile = file.endsWith('.hot-update.js') || file.endsWith('.hot-update.mjs');
+        if (
+          recordedJs ||
+          !isJavaScriptFile ||
+          isHotUpdateFile ||
+          (!this.options.isServer && isRuntimeFile)
+        ) {
+          continue;
+        }
         chunks.push(c.id, file);
         recordedJs = true;
       }
@@ -886,22 +916,17 @@ export class RSCRspackPlugin {
     return pairs.flatMap(([id, file]) => [id, file]);
   }
 
-  private getInitialChunks(compilation: AnyCompilation): Set<unknown> {
-    const initialChunks = new Set<unknown>();
+  private getRuntimeChunkFiles(compilation: AnyCompilation): Set<string> {
+    const runtimeChunkFiles = new Set<string>();
     for (const entrypoint of compilation.entrypoints?.values() ?? []) {
-      const chunks =
-        typeof entrypoint.getChunks === 'function'
-          ? entrypoint.getChunks()
-          : entrypoint.chunks;
-      if (!chunks) continue;
-      for (const chunk of chunks) initialChunks.add(chunk);
+      const runtimeChunk =
+        typeof entrypoint.getRuntimeChunk === 'function'
+          ? entrypoint.getRuntimeChunk()
+          : null;
+      if (!runtimeChunk) continue;
+      for (const file of runtimeChunk.files) runtimeChunkFiles.add(file);
     }
-    return initialChunks;
-  }
-
-  private isInitialChunk(chunk: AnyChunk, initialChunks: Set<unknown>): boolean {
-    if (typeof chunk.canBeInitial === 'function') return chunk.canBeInitial();
-    return initialChunks.has(chunk);
+    return runtimeChunkFiles;
   }
 
   /**
@@ -932,14 +957,25 @@ export class RSCRspackPlugin {
         if (!seen.has(chunks[i]!)) existing.chunks.push(chunks[i]!, chunks[i + 1]!);
       }
       existing.chunks = this.sortChunkPairs(existing.chunks);
+      this.recordManifestCssFiles(existing, css);
       this.recordDiagnosticsCssFiles(href, css, diagnosticsCssFiles);
     } else {
-      filePathToModuleMetadata[href] = {
+      const metadata: ModuleMetadata = {
         id: moduleId,
         chunks: this.sortChunkPairs(chunks),
         name: '*',
       };
+      this.recordManifestCssFiles(metadata, css);
+      filePathToModuleMetadata[href] = metadata;
       this.recordDiagnosticsCssFiles(href, css, diagnosticsCssFiles);
+    }
+  }
+
+  private recordManifestCssFiles(metadata: ModuleMetadata, css: string[]): void {
+    if (css.length === 0) return;
+    if (!metadata.css) metadata.css = [];
+    for (const cssFile of css) {
+      if (!metadata.css.includes(cssFile)) metadata.css.push(cssFile);
     }
   }
 

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -731,6 +731,9 @@ export class RSCRspackPlugin {
           const mayBeClientReference =
             isResolvedClientReference(mod.resource) ||
             (!!mod.modules && mod.modules.some((inner) => isResolvedClientReference(inner.resource)));
+          // Match the webpack plugin: client references are injected as async
+          // boundaries, so any concatenated wrapper owns the CSS dependency
+          // edges needed for sibling CSS-only chunk recovery.
           const manifestCss = mayBeClientReference ? mergeDirectCss(chunkCss, mod) : chunkCss;
           if (isResolvedClientReference(mod.resource)) {
             const moduleCss = this.getCssForModule(

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -728,11 +728,15 @@ export class RSCRspackPlugin {
           if (isRuntimeResource(mod.resource, this.options.isServer)) clientFileNameFound = true;
 
           const moduleId = compilation.chunkGraph.getModuleId(mod);
+          const mayBeClientReference =
+            isResolvedClientReference(mod.resource) ||
+            (!!mod.modules && mod.modules.some((inner) => isResolvedClientReference(inner.resource)));
+          const manifestCss = mayBeClientReference ? mergeDirectCss(chunkCss, mod) : chunkCss;
           if (isResolvedClientReference(mod.resource)) {
             const moduleCss = this.getCssForModule(
               mod.resource,
               normalizedChunkGroup,
-              mergeDirectCss(chunkCss, mod),
+              manifestCss,
               generatedChunkNamesByResource,
             );
             this.recordModule(
@@ -752,7 +756,7 @@ export class RSCRspackPlugin {
               const moduleCss = this.getCssForModule(
                 inner.resource,
                 normalizedChunkGroup,
-                mergeDirectCss(chunkCss, inner),
+                manifestCss,
                 generatedChunkNamesByResource,
               );
               this.recordModule(

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -31,6 +31,8 @@ import {
 } from './injection-loader';
 import { getGeneratedChunkName, hasUseClientDirective } from './shared';
 
+const STYLE_SOURCE_RE = /\.(css|scss|sass|less|styl|pcss)$/i;
+
 // Accept any bundler that looks compatible — webpack 5 or rspack. Typed loose
 // because we cannot depend on `@rspack/core` types without making it a hard
 // peer dep of a package that should stay webpack-centric.
@@ -87,6 +89,12 @@ type AnyCompilation = {
     getModuleChunks(module: unknown): Iterable<unknown>;
     getModuleId(module: unknown): string | number | null;
     getChunkModulesIterable(chunk: unknown): Iterable<unknown>;
+  };
+  moduleGraph?: {
+    getOutgoingConnections?: (module: unknown) => Iterable<{
+      module?: AnyModule | null;
+      resolvedModule?: AnyModule | null;
+    }>;
   };
   chunkGroups: Iterable<AnyChunkGroup>;
   outputOptions: {
@@ -146,6 +154,7 @@ function addClientReferenceWatchDependencies(
 type AnyModule = {
   resource?: string;
   modules?: AnyModule[]; // for ConcatenatedModule
+  type?: string;
 };
 
 type AnyChunk = {
@@ -629,10 +638,7 @@ export class RSCRspackPlugin {
     let clientFileNameFound = false;
 
     const resolvedClientFiles = new Set(this._resolvedClientFiles ?? []);
-    const diagnosticsEnabled = typeof this.options.clientReferenceDiagnosticsFilename === 'string';
-    const generatedChunkNamesByResource = diagnosticsEnabled
-      ? this.getGeneratedChunkNamesByResource()
-      : undefined;
+    const generatedChunkNamesByResource = this.getGeneratedChunkNamesByResource();
     const runtimeChunkFiles = this.getRuntimeChunkFiles(compilation);
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
@@ -640,15 +646,19 @@ export class RSCRspackPlugin {
       !!resource && resolvedClientFiles.has(resource);
     const configuredPublicPath = compilation.outputOptions.publicPath;
     const publicPathIsAuto = configuredPublicPath === 'auto';
-    if (publicPathIsAuto) {
+    const publicPathIsDynamic = publicPathIsAuto || typeof configuredPublicPath === 'function';
+    if (publicPathIsDynamic) {
+      const publicPathDescription = publicPathIsAuto
+        ? "output.publicPath is 'auto'"
+        : 'output.publicPath is a function';
       const warning = bundler.WebpackError
         ? new bundler.WebpackError(
-            "React Server Components: output.publicPath is 'auto', which cannot be serialized into the RSC manifest. " +
+            `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest. ` +
               'moduleLoading.prefix will be emitted as an empty string, and CSS files are omitted from the RSC manifest because their final URLs are only known at runtime. ' +
               'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.',
           )
         : new Error(
-            "React Server Components: output.publicPath is 'auto', which cannot be serialized into the RSC manifest.",
+            `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest.`,
           );
       compilation.warnings.push(warning);
     }
@@ -665,10 +675,53 @@ export class RSCRspackPlugin {
     // chunks in its group — this ensures splitChunks dependencies are
     // included.
     for (const chunkGroup of compilation.chunkGroups) {
-      const groupAssets = this.getGroupAssets(chunkGroup, runtimeChunkFiles, cssPrefix);
+      const groupChunkList = [...chunkGroup.chunks].map((chunk) => chunk as AnyChunk);
+      const normalizedChunkGroup = { name: chunkGroup.name, chunks: groupChunkList };
+      const groupAssets = this.getGroupAssets(
+        normalizedChunkGroup,
+        runtimeChunkFiles,
+        cssPrefix,
+      );
+      const groupChunks = new Set<AnyChunk>(groupChunkList);
+      const getOutgoingConnections =
+        compilation.moduleGraph?.getOutgoingConnections?.bind(compilation.moduleGraph);
 
-      for (const chunkUnknown of chunkGroup.chunks) {
-        const chunk = chunkUnknown as AnyChunk;
+      const directCssDepFiles = (module: AnyModule): string[] => {
+        if (!getOutgoingConnections || cssPrefix === null) return [];
+        const files = new Set<string>();
+        const addCssFromModuleChunks = (cssModule: AnyModule): void => {
+          for (const cssChunkUnknown of compilation.chunkGraph.getModuleChunks(cssModule)) {
+            const cssChunk = cssChunkUnknown as AnyChunk;
+            if (!groupChunks.has(cssChunk)) continue;
+            for (const cssFile of this.getChunkCss(cssChunk, runtimeChunkFiles, cssPrefix)) {
+              files.add(cssFile);
+            }
+          }
+        };
+
+        for (const connection of getOutgoingConnections(module)) {
+          const depModule = connection.module ?? connection.resolvedModule;
+          if (!depModule?.resource) continue;
+          const depResource = depModule.resource.replace(/[?#].*$/, '');
+          if (!STYLE_SOURCE_RE.test(depResource)) continue;
+          addCssFromModuleChunks(depModule);
+          for (const cssConnection of getOutgoingConnections(depModule)) {
+            const extractedCssModule = cssConnection.module ?? cssConnection.resolvedModule;
+            if (!extractedCssModule || extractedCssModule.type !== 'css/mini-extract') continue;
+            addCssFromModuleChunks(extractedCssModule);
+          }
+        }
+
+        return [...files];
+      };
+
+      const mergeDirectCss = (chunkCss: string[], module: AnyModule): string[] => {
+        const siblingCss = directCssDepFiles(module);
+        return siblingCss.length > 0 ? [...new Set([...chunkCss, ...siblingCss])] : chunkCss;
+      };
+
+      for (const chunk of groupChunkList) {
+        const chunkCss = this.getChunkCss(chunk, runtimeChunkFiles, cssPrefix);
         for (const m of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
           const mod = m as AnyModule;
 
@@ -676,17 +729,17 @@ export class RSCRspackPlugin {
 
           const moduleId = compilation.chunkGraph.getModuleId(mod);
           if (isResolvedClientReference(mod.resource)) {
-            const diagnosticsCss = this.getDiagnosticsCssForModule(
+            const moduleCss = this.getCssForModule(
               mod.resource,
-              chunkGroup,
-              groupAssets.css,
+              normalizedChunkGroup,
+              mergeDirectCss(chunkCss, mod),
               generatedChunkNamesByResource,
             );
             this.recordModule(
               mod,
               moduleId,
               groupAssets.chunks,
-              diagnosticsCss,
+              moduleCss,
               resolvedClientFiles,
               filePathToModuleMetadata,
               diagnosticsCssFiles,
@@ -696,17 +749,17 @@ export class RSCRspackPlugin {
             for (const inner of mod.modules) {
               if (isRuntimeResource(inner.resource, this.options.isServer)) clientFileNameFound = true;
               if (!isResolvedClientReference(inner.resource)) continue;
-              const diagnosticsCss = this.getDiagnosticsCssForModule(
+              const moduleCss = this.getCssForModule(
                 inner.resource,
-                chunkGroup,
-                groupAssets.css,
+                normalizedChunkGroup,
+                mergeDirectCss(chunkCss, inner),
                 generatedChunkNamesByResource,
               );
               this.recordModule(
                 inner,
                 moduleId,
                 groupAssets.chunks,
-                diagnosticsCss,
+                moduleCss,
                 resolvedClientFiles,
                 filePathToModuleMetadata,
                 diagnosticsCssFiles,
@@ -834,17 +887,9 @@ export class RSCRspackPlugin {
       const c = chunkUnknown as AnyChunk;
       const files = c.files instanceof Set ? c.files : new Set(c.files);
       let recordedJs = false;
+      css.push(...this.getChunkCss(c, runtimeChunkFiles, cssPrefix));
       for (const file of files) {
         const isRuntimeFile = runtimeChunkFiles.has(file);
-        if (
-          file.endsWith('.css') &&
-          !file.endsWith('.hot-update.css') &&
-          cssPrefix !== null &&
-          (this.options.isServer || !isRuntimeFile)
-        ) {
-          css.push(cssPrefix + file);
-          continue;
-        }
         const isJavaScriptFile = file.endsWith('.js') || file.endsWith('.mjs');
         const isHotUpdateFile = file.endsWith('.hot-update.js') || file.endsWith('.hot-update.mjs');
         if (
@@ -862,6 +907,26 @@ export class RSCRspackPlugin {
     return { chunks: this.sortChunkPairs(chunks), css };
   }
 
+  private getChunkCss(
+    chunk: AnyChunk,
+    runtimeChunkFiles: ReadonlySet<string>,
+    cssPrefix: string | null,
+  ): string[] {
+    if (cssPrefix === null) return [];
+    const css: string[] = [];
+    const files = chunk.files instanceof Set ? chunk.files : new Set(chunk.files);
+    for (const file of files) {
+      if (
+        file.endsWith('.css') &&
+        !file.endsWith('.hot-update.css') &&
+        (this.options.isServer || !runtimeChunkFiles.has(file))
+      ) {
+        css.push(cssPrefix + file);
+      }
+    }
+    return css;
+  }
+
   private getGeneratedChunkNamesByResource(): ReadonlyMap<string, string> {
     return new Map(
       (this._resolvedClientFiles ?? []).map((file, index) => [
@@ -871,13 +936,13 @@ export class RSCRspackPlugin {
     );
   }
 
-  private getDiagnosticsCssForModule(
+  private getCssForModule(
     resource: string | undefined,
     chunkGroup: AnyChunkGroup,
     css: string[],
-    generatedChunkNamesByResource: ReadonlyMap<string, string> | undefined,
+    generatedChunkNamesByResource: ReadonlyMap<string, string>,
   ): string[] {
-    if (!resource || css.length === 0 || !generatedChunkNamesByResource) return css;
+    if (!resource || css.length === 0) return css;
     const generatedChunkName = generatedChunkNamesByResource.get(resource);
     if (!generatedChunkName) return css;
     return this.chunkGroupHasName(chunkGroup, generatedChunkName) ? css : [];

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -166,7 +166,7 @@ type AnyChunk = {
 type ModuleMetadata = {
   id: string | number | null;
   chunks: (string | number | null)[];
-  css?: string[];
+  css: string[];
   name: string;
 };
 
@@ -640,6 +640,7 @@ export class RSCRspackPlugin {
     const resolvedClientFiles = new Set(this._resolvedClientFiles ?? []);
     const generatedChunkNamesByResource = this.getGeneratedChunkNamesByResource();
     const runtimeChunkFiles = this.getRuntimeChunkFiles(compilation);
+    const availableChunkGroupNames = this.getAvailableChunkGroupNames(compilation);
 
     const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
     const isResolvedClientReference = (resource: string | undefined): resource is string =>
@@ -679,6 +680,15 @@ export class RSCRspackPlugin {
       const normalizedChunkGroup = { name: chunkGroup.name, chunks: groupChunkList };
       const groupChunks = this.getGroupAssets(normalizedChunkGroup, runtimeChunkFiles);
       const groupChunkSet = new Set<AnyChunk>(groupChunkList);
+      const chunkCssCache = new Map<AnyChunk, string[]>();
+      const getCachedChunkCss = (chunk: AnyChunk): string[] => {
+        let cached = chunkCssCache.get(chunk);
+        if (!cached) {
+          cached = this.getChunkCss(chunk, runtimeChunkFiles, cssPrefix);
+          chunkCssCache.set(chunk, cached);
+        }
+        return cached;
+      };
       const getOutgoingConnections =
         compilation.moduleGraph?.getOutgoingConnections?.bind(compilation.moduleGraph);
 
@@ -689,7 +699,7 @@ export class RSCRspackPlugin {
           for (const cssChunkUnknown of compilation.chunkGraph.getModuleChunks(cssModule)) {
             const cssChunk = cssChunkUnknown as AnyChunk;
             if (!groupChunkSet.has(cssChunk)) continue;
-            for (const cssFile of this.getChunkCss(cssChunk, runtimeChunkFiles, cssPrefix)) {
+            for (const cssFile of getCachedChunkCss(cssChunk)) {
               files.add(cssFile);
             }
           }
@@ -711,13 +721,11 @@ export class RSCRspackPlugin {
         return [...files];
       };
 
-      const mergeDirectCss = (chunkCss: string[], module: AnyModule): string[] => {
-        const siblingCss = directCssDepFiles(module);
-        return siblingCss.length > 0 ? [...new Set([...chunkCss, ...siblingCss])] : chunkCss;
-      };
+      const mergeCssFiles = (chunkCss: string[], siblingCss: string[]): string[] =>
+        siblingCss.length > 0 ? [...new Set([...chunkCss, ...siblingCss])] : chunkCss;
 
       for (const chunk of groupChunkList) {
-        const chunkCss = this.getChunkCss(chunk, runtimeChunkFiles, cssPrefix);
+        const chunkCss = getCachedChunkCss(chunk);
         for (const m of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
           const mod = m as AnyModule;
 
@@ -730,13 +738,16 @@ export class RSCRspackPlugin {
           // Match the webpack plugin: client references are injected as async
           // boundaries, so any concatenated wrapper owns the CSS dependency
           // edges needed for sibling CSS-only chunk recovery.
-          const manifestCss = mayBeClientReference ? mergeDirectCss(chunkCss, mod) : chunkCss;
+          const directCss = mayBeClientReference ? directCssDepFiles(mod) : [];
+          const manifestCss = mergeCssFiles(chunkCss, directCss);
           if (isResolvedClientReference(mod.resource)) {
             const moduleCss = this.getCssForModule(
               mod.resource,
               normalizedChunkGroup,
               manifestCss,
+              directCss,
               generatedChunkNamesByResource,
+              availableChunkGroupNames,
             );
             this.recordModule(
               mod,
@@ -752,11 +763,17 @@ export class RSCRspackPlugin {
             for (const inner of mod.modules) {
               if (isRuntimeResource(inner.resource, this.options.isServer)) clientFileNameFound = true;
               if (!isResolvedClientReference(inner.resource)) continue;
+              // Rspack can fold an eager "use client" module in as an inner
+              // module; recover its direct CSS without inheriting wrapper CSS.
+              const innerDirectCss = directCssDepFiles(inner);
+              const innerManifestCss = mergeCssFiles(chunkCss, innerDirectCss);
               const moduleCss = this.getCssForModule(
                 inner.resource,
                 normalizedChunkGroup,
-                manifestCss,
+                innerManifestCss,
+                innerDirectCss,
                 generatedChunkNamesByResource,
+                availableChunkGroupNames,
               );
               this.recordModule(
                 inner,
@@ -940,12 +957,15 @@ export class RSCRspackPlugin {
     resource: string | undefined,
     chunkGroup: AnyChunkGroup,
     css: string[],
+    fallbackCss: string[],
     generatedChunkNamesByResource: ReadonlyMap<string, string>,
+    availableChunkGroupNames: ReadonlySet<string>,
   ): string[] {
     if (!resource || css.length === 0) return css;
     const generatedChunkName = generatedChunkNamesByResource.get(resource);
     if (!generatedChunkName) return css;
-    return this.chunkGroupHasName(chunkGroup, generatedChunkName) ? css : [];
+    if (this.chunkGroupHasName(chunkGroup, generatedChunkName)) return css;
+    return availableChunkGroupNames.has(generatedChunkName) ? [] : fallbackCss;
   }
 
   private chunkGroupHasName(chunkGroup: AnyChunkGroup, generatedChunkName: string): boolean {
@@ -955,6 +975,23 @@ export class RSCRspackPlugin {
       if (chunk.name === generatedChunkName) return true;
     }
     return false;
+  }
+
+  private getAvailableChunkGroupNames(compilation: AnyCompilation): Set<string> {
+    const names = new Set<string>();
+    for (const chunkGroup of compilation.chunkGroups) {
+      const chunks = [...chunkGroup.chunks];
+      // Rspack can keep an empty plugin-created group when an eager import
+      // makes the generated client chunk unnecessary; that still needs the
+      // fallback entry group to provide CSS.
+      if (chunks.length === 0) continue;
+      if (chunkGroup.name) names.add(chunkGroup.name);
+      for (const chunkUnknown of chunks) {
+        const chunk = chunkUnknown as { name?: string };
+        if (chunk.name) names.add(chunk.name);
+      }
+    }
+    return names;
   }
 
   private sortChunkPairs(chunks: (string | number | null)[]): (string | number | null)[] {
@@ -1028,6 +1065,7 @@ export class RSCRspackPlugin {
       const metadata: ModuleMetadata = {
         id: moduleId,
         chunks: this.sortChunkPairs(chunks),
+        css: [],
         name: '*',
       };
       this.recordManifestCssFiles(metadata, css);
@@ -1038,7 +1076,6 @@ export class RSCRspackPlugin {
 
   private recordManifestCssFiles(metadata: ModuleMetadata, css: string[]): void {
     if (css.length === 0) return;
-    if (!metadata.css) metadata.css = [];
     for (const cssFile of css) {
       if (!metadata.css.includes(cssFile)) metadata.css.push(cssFile);
     }

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -69,7 +69,7 @@ if (!BUNDLERS.every((b) => b === 'webpack' || b === 'rspack')) {
 interface ModuleMetadata {
   id: string;
   chunks: (string | number)[];
-  css?: string[];
+  css: string[];
   name: string;
 }
 interface Manifest {
@@ -199,19 +199,19 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
     [componentUrl('Counter.js')]: {
       id: './src/components/Counter.js',
       chunks: chunkPair(base('Counter.js')),
-      ...(isWebpack ? { css: [] } : {}),
+      css: [],
       name: '*',
     },
     [componentUrl('NestedLabel.js')]: {
       id: './src/components/NestedLabel.js',
       chunks: [...chunkPair(base('NestedLabel.js')), ...chunkPair(base('ThemeSection.js'))],
-      ...(isWebpack ? { css: [] } : {}),
+      css: [],
       name: '*',
     },
     [componentUrl('ThemeSection.js')]: {
       id: './src/components/ThemeSection.js',
       chunks: chunkPair(base('ThemeSection.js')),
-      ...(isWebpack ? { css: [] } : {}),
+      css: [],
       name: '*',
     },
   };

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -33,9 +33,6 @@
  *
  * Known divergences of the rspack leg (current main behavior, asserted
  * below so any change is caught):
- *   - rspack manifest entries carry no `css` field, so the Flight payload
- *     has no stylesheet hints (CSS still reaches the DOM through rspack's
- *     own chunk-CSS runtime).
  *   - the rspack plugin excludes generated client-reference chunks from
  *     splitChunks, so the shared module is duplicated per chunk instead of
  *     being split into a shared chunk.
@@ -171,14 +168,13 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
   // its own dependency chunk group ([id, file, ...] pairs), minus initial
   // and runtime chunks. NestedLabel is reachable through two groups (its
   // own injected block and ThemeSection's chunk), so its entry is the
-  // union. Only webpack splits the shared module into its own chunk and
-  // records CSS chunk files.
+  // union. Only webpack splits the shared module into its own chunk.
   const sharedPrefix = isWebpack ? chunkPair('shared-format') : [];
   const expectedClientMetadata: Record<string, ModuleMetadata> = {
     [componentUrl('Counter.js')]: {
       id: './src/components/Counter.js',
       chunks: [...sharedPrefix, ...chunkPair(base('Counter.js'))],
-      ...(isWebpack ? { css: [`/assets/${base('Counter.js')}.chunk.css`] } : {}),
+      css: [`/assets/${base('Counter.js')}.chunk.css`],
       name: '*',
     },
     [componentUrl('NestedLabel.js')]: {
@@ -188,13 +184,13 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
         ...chunkPair(base('NestedLabel.js')),
         ...(isWebpack ? [] : chunkPair(base('ThemeSection.js'))),
       ],
-      ...(isWebpack ? { css: [`/assets/${base('NestedLabel.js')}.chunk.css`] } : {}),
+      css: [`/assets/${base('NestedLabel.js')}.chunk.css`],
       name: '*',
     },
     [componentUrl('ThemeSection.js')]: {
       id: './src/components/ThemeSection.js',
       chunks: [...sharedPrefix, ...chunkPair(base('ThemeSection.js'))],
-      ...(isWebpack ? { css: [`/assets/${base('ThemeSection.js')}.chunk.css`] } : {}),
+      css: [`/assets/${base('ThemeSection.js')}.chunk.css`],
       name: '*',
     },
   };
@@ -309,27 +305,12 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
       expect(payload).toContain('rendered-on-server-only');
     });
 
-    it(
-      isWebpack
-        ? 'emits stylesheet hints for the referenced client components'
-        : 'emits no stylesheet hints (rspack manifest has no css metadata — current behavior)',
-      () => {
-        const hints = styleHintRows(payload);
-        if (isWebpack) {
-          expect(hints).toEqual([
-            [`/assets/${base('Counter.js')}.chunk.css`, 'rsc-css'],
-            [`/assets/${base('ThemeSection.js')}.chunk.css`, 'rsc-css'],
-          ]);
-        } else {
-          // Documents the rspack-leg gap: no `css` in the manifest means no
-          // Flight stylesheet hints. CSS still reaches the DOM through
-          // rspack's chunk-CSS runtime (asserted in the hydration test).
-          // If this starts failing, rspack gained CSS hints — tighten the
-          // expectations to match the webpack leg.
-          expect(hints).toEqual([]);
-        }
-      },
-    );
+    it('emits stylesheet hints for the referenced client components', () => {
+      expect(styleHintRows(payload)).toEqual([
+        [`/assets/${base('Counter.js')}.chunk.css`, 'rsc-css'],
+        [`/assets/${base('ThemeSection.js')}.chunk.css`, 'rsc-css'],
+      ]);
+    });
 
     it('serializes app-declared resource hints from the public server export', () => {
       expect(payload).toContain(':HD"https://rsc-assets.example.test"');

--- a/tests/rspack-plugin/fixtures/eager-css/Button.css
+++ b/tests/rspack-plugin/fixtures/eager-css/Button.css
@@ -1,0 +1,3 @@
+.button {
+  color: blue;
+}

--- a/tests/rspack-plugin/fixtures/eager-css/Button.js
+++ b/tests/rspack-plugin/fixtures/eager-css/Button.js
@@ -1,0 +1,7 @@
+'use client';
+
+import './Button.css';
+
+export default function Button() {
+  return 'button';
+}

--- a/tests/rspack-plugin/fixtures/eager-css/index.js
+++ b/tests/rspack-plugin/fixtures/eager-css/index.js
@@ -1,0 +1,3 @@
+import Button from './Button';
+
+export const app = [Button];

--- a/tests/rspack-plugin/fixtures/eager-vendor/ClientWidget.js
+++ b/tests/rspack-plugin/fixtures/eager-vendor/ClientWidget.js
@@ -1,0 +1,7 @@
+'use client';
+
+import { clientLabel } from './clientlib';
+
+export default function ClientWidget() {
+  return clientLabel;
+}

--- a/tests/rspack-plugin/fixtures/eager-vendor/clientlib.js
+++ b/tests/rspack-plugin/fixtures/eager-vendor/clientlib.js
@@ -1,0 +1,3 @@
+import { version as reactDomVersion } from 'react-dom';
+
+export const clientLabel = `clientlib:${reactDomVersion}`;

--- a/tests/rspack-plugin/fixtures/eager-vendor/index.js
+++ b/tests/rspack-plugin/fixtures/eager-vendor/index.js
@@ -1,0 +1,3 @@
+import ClientWidget from './ClientWidget';
+
+export const app = [ClientWidget];

--- a/tests/rspack-plugin/fixtures/static-islands/MixedSplitIsland.css
+++ b/tests/rspack-plugin/fixtures/static-islands/MixedSplitIsland.css
@@ -1,0 +1,3 @@
+.mixed-split-island {
+  color: crimson;
+}

--- a/tests/rspack-plugin/fixtures/static-islands/MixedStyledIsland.css
+++ b/tests/rspack-plugin/fixtures/static-islands/MixedStyledIsland.css
@@ -1,0 +1,3 @@
+.mixed-styled-island {
+  color: darkcyan;
+}

--- a/tests/rspack-plugin/fixtures/static-islands/MixedStyledIsland.js
+++ b/tests/rspack-plugin/fixtures/static-islands/MixedStyledIsland.js
@@ -1,0 +1,8 @@
+'use client';
+
+import './MixedStyledIsland.css';
+import './MixedSplitIsland.css';
+
+export default function MixedStyledIsland() {
+  return 'mixed styled island';
+}

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -26,6 +26,8 @@ export interface CompileOptions {
   withCss?: boolean;
   /** Applies rspack.optimize.LimitChunkCountPlugin({ maxChunks }). */
   maxChunks?: number;
+  outputFilename?: string;
+  outputChunkFilename?: string;
   /** Additional rspack config to merge. Use sparingly. */
   configExtra?: Record<string, unknown>;
 }
@@ -35,7 +37,7 @@ export interface CompileResult {
     moduleLoading: { prefix: string; crossOrigin: string | null };
     filePathToModuleMetadata: Record<
       string,
-      { id: string; chunks: (string | number)[]; name: string }
+      { id: string; chunks: (string | number)[]; css?: string[]; name: string }
     >;
   };
   manifestSource: string;
@@ -57,6 +59,7 @@ export interface CompileResult {
   };
   clientReferenceDiagnosticsSource?: string;
   assets: string[];
+  warnings: string[];
   outputPath: string;
 }
 
@@ -81,6 +84,8 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     crossOriginLoading: options.crossOriginLoading,
     withCss: options.withCss,
     maxChunks: options.maxChunks,
+    outputFilename: options.outputFilename,
+    outputChunkFilename: options.outputChunkFilename,
     configExtra: serializeForRunner(options.configExtra ?? {}),
   };
   const argsFile = path.join(outputPath, '__args__.json');
@@ -139,6 +144,7 @@ export const compile = (fixture: string, options: CompileOptions = {}): CompileR
     clientReferenceDiagnostics,
     clientReferenceDiagnosticsSource,
     assets: result.assets ?? [],
+    warnings: result.warnings ?? [],
     outputPath,
   };
 };

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -37,7 +37,7 @@ export interface CompileResult {
     moduleLoading: { prefix: string; crossOrigin: string | null };
     filePathToModuleMetadata: Record<
       string,
-      { id: string; chunks: (string | number)[]; css?: string[]; name: string }
+      { id: string; chunks: (string | number)[]; css: string[]; name: string }
     >;
   };
   manifestSource: string;

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -50,6 +50,8 @@ const {
   crossOriginLoading,
   withCss,
   maxChunks,
+  outputFilename,
+  outputChunkFilename,
   configExtra,
 } = args;
 
@@ -103,8 +105,8 @@ const config = {
   entry: [runtimeEntry, './index.js'],
   output: {
     path: outputPath,
-    filename: '[name].js',
-    chunkFilename: '[name].chunk.js',
+    filename: outputFilename ?? '[name].js',
+    chunkFilename: outputChunkFilename ?? '[name].chunk.js',
     publicPath: publicPath ?? '',
     crossOriginLoading: crossOriginLoading ?? false,
   },

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -567,7 +567,22 @@ describe('RSCRspackPlugin', () => {
       expect(paths[0]).toContain('/A.js');
     });
 
-    it('records initial entry chunks for statically imported client references', () => {
+    it('excludes default initial entry chunks for statically imported client references', () => {
+      const result = run('basic-client');
+      const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientButton.js'),
+      );
+      expect(key).toBeTruthy();
+
+      const entry = result.manifest.filePathToModuleMetadata[key!]!;
+      const chunkFiles = manifestChunkFiles(entry.chunks);
+
+      expect(result.assets).toContain('main.js');
+      expect(entry.id).toBe('./ClientButton.js');
+      expect(chunkFiles).not.toContain('main.js');
+    });
+
+    it('records split-runtime entry chunks for statically imported client references', () => {
       const result = run('basic-client', {
         configExtra: {
           optimization: {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -241,7 +241,7 @@ describe('RSCRspackPlugin', () => {
       const manifestEntry = Object.entries(result.manifest.filePathToModuleMetadata).find(([file]) =>
         file.endsWith('/StyledIsland.js'),
       )?.[1];
-      expect(manifestEntry).not.toHaveProperty('css');
+      expect(manifestEntry?.css).toEqual(['/assets/client0.chunk.css']);
 
       const diagnosticEntry = result.clientReferenceDiagnostics?.clientReferences[0]!;
       expect(diagnosticEntry.file).toContain('/StyledIsland.js');
@@ -317,8 +317,8 @@ describe('RSCRspackPlugin', () => {
       expect(result.clientReferenceDiagnostics?.isServer).toBe(true);
     });
 
-    it('skips CSS asset collection when diagnostics are disabled', () => {
-      expect(captureBuildManifestCssPrefixes()).toEqual([null]);
+    it('keeps CSS asset collection enabled for manifest output', () => {
+      expect(captureBuildManifestCssPrefixes()).toEqual(['/assets/']);
     });
 
     it('keeps CSS asset collection enabled for diagnostics output', () => {
@@ -351,7 +351,7 @@ describe('RSCRspackPlugin', () => {
       expect(
         internals.getGroupAssets({ chunks: [initialChunk] }, new Set([initialChunk]), '/assets/'),
       ).toEqual({
-        chunks: [],
+        chunks: ['server', 'server-bundle.js'],
         css: ['/assets/server-bundle.css'],
       });
     });
@@ -453,8 +453,17 @@ describe('RSCRspackPlugin', () => {
       expect(paths[0]).toContain('/A.js');
     });
 
-    it('does not preload initial entry chunks for statically imported client references', () => {
-      const result = run('basic-client');
+    it('records initial entry chunks for statically imported client references', () => {
+      const result = run('basic-client', {
+        configExtra: {
+          optimization: {
+            runtimeChunk: 'single',
+            chunkIds: 'named',
+            moduleIds: 'named',
+            minimize: false,
+          },
+        },
+      });
       const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
         p.endsWith('ClientButton.js'),
       );
@@ -462,13 +471,14 @@ describe('RSCRspackPlugin', () => {
 
       const entry = result.manifest.filePathToModuleMetadata[key!]!;
       const chunkFiles = manifestChunkFiles(entry.chunks);
-      const initialAssets = new Set(
-        result.assets.filter((asset) => asset === 'main.js' || asset.startsWith('vendors-')),
+      const initialAssets = new Set<string>(
+        result.assets.filter((asset) => asset === 'main.js' || asset === 'runtime.js'),
       );
 
       expect(entry.id).toBe('./ClientButton.js');
       expect(initialAssets.size).toBeGreaterThan(0);
-      expect(chunkFiles.filter((file) => initialAssets.has(file))).toEqual([]);
+      expect(chunkFiles.filter((file) => initialAssets.has(file))).toEqual(['main.js']);
+      expect(chunkFiles).not.toContain('runtime.js');
     });
 
     it('preserves client references discovered through symlinked directories', () => {
@@ -1042,12 +1052,10 @@ describe('RSCRspackPlugin', () => {
   });
 
   describe('publicPath handling', () => {
-    it('passes publicPath "auto" through verbatim (matches webpack)', () => {
+    it('warns and avoids emitting literal publicPath "auto"', () => {
       const result = run('basic-client', { publicPath: 'auto' });
-      // Matches webpack plugin behavior: publicPath || "" — since "auto"
-      // is truthy, it passes through. The runtime may produce broken URLs
-      // like "auto/main.js" but this matches the webpack contract.
-      expect(result.manifest.moduleLoading.prefix).toBe('auto');
+      expect(result.manifest.moduleLoading.prefix).toBe('');
+      expect(result.warnings.join('\n')).toContain("output.publicPath is 'auto'");
     });
 
     it('preserves an absolute URL publicPath', () => {
@@ -1154,8 +1162,33 @@ describe('RSCRspackPlugin', () => {
       // Every second entry should look like a filename
       for (let i = 1; i < entry.chunks.length; i += 2) {
         expect(typeof entry.chunks[i]).toBe('string');
-        expect(String(entry.chunks[i]).endsWith('.js')).toBe(true);
+        expect(String(entry.chunks[i])).toMatch(/\.m?js$/);
       }
+    });
+
+    it('records .mjs chunk files', () => {
+      const result = run('basic-client', {
+        outputFilename: '[name].mjs',
+        outputChunkFilename: '[name].chunk.mjs',
+        configExtra: {
+          optimization: {
+            runtimeChunk: 'single',
+            chunkIds: 'named',
+            moduleIds: 'named',
+            minimize: false,
+          },
+        },
+      });
+      const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientButton.js'),
+      );
+      expect(key).toBeTruthy();
+
+      const chunkFiles = manifestChunkFiles(
+        result.manifest.filePathToModuleMetadata[key!]!.chunks,
+      );
+      expect(chunkFiles).toEqual(['main.mjs']);
+      expect(chunkFiles).not.toContain('runtime.mjs');
     });
   });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -183,47 +183,6 @@ describe('RSCRspackPlugin', () => {
 
   describe('static island diagnostics', () => {
     const diagnosticsFilename = 'rsc-client-reference-diagnostics.json';
-    const captureBuildManifestCssPrefixes = (
-      options: { clientReferenceDiagnosticsFilename?: string | false } = {},
-    ): Array<string | null> => {
-      const { RSCRspackPlugin } = require(DIST_PLUGIN);
-      const plugin = new RSCRspackPlugin({ isServer: false, ...options });
-      const cssPrefixes: Array<string | null> = [];
-      const internals = plugin as {
-        getGroupAssets: (
-          chunkGroup: unknown,
-          initialChunks: Set<unknown>,
-          cssPrefix: string | null,
-        ) => { chunks: (string | number | null)[]; css: string[] };
-        buildManifest: (
-          compilation: unknown,
-          bundler: unknown,
-          diagnosticsCssFiles: Map<string, string[]>,
-        ) => unknown;
-      };
-      internals.getGroupAssets = (
-        _chunkGroup: unknown,
-        _initialChunks: Set<unknown>,
-        cssPrefix: string | null,
-      ) => {
-        cssPrefixes.push(cssPrefix);
-        return { chunks: [], css: [] };
-      };
-
-      internals.buildManifest(
-        {
-          outputOptions: { publicPath: '/assets' },
-          entrypoints: new Map(),
-          chunkGroups: [{ chunks: [] }],
-          chunkGraph: { getChunkModulesIterable: () => [] },
-          warnings: [],
-        },
-        {},
-        new Map(),
-      );
-
-      return cssPrefixes;
-    };
 
     it('emits empty diagnostics for an explicitly server-only static page config', () => {
       const result = run('static-islands', {
@@ -429,45 +388,6 @@ describe('RSCRspackPlugin', () => {
       expect(childCss).toContain('.styled-island');
       expect(parentCss).toContain('.parent-styled-island');
       expect(result.clientReferenceDiagnostics?.isServer).toBe(true);
-    });
-
-    it('keeps CSS asset collection enabled for manifest output', () => {
-      expect(captureBuildManifestCssPrefixes()).toEqual(['/assets/']);
-    });
-
-    it('keeps CSS asset collection enabled for diagnostics output', () => {
-      expect(
-        captureBuildManifestCssPrefixes({
-          clientReferenceDiagnosticsFilename: diagnosticsFilename,
-        }),
-      ).toEqual(['/assets/']);
-    });
-
-    it('keeps server diagnostics CSS from merged initial chunks without initial JS', () => {
-      const { RSCRspackPlugin } = require(DIST_PLUGIN);
-      const plugin = new RSCRspackPlugin({
-        isServer: true,
-        clientReferenceDiagnosticsFilename: diagnosticsFilename,
-      });
-      const internals = plugin as {
-        getGroupAssets: (
-          chunkGroup: unknown,
-          initialChunks: Set<unknown>,
-          cssPrefix: string | null,
-        ) => { chunks: (string | number | null)[]; css: string[] };
-      };
-      const initialChunk = {
-        id: 'server',
-        files: new Set(['server-bundle.js', 'server-bundle.css']),
-        canBeInitial: () => true,
-      };
-
-      expect(
-        internals.getGroupAssets({ chunks: [initialChunk] }, new Set([initialChunk]), '/assets/'),
-      ).toEqual({
-        chunks: ['server', 'server-bundle.js'],
-        css: ['/assets/server-bundle.css'],
-      });
     });
   });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -41,6 +41,25 @@ const readDiagnosticCss = (result: CompileResult, entryFileSuffix: string): stri
     .join('\n');
 };
 
+const manifestMetadataFor = (
+  result: CompileResult,
+  entryFileSuffix: string,
+): CompileResult['manifest']['filePathToModuleMetadata'][string] => {
+  const entry = Object.entries(result.manifest.filePathToModuleMetadata).find(([file]) =>
+    file.endsWith(entryFileSuffix),
+  );
+  expect(entry).toBeTruthy();
+  return entry![1];
+};
+
+const readManifestCss = (result: CompileResult, entryFileSuffix: string): string =>
+  (manifestMetadataFor(result, entryFileSuffix).css ?? [])
+    .map((file) => {
+      const assetName = file.replace(/^\/assets\//, '');
+      return fs.readFileSync(path.join(result.outputPath, assetName), 'utf8');
+    })
+    .join('\n');
+
 const staticIslandClientReferences = (include: RegExp) => [
   { directory: '.', recursive: false, include },
 ];
@@ -61,6 +80,45 @@ const splitStaticIslandVendors = {
         heavyVendor: {
           test: /heavy-vendor\.js$/,
           name: 'vendors-heavy',
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+
+const splitStaticIslandCssOnlyChunks = {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      cacheGroups: {
+        default: false,
+        defaultVendors: false,
+        styles: {
+          name: 'styles',
+          type: 'css/mini-extract',
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+
+const splitStaticIslandMixedCssOnlyChunk = {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      cacheGroups: {
+        default: false,
+        defaultVendors: false,
+        splitIslandStyles: {
+          test: /MixedSplitIsland\.css$/,
+          name: 'styles',
+          type: 'css/mini-extract',
+          chunks: 'all',
           enforce: true,
         },
       },
@@ -273,6 +331,62 @@ describe('RSCRspackPlugin', () => {
       expect(childCss).toContain('.styled-island');
       expect(childCss).not.toContain('.parent-styled-island');
       expect(parentCss).toContain('.parent-styled-island');
+    });
+
+    it("scopes manifest CSS to the referenced island's chunk group when diagnostics are disabled", () => {
+      const result = run('static-islands', {
+        clientReferences: staticIslandClientReferences(
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+        ),
+        publicPath: '/assets',
+        withCss: true,
+      });
+
+      const childCss = readManifestCss(result, '/StyledIsland.js');
+      const parentCss = readManifestCss(result, '/ParentStyledIsland.js');
+
+      expect(childCss).toContain('.styled-island');
+      expect(childCss).not.toContain('.parent-styled-island');
+      expect(parentCss).toContain('.parent-styled-island');
+    });
+
+    it('keeps CSS-only split chunk styles in the server manifest', () => {
+      const result = run('static-islands', {
+        isServer: true,
+        clientReferences: staticIslandClientReferences(/^\.\/StyledIsland\.js$/),
+        publicPath: '/assets',
+        withCss: true,
+        configExtra: splitStaticIslandCssOnlyChunks,
+      });
+
+      expect(result.assets).toContain('styles.chunk.css');
+      expect(manifestMetadataFor(result, '/StyledIsland.js').css).toEqual([
+        '/assets/styles.chunk.css',
+      ]);
+      expect(readManifestCss(result, '/StyledIsland.js')).toContain('.styled-island');
+    });
+
+    it('keeps mixed chunk-local and CSS-only split styles in the server manifest', () => {
+      const result = run('static-islands', {
+        isServer: true,
+        clientReferences: staticIslandClientReferences(/^\.\/MixedStyledIsland\.js$/),
+        publicPath: '/assets',
+        withCss: true,
+        configExtra: splitStaticIslandMixedCssOnlyChunk,
+      });
+
+      const cssFiles = manifestMetadataFor(result, '/MixedStyledIsland.js').css ?? [];
+      expect(result.assets).toEqual(
+        expect.arrayContaining(['client0.chunk.css', 'styles.chunk.css']),
+      );
+      expect(cssFiles).toEqual(
+        expect.arrayContaining(['/assets/client0.chunk.css', '/assets/styles.chunk.css']),
+      );
+      expect(cssFiles).toHaveLength(2);
+
+      const css = readManifestCss(result, '/MixedStyledIsland.js');
+      expect(css).toContain('.mixed-styled-island');
+      expect(css).toContain('.mixed-split-island');
     });
 
     it("scopes server diagnostics CSS to the referenced island's chunk group", () => {
@@ -1056,6 +1170,36 @@ describe('RSCRspackPlugin', () => {
       const result = run('basic-client', { publicPath: 'auto' });
       expect(result.manifest.moduleLoading.prefix).toBe('');
       expect(result.warnings.join('\n')).toContain("output.publicPath is 'auto'");
+    });
+
+    it('warns and avoids serializing function-valued publicPath', () => {
+      const { RSCRspackPlugin } = require(DIST_PLUGIN);
+      const plugin = new RSCRspackPlugin({ isServer: false });
+      const warnings: Error[] = [];
+      const internals = plugin as {
+        buildManifest: (
+          compilation: unknown,
+          bundler: unknown,
+          diagnosticsCssFiles: Map<string, string[]>,
+        ) => { moduleLoading: { prefix: string } };
+      };
+
+      const manifest = internals.buildManifest(
+        {
+          outputOptions: { publicPath: () => '/assets/' },
+          entrypoints: new Map(),
+          chunkGroups: [],
+          chunkGraph: { getChunkModulesIterable: () => [] },
+          warnings,
+        },
+        { WebpackError: Error },
+        new Map(),
+      );
+
+      expect(manifest.moduleLoading.prefix).toBe('');
+      expect(warnings.map((warning) => warning.message).join('\n')).toContain(
+        'output.publicPath is a function',
+      );
     });
 
     it('preserves an absolute URL publicPath', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -499,6 +499,7 @@ describe('RSCRspackPlugin', () => {
 
       expect(result.assets).toContain('main.js');
       expect(entry.id).toBe('./ClientButton.js');
+      expect(entry.css).toEqual([]);
       expect(chunkFiles).not.toContain('main.js');
     });
 
@@ -527,6 +528,79 @@ describe('RSCRspackPlugin', () => {
       expect(entry.id).toBe('./ClientButton.js');
       expect(initialAssets.size).toBeGreaterThan(0);
       expect(chunkFiles.filter((file) => initialAssets.has(file))).toEqual(['main.js']);
+      expect(chunkFiles).not.toContain('runtime.js');
+    });
+
+    it('records non-runtime vendor chunks for statically imported client references', () => {
+      const result = run('eager-vendor', {
+        configExtra: {
+          optimization: {
+            chunkIds: 'named',
+            moduleIds: 'named',
+            minimize: false,
+            splitChunks: {
+              chunks: 'all',
+              minSize: 0,
+              cacheGroups: {
+                default: false,
+                defaultVendors: false,
+                clientVendor: {
+                  test: /react-dom/,
+                  name: 'vendors-client',
+                  enforce: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
+        p.endsWith('ClientWidget.js'),
+      );
+      expect(key).toBeTruthy();
+
+      const entry = result.manifest.filePathToModuleMetadata[key!]!;
+      const chunkFiles = manifestChunkFiles(entry.chunks);
+
+      expect(result.assets).toContain('main.js');
+      expect(result.assets).toContain('vendors-client.js');
+      expect(entry.id).toBe('./ClientWidget.js');
+      expect(chunkFiles).toContain('vendors-client.js');
+      expect(chunkFiles).not.toContain('main.js');
+    });
+
+    it('omits eager entry CSS when the entry chunk is also the runtime chunk', () => {
+      const result = run('eager-css', {
+        publicPath: '/assets/',
+        withCss: true,
+      });
+      const entry = manifestMetadataFor(result, 'Button.js');
+
+      expect(result.assets).toContain('main.css');
+      expect(entry.id).toBe('./Button.js');
+      expect(entry.css).toEqual([]);
+    });
+
+    it('records eager entry CSS when runtimeChunk is split out', () => {
+      const result = run('eager-css', {
+        publicPath: '/assets/',
+        withCss: true,
+        configExtra: {
+          optimization: {
+            runtimeChunk: 'single',
+            chunkIds: 'named',
+            moduleIds: 'named',
+            minimize: false,
+          },
+        },
+      });
+      const entry = manifestMetadataFor(result, 'Button.js');
+      const chunkFiles = manifestChunkFiles(entry.chunks);
+
+      expect(result.assets).toContain('main.css');
+      expect(entry.id).toBe('./Button.js');
+      expect(entry.css).toEqual(['/assets/main.css']);
+      expect(chunkFiles).toContain('main.js');
       expect(chunkFiles).not.toContain('runtime.js');
     });
 


### PR DESCRIPTION
## Summary

- Add Rspack client manifest CSS metadata so `withStylesheetHints` can emit stylesheet hints for Rspack-built client references.
- Scope Rspack manifest CSS per client reference while preserving direct stylesheet imports that Rspack extracts into CSS-only split chunks.
- Recover eager-entry fallback CSS when Rspack optimizes the plugin-created client chunk away, while preserving the generated-chunk guard when that chunk exists.
- Normalize Rspack `output.publicPath: "auto"` and function-valued `output.publicPath` to an empty manifest prefix with warnings because runtime public paths cannot be serialized safely.
- Preserve `.mjs` client chunk files and include non-runtime split chunks while excluding the runtime chunk.
- Add the required changelog entry for the user-visible Rspack manifest behavior fixes.

Fixes #157.
Fixes #160.
Closes #158 after the webpack-side #171 merge.

## Status

Closeout in progress on current head `f48666a`. Local validation is green after the final review-fix commit. Hosted checks and current-head review comments are resolved/triaged and hosted checks are being re-polled before this PR is marked ready or merged.

Sibling PR #171 covered the webpack-side `publicPath: "auto"` behavior and was merged first as `9758072`, so this PR completes the rspack side of #158.

merge_authority: `auto_merge_when_gates_pass` for this closeout request. This PR will still wait for full current-head checks, resolved/triaged review threads, and clean mergeability before merge.

## Codex Decision Log

- **Non-blocking:** Should non-runtime vendor chunks attached to a statically imported client reference stay in the Rspack manifest?
  - **Decision:** Yes. Keep runtime-chunk-only exclusion, matching the webpack plugin behavior; webpack/Rspack chunk loaders no-op on chunks already installed by the page.
  - **Why:** Excluding every initial chunk would diverge from the webpack-side contract and could omit real dependencies when `runtimeChunk: "single"` splits the runtime from other entry chunks.
  - **Review later:** None unless a concrete consuming-app regression shows these redundant entries are harmful.
- **Non-blocking:** Should default eager-entry CSS be recorded when the entry chunk is also the runtime chunk?
  - **Decision:** No. Keep runtime chunk CSS excluded in the default config, but record eager-entry CSS when `runtimeChunk: "single"` separates `main.css` from the runtime chunk.
  - **Why:** This mirrors the webpack-side tests and preserves the runtime-chunk exclusion contract while covering the split-runtime stylesheet-hint path.
  - **Review later:** Broader runtime CSS policy can be revisited separately if maintainers want stylesheet hints from default entry-runtime chunks.
- **Non-blocking:** Should the duplicated CSS-source matching helper move to shared code in this PR?
  - **Decision:** No. Leave `STYLE_SOURCE_RE`/direct CSS recovery local to avoid widening a runtime parity fix into a shared webpack/rspack refactor.
  - **Why:** The constants are currently identical and covered by parity tests; hoisting would touch webpack-owned structure without fixing a #157/#160/#158 behavior gap.
  - **Review later:** Consider a small cleanup PR if this logic changes again.

## Verification

- Red repro before the original fix: `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand` failed for missing manifest CSS, diagnostics-disabled CSS manifest collection, dropped initial entry chunks, literal `moduleLoading.prefix: "auto"`, and missing `.mjs` chunk files.
- Final head `f48666a`: `yarn build`
- Final head `f48666a`: `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand`
- Final head `f48666a`: `git diff --check`
- Final head `f48666a`: `yarn test:e2e`
- Final head `f48666a`: `yarn test`

## Review / Churn Notes

- Pre-push review caught CSS scoping and split CSS gaps; those were fixed with direct-style-import recovery and regressions.
- Claude review later exposed an eager-entry fallback CSS gap in the split-runtime case; final commit `f48666a` fixes that path and adds focused fixtures for eager CSS and eager vendor split chunks.
- Current-head review threads are resolved or explicitly triaged. No maintainer decision is needed unless a current-head reviewer reports a confirmed blocker.