### PR TITLE
Prepare 19.2.1-rc.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [19.3.0-rc.0] - 2026-07-05
 
 ### Added
 - Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
@@ -65,7 +65,7 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[Unreleased]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...HEAD
+[19.3.0-rc.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...19.3.0-rc.0
 [19.2.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this package will be documented in this file.
 
-## [19.3.0-rc.0] - 2026-07-05
+## [19.2.1-rc.0] - 2026-07-05
 
 ### Added
 - Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
@@ -65,7 +65,7 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[19.3.0-rc.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...19.3.0-rc.0
+[19.2.1-rc.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...19.2.1-rc.0
 [19.2.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-rsc",
-  "version": "19.2.0",
+  "version": "19.3.0-rc.0",
   "description": "React Server Components support for react_on_rails Ruby gem",
   "exports": {
     "./client": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-rsc",
-  "version": "19.3.0-rc.0",
+  "version": "19.2.1-rc.0",
   "description": "React Server Components support for react_on_rails Ruby gem",
   "exports": {
     "./client": {

--- a/tests/package-runtime-policy.test.ts
+++ b/tests/package-runtime-policy.test.ts
@@ -30,7 +30,7 @@ const collectExportTargets = (value: unknown): string[] => {
 };
 
 describe('19.2 runtime release policy', () => {
-  it('stamps the package and changelog for the 19.3.0 release line', () => {
+  it('stamps the package and changelog for the 19.2.1 release line', () => {
     const pkg = readJson<PackageJson>('package.json');
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
 
@@ -38,7 +38,7 @@ describe('19.2 runtime release policy', () => {
     // require editing this test between RC and final stamps. Still pins the
     // current package release line and requires the
     // CHANGELOG's top entry to match the package version exactly.
-    expect(pkg.version).toMatch(/^19\.3\.0(?:-rc\.\d+)?$/);
+    expect(pkg.version).toMatch(/^19\.2\.1(?:-rc\.\d+)?$/);
     const topChangelogVersion = changelog.match(/^## \[([^\]]+)\] - \d{4}-\d{2}-\d{2}$/m)?.[1];
     expect(topChangelogVersion).toBe(pkg.version);
   });

--- a/tests/package-runtime-policy.test.ts
+++ b/tests/package-runtime-policy.test.ts
@@ -30,15 +30,15 @@ const collectExportTargets = (value: unknown): string[] => {
 };
 
 describe('19.2 runtime release policy', () => {
-  it('stamps the package and changelog for the 19.2.0 release line', () => {
+  it('stamps the package and changelog for the 19.3.0 release line', () => {
     const pkg = readJson<PackageJson>('package.json');
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
 
     // Derive the expected version from package.json so a version bump doesn't
-    // require editing this test (a hard-coded version here previously blocked
-    // the rc.3 release). Still pins the 19.2.0 release line and requires the
+    // require editing this test between RC and final stamps. Still pins the
+    // current package release line and requires the
     // CHANGELOG's top entry to match the package version exactly.
-    expect(pkg.version).toMatch(/^19\.2\.0(?:-rc\.\d+)?$/);
+    expect(pkg.version).toMatch(/^19\.3\.0(?:-rc\.\d+)?$/);
     const topChangelogVersion = changelog.match(/^## \[([^\]]+)\] - \d{4}-\d{2}-\d{2}$/m)?.[1];
     expect(topChangelogVersion).toBe(pkg.version);
   });


### PR DESCRIPTION
## Summary
- Stamps `CHANGELOG.md` for `19.2.1-rc.0` using the existing `Unreleased` entries.
- Bumps `package.json` to `19.2.1-rc.0` and keeps the release-policy test on the React 19.2 runtime package line.
- Adds the `19.2.0...19.2.1-rc.0` compare link.

## Classification sweep
Range: `19.2.0..origin/main`

| PR | Result | Category | Reason |
| --- | --- | --- | --- |
| #138 | no-entry | release-process | GitHub Actions dependency updates only. |
| #144 | entry-needed | product code | Adds opt-in static RSC island diagnostics. |
| #143 | entry-needed | product code | Adds RSC resource hint helpers and expanded server types. |
| #139 | no-entry | internal | Package dependency metadata/lockfile update without package behavior change. |
| #151 | entry-needed | product code | Restores CSS hints for CSS-only split chunks. |
| #164 | entry-needed | product code | Refreshes client references during watch rebuilds. |
| #152 | entry-needed | perf-reliability | Skips unused rspack diagnostics CSS work. |
| #165 | entry-needed | product code | Installs the rspack splitChunks guard after defaults. |
| #166 | entry-needed | product code | Scopes rspack diagnostics CSS to owner chunks. |
| #163 | no-entry | release-process | Dependabot auto-merge workflow hardening only. |
| #167 | entry-needed | perf-reliability | Preserves rspack incremental caching while keeping discovery behavior. |
| #168 | entry-needed | product code | Scopes rspack runtime injection state by compiler. |
| #169 | no-entry | release-process | Claude review workflow token wiring only. |
| #170 | no-entry | internal | Release documentation only. |
| #140 | entry-needed | product code | Adds Rspack 2 manifest compatibility fixes. |
| #173 | no-entry | internal | Static-island documentation only. |
| #174 | no-entry | internal | README/system-spec transport documentation only. |
| #171 | entry-needed | product code | Fixes Webpack manifest path/publicPath parity gaps. |
| #175 | no-entry | internal | Agent workflow/docs maintenance only. |
| #172 | entry-needed | product code | Fixes Rspack manifest runtime parity gaps. |

## Verification
- `yarn build`
- `yarn jest tests/package-runtime-policy.test.ts`
- `yarn test`
- `yarn release:check` metadata/tag/npm checks passed for `19.2.1-rc.0`; the command then failed as expected because it must run from a clean `main` checkout after this PR merges.

After this PR merges, run `yarn release:check` from clean synced `main` and dispatch the `Release package` workflow command printed by that check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for **19.2.1-rc.0**, including updated comparison links.

* **Chores**
  * Bumped the package version to **19.2.1-rc.0**.

* **Tests**
  * Updated release-line validation to recognize **19.2.1** and related release-candidate versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->