### PR TITLE
Document tiny browser sidecars for static RSC pages

### DIFF
--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -114,6 +114,46 @@ dependency through the emitted chunk files and byte totals. Remove or defer the
 import in the island itself; the diagnostics option only reports what the build
 emitted and does not rewrite the module graph.
 
+## Tiny Browser Sidecars
+
+Use a tiny browser sidecar when a page should ship static RSC HTML and CSS on the
+initial path but still needs browser-only effects, such as auth checks,
+query-param handling, analytics beacons, or intent-driven modals. The sidecar is
+a normal browser entry. It is not a Flight client reference unless the RSC page
+actually renders it as a `"use client"` component.
+
+Recommended shape:
+
+1. Render the mostly static page from an isolated RSC build target.
+2. Keep `clientReferences: []` for pages that cannot render Flight client
+   components, or declare only the tiny islands that the page may render.
+3. Add a dedicated browser entry, for example `public-page-client-effects`, for
+   page effects that do not need to be in the Flight manifest.
+4. Hand server data to the sidecar with inert JSON, such as an
+   `application/json` script tag, instead of auto-mounting a React component on
+   page load.
+5. Lazy-import React, React DOM, dashboard clients, and other heavy modules only
+   after user intent or after the browser condition that needs them.
+
+The browser entry should avoid importing the normal application pack. If the
+normal pack includes global dashboard code, analytics setup, or authenticated
+app vendors, importing it from the sidecar puts that cost back on the static
+page even when the RSC manifest is empty.
+
+For webpack or rspack split-chunk configuration, keep the sidecar separate from
+the app-wide vendor cache group when the vendor group would pull in the main app
+shell. A sidecar can still share small, intentional dependencies, but the static
+page budget should be verified from emitted assets rather than inferred from the
+entry name. Use the diagnostics JSON to confirm the Flight client-reference
+chunks stay empty or tiny, and inspect the bundler stats or emitted asset list to
+confirm the sidecar did not inherit the monolithic app vendor chunk.
+
+Avoid using the sidecar as a substitute for missing route-scoped manifests. It is
+a supported integration pattern for static pages whose browser effects can live
+outside Flight. If a route renders real Flight client components, keep those
+components in `clientReferences` and use the diagnostics output to prove the
+declared island set is still narrow.
+
 ## Boundaries
 
 This diagnostics slice is intentionally narrow:

--- a/docs/rsc-static-islands-diagnostics.md
+++ b/docs/rsc-static-islands-diagnostics.md
@@ -125,8 +125,9 @@ actually renders it as a `"use client"` component.
 Recommended shape:
 
 1. Render the mostly static page from an isolated RSC build target.
-2. Keep `clientReferences: []` for pages that cannot render Flight client
-   components, or declare only the tiny islands that the page may render.
+2. Follow the static page patterns above: use `clientReferences: []` for pages
+   that cannot render Flight client components, or declare only the tiny islands
+   that the page may render.
 3. Add a dedicated browser entry, for example `public-page-client-effects`, for
    page effects that do not need to be in the Flight manifest.
 4. Hand server data to the sidecar with inert JSON, such as an
@@ -134,6 +135,12 @@ Recommended shape:
    page load.
 5. Lazy-import React, React DOM, dashboard clients, and other heavy modules only
    after user intent or after the browser condition that needs them.
+
+Do not write raw serialized JSON into the script tag. Even inert
+`application/json` blocks are parsed as HTML, so a string containing
+`</script>` can close the element. Escape the JSON for an HTML script context
+before embedding it; Rails apps can use `json_escape` or an equivalent safe
+serializer that prevents user-controlled values from breaking out of the tag.
 
 The browser entry should avoid importing the normal application pack. If the
 normal pack includes global dashboard code, analytics setup, or authenticated


### PR DESCRIPTION
## Summary

- Recover the closed-unmerged #146 work on current `main`.
- Document the supported tiny browser sidecar pattern for mostly static RSC pages.
- Clarify that a sidecar browser entry is separate from Flight client references unless rendered as a `"use client"` island.
- Add bundler/vendor guidance for keeping the sidecar out of the monolithic app pack and validating emitted assets.

Closes #145.

## Recovery Notes

- Replaces closed-unmerged PR #146.
- Rebased onto current `origin/main` after PR #143 and later RSC follow-up work landed.
- The companion system-spec recovery branch adds README navigation for this static-islands guide and the streamed system-spec guide.

## Codex Decision Log

- **Non-blocking:** Should this add a package helper or framework-wide abstraction?
  - **Decision:** No. This PR documents the supported integration shape using the existing plugin options.
  - **Why:** #134 is still a product/API decision for route-scoped manifests; adding an abstraction here would widen #145 beyond the narrow static-page sidecar pattern.
  - **Review later:** Revisit helper APIs after #134 decides the manifest/runtime contract.

## Validation

- `git diff --check`
- `yarn build`
- `yarn test`

## Review Churn / Audit Notes

- Changelog: not updated because this is docs-only guidance and does not add package behavior.
- Coordination: #134 was closed for this batch with a no-PR/product-decision comment before the original PR was opened: https://github.com/shakacode/react_on_rails_rsc/issues/134#issuecomment-4859630548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for “Tiny Browser Sidecars” in the RSC Static Island Diagnostics guide.
  * Clarified the recommended setup for keeping initial HTML/CSS lightweight while enabling browser-only effects.
  * Included checks for verifying that client-side metadata stays minimal and that shared browser assets remain separated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->