### PR TITLE
Declare rspack 1.x and 2.x support

### DIFF
--- a/.github/workflows/compatibility-matrix.yml
+++ b/.github/workflows/compatibility-matrix.yml
@@ -60,6 +60,14 @@ jobs:
             types-react-dom-version: '~19.2.0'
             webpack-version: '^5.0.0'
             rspack-version: '1.x'
+          - label: React 19.2.x / webpack latest 5.x + rspack 2.x / Node 22
+            node-version: '22.x'
+            react-version: '~19.2.0'
+            react-dom-version: '~19.2.0'
+            types-react-version: '~19.2.0'
+            types-react-dom-version: '~19.2.0'
+            webpack-version: '^5.0.0'
+            rspack-version: '2.x'
 
     steps:
       # Pinned immutable actions/checkout@v7 release SHA verified via git ls-remote.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file.
 - Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
 
 ### Changed
+- Declared the optional `@rspack/core` peer range as Rspack 1.x or 2.x and added explicit Rspack 2.x compatibility coverage. ([#183])
 - Stopped `RSCRspackPlugin` from injecting a no-op `"use client"` tagging loader into every first-party module, preserving rspack incremental caching while keeping filesystem-based client-reference discovery. ([#167])
 - Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
 
@@ -79,6 +80,7 @@ All notable changes to this package will be documented in this file.
 [#168]: https://github.com/shakacode/react_on_rails_rsc/pull/168
 [#172]: https://github.com/shakacode/react_on_rails_rsc/pull/172
 [#176]: https://github.com/shakacode/react_on_rails_rsc/pull/176
+[#183]: https://github.com/shakacode/react_on_rails_rsc/pull/183
 [#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Release this package from `main` using the changelog-driven workflow in
 ## Compatibility Policy
 
 The package peer dependencies are the current source of truth for supported
-React and webpack ranges. CI also runs a focused compatibility matrix covering
-React 19.0.4 and 19.2.x, Node.js 20 and 22, webpack 5.59.0 and latest 5.x, and
-rspack latest 1.x. A weekly React canary job is signal-only and is allowed to
-fail while upstream canary APIs move; review its GitHub Actions summary for
-early warnings.
+React, webpack, and rspack ranges. CI also runs a focused compatibility matrix
+covering React 19.0.4 and 19.2.x, Node.js 20 and 22, webpack 5.59.0 and latest
+5.x, and rspack latest 1.x plus latest 2.x. The `@rspack/core` peer is optional
+so webpack-only consumers do not need to install rspack. A weekly React canary
+job is signal-only and is allowed to fail while upstream canary APIs move;
+review its GitHub Actions summary for early warnings.
 
 A formal versioning policy is tracked in
 [#70](https://github.com/shakacode/react_on_rails_rsc/issues/70).

--- a/internal/docs/versioning.md
+++ b/internal/docs/versioning.md
@@ -46,9 +46,11 @@ Each runtime line owns its peer dependency policy:
 - Lowering a root peer minimum, advertising a new React minor line, or broadening
   the supported peer contract needs explicit matrix and downstream evidence in
   the release PR before `latest` is promoted.
-- `webpack` and other bundler peers are compatibility contracts for the plugin
-  layer. Keep them tied to tested bundler behavior rather than to the React
-  runtime version alone.
+- `webpack`, `@rspack/core`, and other bundler peers are compatibility
+  contracts for the plugin layer. Keep them tied to tested bundler behavior
+  rather than to the React runtime version alone. When consumers can use only
+  one bundler integration, declare the bundler-specific peer as optional and
+  pair every advertised major range with an explicit compatibility-matrix lane.
 
 When a newer runtime line becomes `latest`, older runtime lines enter
 maintenance mode:

--- a/package.json
+++ b/package.json
@@ -127,9 +127,15 @@
     "webpack": "^5.98.0"
   },
   "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "webpack": "^5.59.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
   },
   "dependencies": {
     "acorn-loose": "^8.3.0",

--- a/scripts/prepare-compatibility-install.cjs
+++ b/scripts/prepare-compatibility-install.cjs
@@ -247,18 +247,23 @@ function assertWebpackSpec(spec) {
 }
 
 function assertRspackSpec(spec) {
-  if (spec === '^1' || spec === '1.x') return;
+  if (getRspackMajorSpec(spec) !== null) return;
 
   const version = parseVersion(stripSimpleRangePrefix(spec));
-  if (version.major !== 1) {
-    throw new Error(`@rspack/core@${spec} is outside the supported rspack 1.x compatibility matrix`);
+  if (version.major !== 1 && version.major !== 2) {
+    throw new Error(
+      `@rspack/core@${spec} is outside the supported rspack 1.x/2.x compatibility matrix`
+    );
   }
 }
 
 function matchesSpec(packageName, actualVersion, spec) {
   if (isCanarySpec(spec)) return actualVersion.includes('canary');
-  if (spec === '^1' || spec === '1.x') {
-    return parseVersion(actualVersion).major === 1;
+  if (packageName === '@rspack/core') {
+    const rspackMajorSpec = getRspackMajorSpec(spec);
+    if (rspackMajorSpec !== null) {
+      return parseVersion(actualVersion).major === rspackMajorSpec;
+    }
   }
 
   if (spec.startsWith('^')) {
@@ -284,6 +289,12 @@ function matchesSpec(packageName, actualVersion, spec) {
   }
 
   return actualVersion === spec;
+}
+
+function getRspackMajorSpec(spec) {
+  if (spec === '^1' || spec === '1.x') return 1;
+  if (spec === '^2' || spec === '2.x') return 2;
+  return null;
 }
 
 function isCanarySpec(spec) {


### PR DESCRIPTION
## Summary

- Adds an explicit Rspack 2.x compatibility-matrix row while preserving existing Rspack 1.x coverage and the existing signal-only React canary/Rspack 1.x lane.
- Declares `@rspack/core` as an optional peer dependency supported on `^1.0.0 || ^2.0.0`.
- Updates the published README, maintainer versioning policy, changelog, and compatibility installer so the documented support range is actually testable.

Fixes #179.

## Validation

- `yarn` passed to install dependencies in the fresh worktree.
- `yarn build` passed.
- `yarn test` passed: 7 RSC suites / 15 tests and 25 non-RSC suites / 252 tests.
- `COMPAT_LABEL='local React 19.2.x / webpack latest 5.x + rspack 2.x / Node 22' COMPAT_REACT='~19.2.0' COMPAT_REACT_DOM='~19.2.0' COMPAT_REACT_SERVER_DOM_WEBPACK='~19.2.0' COMPAT_TYPES_REACT='~19.2.0' COMPAT_TYPES_REACT_DOM='~19.2.0' COMPAT_WEBPACK='^5.0.0' COMPAT_RSPACK='2.x' node scripts/prepare-compatibility-install.cjs` passed and installed `@rspack/core@2.1.3` with `webpack@5.108.4`.
- `yarn build && yarn test` passed with `@rspack/core@2.1.3` installed.
- `COREPACK_ENABLE_PROJECT_SPEC=0 yarn verify:artifacts` passed. The env override keeps the verifier's temporary consumer on Yarn Classic in this local Corepack setup.
- `.agents/bin/validate` passed.
- `actionlint .github/workflows/compatibility-matrix.yml` passed.
- `git diff --check origin/main...HEAD` passed.

## Codex Decision Log

- **Non-blocking:** `scripts/prepare-compatibility-install.cjs` was not in the original file-touch map, but the new matrix row cannot run without changing it because the helper rejected non-1.x Rspack specs.
  - **Decision:** Treat the helper as part of #179's workflow gate surface and update only the Rspack spec validation/matching logic.
  - **Why:** The assigned trusted target explicitly requires a pinned Rspack 2.x compatibility lane, and the repo workflow treats directly required workflow/build/package support files as normal issue scope.
  - **Review later:** None.

## Review And Churn Notes

- Manual self-review completed against `origin/main...HEAD`.
- Read-only pre-push review subagent found no blocking findings.
- `codex review --base origin/main` was attempted, inspected the diff, then became inconclusive after its sandbox package install hit `ENOTFOUND registry.yarnpkg.com` and the process continued without a final verdict; I terminated it and used the completed read-only review plus local validation as the fallback evidence.
- `claude -p '/code-review origin/main...HEAD'` was attempted but produced no output after multiple poll windows; I terminated the hung command and recorded it as unavailable.
- `claude -p '/simplify origin/main...HEAD'` completed with no code changes recommended. It flagged that changing the React canary lane from Rspack 1.x to 2.x would drop 1.x canary signal, so I restored the canary lane to 1.x and kept the new Rspack 2.x coverage in the blocking compatibility matrix.
- Post-push churn: 0 review-fix commits; one follow-up amend added this PR number to the changelog reference and current head is 182fc20.

## QA Evidence

```text
qa-evidence v1
scope: #179 workflow/package/docs support-range lane
base: origin/main @ 6b96e536a6cbc2d74872163c64ad020c06ee97c4
head: 182fc20
local_validation:
  - yarn build: pass
  - yarn test: pass (7 RSC suites / 15 tests; 25 non-RSC suites / 252 tests)
  - 2.x compatibility installer: pass (@rspack/core@2.1.3, webpack@5.108.4)
  - yarn build && yarn test with @rspack/core@2.1.3 installed: pass
  - COREPACK_ENABLE_PROJECT_SPEC=0 yarn verify:artifacts: pass
  - .agents/bin/validate: pass
  - actionlint .github/workflows/compatibility-matrix.yml: pass
  - git diff --check origin/main...HEAD: pass
review_gate:
  - read-only pre-push review: no blocking findings
  - codex review: attempted/inconclusive due sandbox registry ENOTFOUND and long-running process
  - Claude code-review: attempted/unavailable, no output before bounded termination
  - simplify: completed, no simplification patch applied; canary lane restored to 1.x after scope note
coordination:
  - open PR collision sweep before branch: none
  - private coordination writes partially degraded earlier by stale claim/write contention; live GitHub collision state was clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded compatibility coverage to include an additional Rspack 2.x configuration, alongside existing React and webpack support.
  * Marked the Rspack peer as optional for webpack-only setups while supporting both Rspack 1.x and 2.x.

* **Documentation**
  * Updated compatibility guidance and changelog notes to reflect the latest supported version ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->