### PR TITLE
Recover transitive CSS-only split chunk styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this package will be documented in this file.
 - Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
 
 ### Fixed
+- Recovered RSC stylesheet hints for CSS imported by a client reference's child module when a CSS-merging SplitChunks cache group moves the stylesheet into a CSS-only split chunk. ([#184])
 - Fixed Webpack client-reference string paths to resolve relative to the compiler context and warned when `output.publicPath: "auto"` cannot be serialized into the RSC manifest. ([#171])
 - Fixed `RSCRspackPlugin` to skip manifest and diagnostics emission when the Flight client runtime is missing, matching the Webpack plugin's misconfiguration behavior instead of writing unusable assets. ([#176])
 - Fixed Rspack client-reference manifests to emit deterministic chunk pair ordering under Rspack 2 while preserving the full sibling chunk set. ([#140])
@@ -81,6 +82,7 @@ All notable changes to this package will be documented in this file.
 [#172]: https://github.com/shakacode/react_on_rails_rsc/pull/172
 [#176]: https://github.com/shakacode/react_on_rails_rsc/pull/176
 [#183]: https://github.com/shakacode/react_on_rails_rsc/pull/183
+[#184]: https://github.com/shakacode/react_on_rails_rsc/pull/184
 [#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -708,6 +708,17 @@ export class RSCRspackPlugin {
     // plugin, lines 241-294). Each module gets the full list of sibling
     // chunks in its group — this ensures splitChunks dependencies are
     // included.
+    const chunkGroupUseCount = new Map<AnyChunk, number>();
+    for (const candidateGroup of compilation.chunkGroups) {
+      for (const candidateChunkUnknown of candidateGroup.chunks) {
+        const candidateChunk = candidateChunkUnknown as AnyChunk;
+        chunkGroupUseCount.set(
+          candidateChunk,
+          (chunkGroupUseCount.get(candidateChunk) ?? 0) + 1,
+        );
+      }
+    }
+
     for (const chunkGroup of compilation.chunkGroups) {
       const groupChunkList = [...chunkGroup.chunks].map((chunk) => chunk as AnyChunk);
       const normalizedChunkGroup = { name: chunkGroup.name, chunks: groupChunkList };
@@ -728,6 +739,11 @@ export class RSCRspackPlugin {
       const directCssDepFiles = (module: AnyModule): string[] => {
         if (!getOutgoingConnections || cssPrefix === null) return [];
         const files = new Set<string>();
+        const moduleChunks = new Set(
+          [...compilation.chunkGraph.getModuleChunks(module)]
+            .map((chunk) => chunk as AnyChunk)
+            .filter((chunk) => groupChunkSet.has(chunk)),
+        );
         const addCssFromModuleChunks = (cssModule: AnyModule): void => {
           for (const cssChunkUnknown of compilation.chunkGraph.getModuleChunks(cssModule)) {
             const cssChunk = cssChunkUnknown as AnyChunk;
@@ -737,18 +753,44 @@ export class RSCRspackPlugin {
             }
           }
         };
+        const addDirectStyleImports = (sourceModule: AnyModule): void => {
+          for (const connection of getOutgoingConnections(sourceModule)) {
+            const depModule = connection.module ?? connection.resolvedModule;
+            if (!depModule?.resource) continue;
+            const depResource = depModule.resource.replace(/[?#].*$/, '');
+            if (!STYLE_SOURCE_RE.test(depResource)) continue;
+            addCssFromModuleChunks(depModule);
+            for (const cssConnection of getOutgoingConnections(depModule)) {
+              const extractedCssModule = cssConnection.module ?? cssConnection.resolvedModule;
+              if (!extractedCssModule || extractedCssModule.type !== 'css/mini-extract') continue;
+              addCssFromModuleChunks(extractedCssModule);
+            }
+          }
+        };
+        // Match the webpack plugin: a one-hop non-style child qualifies only
+        // when it shares the reference module's chunk or rspack split it to a
+        // chunk used by this async chunk group only. The use-count check keeps
+        // local child-component CSS without re-broadcasting shared dependency
+        // chunks across reference groups (#108).
+        const belongsToReferenceChunkGroup = (depModule: AnyModule): boolean => {
+          for (const depChunkUnknown of compilation.chunkGraph.getModuleChunks(depModule)) {
+            const depChunk = depChunkUnknown as AnyChunk;
+            if (moduleChunks.has(depChunk)) return true;
+            if (groupChunkSet.has(depChunk) && (chunkGroupUseCount.get(depChunk) ?? 0) === 1) {
+              return true;
+            }
+          }
+          return false;
+        };
 
+        addDirectStyleImports(module);
         for (const connection of getOutgoingConnections(module)) {
           const depModule = connection.module ?? connection.resolvedModule;
           if (!depModule?.resource) continue;
           const depResource = depModule.resource.replace(/[?#].*$/, '');
-          if (!STYLE_SOURCE_RE.test(depResource)) continue;
-          addCssFromModuleChunks(depModule);
-          for (const cssConnection of getOutgoingConnections(depModule)) {
-            const extractedCssModule = cssConnection.module ?? cssConnection.resolvedModule;
-            if (!extractedCssModule || extractedCssModule.type !== 'css/mini-extract') continue;
-            addCssFromModuleChunks(extractedCssModule);
-          }
+          if (STYLE_SOURCE_RE.test(depResource)) continue;
+          if (!belongsToReferenceChunkGroup(depModule)) continue;
+          addDirectStyleImports(depModule);
         }
 
         return [...files];

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -668,6 +668,15 @@ export class RSCWebpackPlugin {
 
           let missingClientReferenceBlocksWarningEmitted = false;
           const clientReferenceChunkGroupsByResource = new Map<string, Set<FlightChunkGroup>>();
+          const chunkGroupUseCount = new Map<FlightChunk, number>();
+          for (const candidateGroup of compilation.chunkGroups) {
+            for (const candidateChunk of candidateGroup.chunks) {
+              chunkGroupUseCount.set(
+                candidateChunk,
+                (chunkGroupUseCount.get(candidateChunk) ?? 0) + 1,
+              );
+            }
+          }
 
           // Records every module of `chunkGroup` whose resource is in
           // `chunkResolvedClientFiles`, listing the chunk group's own
@@ -789,10 +798,12 @@ export class RSCWebpackPlugin {
             // css/mini-extract cache group that moves the extracted CssModule
             // into a CSS-only chunk). Follow the module's DIRECT `.css`
             // imports to the chunk(s) that carry them, intersected with this
-            // chunk group, and merge that CSS. Only direct imports are
-            // followed, so CSS reached through a shared dependency (imported by
-            // another module, not the reference) is NOT picked up — the #108
-            // broadcast stays fixed.
+            // chunk group, and merge that CSS. Also follow one non-style child
+            // hop when that child belongs to the reference's async chunk group:
+            // either it shares one of the reference module's chunks, or webpack
+            // split it to a chunk used by this group only. That second check
+            // keeps a split local child component's stylesheet while still
+            // excluding chunks shared by multiple reference groups (#108).
             // Guarded on `moduleGraph`/`getModuleChunksIterable`, which the
             // unit-test mocks omit (they exercise the per-chunk pass only).
             const moduleGraph = compilation.moduleGraph;
@@ -801,6 +812,9 @@ export class RSCWebpackPlugin {
             const directCssDepFiles = (module: FlightModule): string[] => {
               if (!moduleGraph || !getModuleChunksIterable || cssPrefix === null) return [];
               const files = new Set<string>();
+              const moduleChunks = new Set(
+                [...getModuleChunksIterable(module)].filter((chunk) => groupChunks.has(chunk)),
+              );
               const addCssFromModuleChunks = (cssModule: FlightModule): void => {
                 for (const cssChunk of getModuleChunksIterable(cssModule)) {
                   if (!groupChunks.has(cssChunk)) continue;
@@ -811,6 +825,32 @@ export class RSCWebpackPlugin {
                   }
                 }
               };
+              const addDirectStyleImports = (sourceModule: FlightModule): void => {
+                for (const connection of moduleGraph.getOutgoingConnections(sourceModule)) {
+                  const depModule = connection.module ?? connection.resolvedModule;
+                  if (!depModule || !depModule.resource) continue;
+                  const depResource = depModule.resource.replace(/[?#].*$/, '');
+                  if (!STYLE_SOURCE_RE.test(depResource)) continue;
+                  addCssFromModuleChunks(depModule);
+                  for (const cssConnection of moduleGraph.getOutgoingConnections(depModule)) {
+                    const extractedCssModule = cssConnection.module ?? cssConnection.resolvedModule;
+                    if (!extractedCssModule || extractedCssModule.type !== 'css/mini-extract') {
+                      continue;
+                    }
+                    addCssFromModuleChunks(extractedCssModule);
+                  }
+                }
+              };
+              const belongsToReferenceChunkGroup = (depModule: FlightModule): boolean => {
+                for (const depChunk of getModuleChunksIterable(depModule)) {
+                  if (moduleChunks.has(depChunk)) return true;
+                  if (groupChunks.has(depChunk) && (chunkGroupUseCount.get(depChunk) ?? 0) === 1) {
+                    return true;
+                  }
+                }
+                return false;
+              };
+              addDirectStyleImports(module);
               for (const connection of moduleGraph.getOutgoingConnections(module)) {
                 // `module` is the resolved destination for most connections;
                 // some dependency types leave it null with the target on
@@ -823,15 +863,9 @@ export class RSCWebpackPlugin {
                 // emitted chunk file is always `.css`. Strip any webpack
                 // resource query/fragment (`./Button.css?inline`) first.
                 const depResource = depModule.resource.replace(/[?#].*$/, '');
-                if (!STYLE_SOURCE_RE.test(depResource)) continue;
-                addCssFromModuleChunks(depModule);
-                for (const cssConnection of moduleGraph.getOutgoingConnections(depModule)) {
-                  const extractedCssModule = cssConnection.module ?? cssConnection.resolvedModule;
-                  if (!extractedCssModule || extractedCssModule.type !== 'css/mini-extract') {
-                    continue;
-                  }
-                  addCssFromModuleChunks(extractedCssModule);
-                }
+                if (STYLE_SOURCE_RE.test(depResource)) continue;
+                if (!belongsToReferenceChunkGroup(depModule)) continue;
+                addDirectStyleImports(depModule);
               }
               return [...files];
             };

--- a/tests/rspack-plugin/fixtures/transitive-css-only-chunk/Button.js
+++ b/tests/rspack-plugin/fixtures/transitive-css-only-chunk/Button.js
@@ -1,0 +1,7 @@
+'use client';
+
+import { Panel } from './Panel';
+
+export default function Button() {
+  return 'button:' + Panel();
+}

--- a/tests/rspack-plugin/fixtures/transitive-css-only-chunk/Panel.css
+++ b/tests/rspack-plugin/fixtures/transitive-css-only-chunk/Panel.css
@@ -1,0 +1,3 @@
+.panel {
+  color: rebeccapurple;
+}

--- a/tests/rspack-plugin/fixtures/transitive-css-only-chunk/Panel.js
+++ b/tests/rspack-plugin/fixtures/transitive-css-only-chunk/Panel.js
@@ -1,0 +1,5 @@
+import './Panel.css';
+
+export function Panel() {
+  return 'panel';
+}

--- a/tests/rspack-plugin/fixtures/transitive-css-only-chunk/entryOnly.js
+++ b/tests/rspack-plugin/fixtures/transitive-css-only-chunk/entryOnly.js
@@ -1,0 +1,1 @@
+export const entryOnly = 'entry-only-module';

--- a/tests/rspack-plugin/fixtures/transitive-css-only-chunk/index.js
+++ b/tests/rspack-plugin/fixtures/transitive-css-only-chunk/index.js
@@ -1,0 +1,3 @@
+import { entryOnly } from './entryOnly';
+
+export const app = [entryOnly];

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -337,6 +337,60 @@ describe('RSCRspackPlugin', () => {
       expect(readManifestCss(result, '/StyledIsland.js')).toContain('.styled-island');
     });
 
+    it('keeps child-module CSS-only split chunk styles in the server manifest', () => {
+      const result = run('transitive-css-only-chunk', {
+        isServer: true,
+        clientReferences: staticIslandClientReferences(/^\.\/Button\.js$/),
+        publicPath: '/assets',
+        withCss: true,
+        configExtra: splitStaticIslandCssOnlyChunks,
+      });
+
+      expect(result.assets).toContain('styles.chunk.css');
+      expect(manifestMetadataFor(result, '/Button.js').css).toEqual([
+        '/assets/styles.chunk.css',
+      ]);
+      expect(readManifestCss(result, '/Button.js')).toContain('.panel');
+    });
+
+    it('keeps child-module CSS when the child is split into its own JS chunk', () => {
+      const result = run('transitive-css-only-chunk', {
+        isServer: true,
+        clientReferences: staticIslandClientReferences(/^\.\/Button\.js$/),
+        publicPath: '/assets',
+        withCss: true,
+        configExtra: {
+          optimization: {
+            splitChunks: {
+              chunks: 'all',
+              minSize: 0,
+              cacheGroups: {
+                default: false,
+                defaultVendors: false,
+                panel: {
+                  test: /Panel\.js$/,
+                  name: 'panel',
+                  chunks: 'all',
+                  enforce: true,
+                },
+                styles: {
+                  name: 'styles',
+                  type: 'css/mini-extract',
+                  chunks: 'all',
+                  enforce: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.assets).toEqual(expect.arrayContaining(['panel.chunk.js', 'styles.chunk.css']));
+      const button = manifestMetadataFor(result, '/Button.js');
+      expect(manifestChunkFiles(button.chunks)).toContain('panel.chunk.js');
+      expect(button.css).toContain('/assets/styles.chunk.css');
+    });
+
     it('keeps mixed chunk-local and CSS-only split styles in the server manifest', () => {
       const result = run('static-islands', {
         isServer: true,

--- a/tests/webpack-plugin/fixtures/transitive-css-only-chunk/Button.js
+++ b/tests/webpack-plugin/fixtures/transitive-css-only-chunk/Button.js
@@ -1,0 +1,7 @@
+'use client';
+
+import { Panel } from './Panel';
+
+export default function Button() {
+  return 'button:' + Panel();
+}

--- a/tests/webpack-plugin/fixtures/transitive-css-only-chunk/Panel.css
+++ b/tests/webpack-plugin/fixtures/transitive-css-only-chunk/Panel.css
@@ -1,0 +1,3 @@
+.panel {
+  color: rebeccapurple;
+}

--- a/tests/webpack-plugin/fixtures/transitive-css-only-chunk/Panel.js
+++ b/tests/webpack-plugin/fixtures/transitive-css-only-chunk/Panel.js
@@ -1,0 +1,5 @@
+import './Panel.css';
+
+export function Panel() {
+  return 'panel';
+}

--- a/tests/webpack-plugin/fixtures/transitive-css-only-chunk/entryOnly.js
+++ b/tests/webpack-plugin/fixtures/transitive-css-only-chunk/entryOnly.js
@@ -1,0 +1,1 @@
+export const entryOnly = 'entry-only-module';

--- a/tests/webpack-plugin/fixtures/transitive-css-only-chunk/index.js
+++ b/tests/webpack-plugin/fixtures/transitive-css-only-chunk/index.js
@@ -1,0 +1,3 @@
+import { entryOnly } from './entryOnly';
+
+export const app = [entryOnly];

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -413,6 +413,85 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
     });
   });
 
+  describe('CSS-only SplitChunks chunks: transitive CSS moved away from client-reference JS', () => {
+    let result: CompileResult;
+
+    beforeAll(() => {
+      result = run('transitive-css-only-chunk', {
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              styles: {
+                name: 'styles',
+                type: 'css/mini-extract',
+                chunks: 'all',
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('emits the child stylesheet as a CSS-only split chunk (precondition)', () => {
+      expect(result.assets).toContain('styles.chunk.css');
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(chunkFiles(button)).toContain('client-Button-js.chunk.js');
+      expect(result.assets).not.toContain('client-Button-js.chunk.css');
+    });
+
+    it("keeps CSS imported by the client reference's child module", () => {
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(button.css).toContain('/assets/styles.chunk.css');
+    });
+
+    it("keeps child-module CSS when the child is split into its own JS chunk", () => {
+      const splitChild = run('transitive-css-only-chunk', {
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              panel: {
+                test: /Panel\.js$/,
+                name: 'panel',
+                chunks: 'all',
+                enforce: true,
+              },
+              styles: {
+                name: 'styles',
+                type: 'css/mini-extract',
+                chunks: 'all',
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+
+      expect(splitChild.assets).toEqual(expect.arrayContaining(['panel.chunk.js', 'styles.chunk.css']));
+      const button = entryEndingWith(splitChild.manifest, '/Button.js');
+      expect(chunkFiles(button)).toContain('panel.chunk.js');
+      expect(button.css).toContain('/assets/styles.chunk.css');
+    });
+
+    it('produces no fallback warning', () => {
+      expectNoWarnings(result);
+    });
+  });
+
   describe('CSS-only shared dependency chunks stay excluded from client-reference CSS', () => {
     let result: CompileResult;
 
@@ -718,6 +797,45 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
         'client-SettingsPage-js.chunk.js',
       ]);
       expect(chunkFiles(settings)).toEqual(['client-SettingsPage-js.chunk.js']);
+      expectNoWarnings(result);
+    });
+
+    it("does not broadcast a shared dependency's split stylesheet on the server build", () => {
+      const result = run('split-shared-css', {
+        isServer: true,
+        chunkName: 'client-[request]',
+        publicPath: '/assets/',
+        withCss: true,
+        optimizationExtra: {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              default: false,
+              defaultVendors: false,
+              sharedJs: {
+                test: /shared\.js$/,
+                name: 'shared-js',
+                minChunks: 2,
+                enforce: true,
+              },
+              sharedStyles: {
+                test: /shared\.css$/,
+                name: 'shared-styles',
+                type: 'css/mini-extract',
+                chunks: 'all',
+                enforce: true,
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.assets).toContain('shared-styles.chunk.css');
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      const settings = entryEndingWith(result.manifest, '/SettingsPage.js');
+      expect(button.css ?? []).not.toContain('/assets/shared-styles.chunk.css');
+      expect(settings.css ?? []).not.toContain('/assets/shared-styles.chunk.css');
       expectNoWarnings(result);
     });
   });


### PR DESCRIPTION
## Summary

- Recovers stylesheet hints when a client reference imports a child module whose CSS is moved into a CSS-only SplitChunks chunk.
- Applies the bounded child-module recovery to both `RSCWebpackPlugin` and `RSCRspackPlugin` while keeping the existing group/chunk guard that prevents shared dependency CSS broadcast.
- Adds focused webpack and rspack fixtures/tests for `Button.js -> Panel.js -> Panel.css` under a `styles` CSS-only cache group, plus a webpack server-build regression that proves shared dependency CSS-only chunks still stay excluded.

Fixes #180.

## Validation

- Red before fix: `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand -t "transitive CSS"` failed because `Button.js` had `css: []` while `styles.chunk.css` was emitted.
- Red before fix: `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand -t "child-module CSS-only"` failed because `Button.js` had `css: []` while `styles.chunk.css` was emitted.
- `yarn build` passed.
- Focused after-fix webpack run passed: `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand -t "shared dependency|transitive CSS|server build"`.
- Focused after-fix rspack run passed: `yarn jest tests/rspack-plugin/plugin.test.ts --runInBand -t "child-module CSS-only|child-module CSS when the child is split|CSS-only split chunk styles|scopes manifest CSS|does not attach an importing"`.
- `.agents/bin/validate` passed: `yarn build` plus `yarn test` (7 RSC suites / 15 tests; 25 non-RSC suites / 259 tests).
- `git diff --check origin/main...HEAD` and `git diff --check` passed.

## Review And Churn Notes

- Manual self-review completed against `origin/main...HEAD`.
- Read-only pre-push review subagent found no blocking findings. It noted the new fixtures must be committed, which they are in this PR, and that the changelog needs this PR number once assigned.
- Post-push churn: 4 review-fix amends. The amends added this PR number to the changelog, addressed the split-child finding, tightened chunk membership to the current chunk group, hoisted chunk-use counting per compilation, added the server shared-CSS non-broadcast regression, and documented the private-chunk heuristic. Current head is `6d05731`.
- Deeper nested child traversal remains intentionally outside #180's bounded one-hop recovery scope.

## QA Evidence

```text
qa-evidence v1
scope: #180 transitive CSS-only SplitChunks recovery
base: origin/main @ 0ba73172b02d6d939819ae2187638a5127802465
head: 6d05731
fixtures_created:
  - tests/webpack-plugin/fixtures/transitive-css-only-chunk/{Button.js,Panel.js,Panel.css,entryOnly.js,index.js}
  - tests/rspack-plugin/fixtures/transitive-css-only-chunk/{Button.js,Panel.js,Panel.css,entryOnly.js,index.js}
regression_coverage_added:
  - webpack server build keeps shared dependency CSS-only split chunks out of client-reference css arrays
red_before_fix:
  - webpack focused transitive CSS test: failed with empty Button.css despite styles.chunk.css
  - rspack focused child-module CSS-only test: failed with empty Button.css despite styles.chunk.css
local_validation:
  - yarn build: pass
  - focused webpack shared/transitive/server CSS tests: pass
  - focused rspack child/direct/scope CSS tests: pass
  - .agents/bin/validate: pass (yarn build; yarn test with 7 RSC suites / 15 tests and 25 non-RSC suites / 259 tests)
  - git diff --check origin/main...HEAD: pass
  - git diff --check: pass
review_gate:
  - read-only pre-push review: no blocking findings
  - hosted review triage: fixed direct child split into its own JS chunk, current-group chunk membership, and per-compilation chunk-use counting; added server shared-CSS non-broadcast regression; deeper nested child traversal remains intentionally out of #180 scope
coordination:
  - live open PR collision sweep before branch: none
  - agent-coord target #180 claim is released/expired; target read degraded for batch state, so coordination remains partially UNKNOWN/degraded
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved stylesheet references for client-rendered components when related styles are moved into separate chunks.
  * Improved handling of shared and transitive CSS so page/component manifests no longer pick up unrelated styles.
  * Kept server-side manifest CSS output accurate for split and shared chunk scenarios.

* **Tests**
  * Added coverage for transitive CSS, CSS-only split chunks, and shared stylesheet cases to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->