### PR TITLE
Restore webpack parity for dynamic public paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this package will be documented in this file.
 - Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
 
 ### Fixed
+- Fixed Webpack parity for function-valued `output.publicPath` warnings and symlinked string `clientReferences` realpath matching. ([#185])
 - Recovered RSC stylesheet hints for CSS imported by a client reference's child module when a CSS-merging SplitChunks cache group moves the stylesheet into a CSS-only split chunk. ([#184])
 - Fixed Webpack client-reference string paths to resolve relative to the compiler context and warned when `output.publicPath: "auto"` cannot be serialized into the RSC manifest. ([#171])
 - Fixed `RSCRspackPlugin` to skip manifest and diagnostics emission when the Flight client runtime is missing, matching the Webpack plugin's misconfiguration behavior instead of writing unusable assets. ([#176])
@@ -83,6 +84,7 @@ All notable changes to this package will be documented in this file.
 [#176]: https://github.com/shakacode/react_on_rails_rsc/pull/176
 [#183]: https://github.com/shakacode/react_on_rails_rsc/pull/183
 [#184]: https://github.com/shakacode/react_on_rails_rsc/pull/184
+[#185]: https://github.com/shakacode/react_on_rails_rsc/pull/185
 [#165]: https://github.com/shakacode/react_on_rails_rsc/pull/165
 [#164]: https://github.com/shakacode/react_on_rails_rsc/pull/164
 [#151]: https://github.com/shakacode/react_on_rails_rsc/pull/151

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -627,19 +627,28 @@ export class RSCWebpackPlugin {
           );
           const configuredPublicPath = compilation.outputOptions.publicPath;
           const publicPathIsAuto = configuredPublicPath === 'auto';
-          if (publicPathIsAuto) {
+          const publicPathIsDynamic =
+            publicPathIsAuto || typeof configuredPublicPath === 'function';
+          if (publicPathIsDynamic) {
+            const publicPathDescription = publicPathIsAuto
+              ? "output.publicPath is 'auto'"
+              : 'output.publicPath is a function';
             compilation.warnings.push(
               new webpack.WebpackError(
-                "React Server Components: output.publicPath is 'auto', which cannot be serialized into the RSC manifest. " +
+                `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest. ` +
                   'moduleLoading.prefix will be emitted as an empty string, and CSS files are omitted from the RSC manifest because their final URLs are only known at runtime. ' +
                   'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.',
               ),
             );
           }
+          const moduleLoadingPrefix =
+            publicPathIsDynamic || typeof configuredPublicPath !== 'string'
+              ? ''
+              : configuredPublicPath;
           const filePathToModuleMetadata: Record<string, ModuleMetadata> = {};
           const manifest = {
             moduleLoading: {
-              prefix: publicPathIsAuto ? '' : configuredPublicPath || '',
+              prefix: moduleLoadingPrefix,
               crossOrigin,
             },
             filePathToModuleMetadata,
@@ -682,7 +691,11 @@ export class RSCWebpackPlugin {
           // `chunkResolvedClientFiles`, listing the chunk group's own
           // chunks (and CSS files) in the manifest entry. Merges into an
           // existing manifest entry (chunks deduped by chunk id, CSS by
-          // URL) instead of overwriting it.
+          // URL) instead of overwriting it. Webpack preserves graph-order
+          // chunk pairs here; rspack sorts generated chunk pairs by filename
+          // because its chunk iteration order is less stable. Flight ignores
+          // pair order, so byte-level cross-bundler parity intentionally does
+          // not require sorting the webpack manifest.
           const recordChunkGroup = (
             chunkGroup: FlightChunkGroup,
             chunkResolvedClientFiles: Set<string>,
@@ -1164,7 +1177,8 @@ export class RSCWebpackPlugin {
   /**
    * Resolves every configured `clientReferences` entry to a
    * `ClientReferenceDependency`:
-   *   - string entries are direct file references, included unconditionally;
+   *   - string entries are direct file references, resolved through webpack's
+   *     normal resolver so they match the module graph's symlink policy;
    *   - search-path entries are expanded through the context module factory
    *     and filtered to files containing a `"use client"` directive.
    */
@@ -1181,11 +1195,30 @@ export class RSCWebpackPlugin {
       this.clientReferences,
       (clientReferencePath, cb) => {
         if (typeof clientReferencePath === 'string') {
-          const request = path.resolve(context, clientReferencePath);
-          watchDependencies.files.add(request);
-          const clientRefDep = new ClientReferenceDependency(request);
-          clientRefDep.userRequest = clientReferencePath;
-          cb(null, [clientRefDep]);
+          const configuredRequest = path.resolve(context, clientReferencePath);
+          watchDependencies.files.add(configuredRequest);
+          normalResolver.resolve({}, context, configuredRequest, {}, (err, resolvedPath) => {
+            if (err) {
+              watchDependencies.missing.add(configuredRequest);
+              const clientRefDep = new ClientReferenceDependency(configuredRequest);
+              clientRefDep.userRequest = clientReferencePath;
+              cb(null, [clientRefDep]);
+              return;
+            }
+            if (typeof resolvedPath !== 'string') {
+              watchDependencies.missing.add(configuredRequest);
+              cb(
+                new Error(
+                  `React Server Components: clientReferences entry "${clientReferencePath}" resolved to a non-file request.`,
+                ),
+              );
+              return;
+            }
+            watchDependencies.files.add(resolvedPath);
+            const clientRefDep = new ClientReferenceDependency(resolvedPath);
+            clientRefDep.userRequest = clientReferencePath;
+            cb(null, [clientRefDep]);
+          });
           return;
         }
         contextResolver.resolve(

--- a/tests/webpack-plugin/fixtures/symlink-client/index.js
+++ b/tests/webpack-plugin/fixtures/symlink-client/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/webpack-plugin/fixtures/symlink-target/SymlinkButton.js
+++ b/tests/webpack-plugin/fixtures/symlink-target/SymlinkButton.js
@@ -1,0 +1,5 @@
+'use client';
+
+export default function SymlinkButton() {
+  return 'symlink';
+}

--- a/tests/webpack-plugin/helpers/compile.ts
+++ b/tests/webpack-plugin/helpers/compile.ts
@@ -24,7 +24,10 @@ export interface CompileOptions {
   /** Chunk name template, e.g. 'client-[request]' for readable chunk ids. */
   chunkName?: string;
   publicPath?: string;
+  publicPathAsFunction?: boolean;
   crossOriginLoading?: false | 'anonymous' | 'use-credentials';
+  /** Merged into webpack config.resolve (e.g. { symlinks: false }). */
+  resolveExtra?: Record<string, unknown>;
   /** Merged into webpack config.output (e.g. { chunkFilename: '[name].chunk.mjs' }). */
   outputExtra?: Record<string, unknown>;
   /** Merged into webpack config.optimization (e.g. { splitChunks: {...} }). */
@@ -133,7 +136,9 @@ const compileInto = (
     clientReferences: serializeForRunner(options.clientReferences),
     chunkName: options.chunkName,
     publicPath: options.publicPath,
+    publicPathAsFunction: options.publicPathAsFunction,
     crossOriginLoading: options.crossOriginLoading,
+    resolveExtra: serializeForRunner(options.resolveExtra),
     outputExtra: serializeForRunner(options.outputExtra),
     optimizationExtra: serializeForRunner(options.optimizationExtra),
     maxChunks: options.maxChunks,

--- a/tests/webpack-plugin/helpers/runWebpackWithPlugin.js
+++ b/tests/webpack-plugin/helpers/runWebpackWithPlugin.js
@@ -26,7 +26,9 @@
  *     clientReferences?: unknown,   // RegExps encoded as {__type:'RegExp',...}
  *     chunkName?: string,
  *     publicPath?: string,
+ *     publicPathAsFunction?: boolean,
  *     crossOriginLoading?: false|'anonymous'|'use-credentials',
+ *     resolveExtra?: object,        // merged into config.resolve
  *     outputExtra?: object,         // merged into config.output
  *     optimizationExtra?: object,   // merged into config.optimization
  *     maxChunks?: number,           // applies webpack LimitChunkCountPlugin
@@ -78,7 +80,9 @@ const {
   clientReferences: rawClientReferences,
   chunkName,
   publicPath,
+  publicPathAsFunction,
   crossOriginLoading,
+  resolveExtra,
   outputExtra,
   optimizationExtra,
   maxChunks,
@@ -92,6 +96,7 @@ const runtimeEntry = require.resolve(
 );
 
 const clientReferences = reviveFromRunner(rawClientReferences);
+const revivedResolveExtra = reviveFromRunner(resolveExtra);
 const revivedOutputExtra = reviveFromRunner(outputExtra);
 const revivedOptimizationExtra = reviveFromRunner(optimizationExtra);
 
@@ -137,9 +142,16 @@ const config = {
     path: outputPath,
     filename: '[name].js',
     chunkFilename: '[name].chunk.js',
-    publicPath: publicPath !== undefined ? publicPath : '',
+    publicPath: publicPathAsFunction
+      ? () => '/assets/'
+      : publicPath !== undefined
+        ? publicPath
+        : '',
     crossOriginLoading: crossOriginLoading !== undefined ? crossOriginLoading : false,
     ...(revivedOutputExtra || {}),
+  },
+  resolve: {
+    ...(revivedResolveExtra || {}),
   },
   optimization: {
     chunkIds: 'named',

--- a/tests/webpack-plugin/plugin-integration.test.ts
+++ b/tests/webpack-plugin/plugin-integration.test.ts
@@ -81,6 +81,28 @@ const splitStaticIslandVendors = {
   },
 };
 
+const withSymlinkFixture = (testBody: () => void): void => {
+  const fixtureRoot = path.join(__dirname, 'fixtures/symlink-client');
+  const targetPath = path.join(__dirname, 'fixtures/symlink-target');
+  const linkPath = path.join(fixtureRoot, 'linked');
+  fs.rmSync(linkPath, { force: true, recursive: true });
+
+  let created = false;
+  try {
+    fs.symlinkSync(targetPath, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+    created = true;
+    testBody();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!created && (code === 'EPERM' || code === 'EACCES' || code === 'ENOTSUP')) {
+      return;
+    }
+    throw error;
+  } finally {
+    if (created) fs.rmSync(linkPath, { force: true, recursive: true });
+  }
+};
+
 describe('ReactFlightWebpackPlugin (real webpack)', () => {
   describe('clientReferences string entries', () => {
     it('resolves relative string entries from the compiler context', () => {
@@ -92,6 +114,45 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
       const button = entryEndingWith(result.manifest, '/Button.js');
       expect(chunkFiles(button)).toEqual(['client-Button-js.chunk.js']);
       expectNoWarnings(result);
+    });
+
+    it('realpath-normalizes string entries that point through symlinked directories', () => {
+      withSymlinkFixture(() => {
+        const result = run('symlink-client', {
+          chunkName: 'client-[request]',
+          clientReferences: ['./linked/SymlinkButton.js'],
+        });
+        const paths = Object.keys(result.manifest.filePathToModuleMetadata);
+        expect(paths.some((p) => p.endsWith('/symlink-target/SymlinkButton.js'))).toBe(true);
+        entryEndingWith(result.manifest, '/SymlinkButton.js');
+        expectNoWarnings(result);
+      });
+    });
+
+    it('honors resolve.symlinks: false for string entries through symlinked directories', () => {
+      withSymlinkFixture(() => {
+        const result = run('symlink-client', {
+          chunkName: 'client-[request]',
+          clientReferences: ['./linked/SymlinkButton.js'],
+          resolveExtra: { symlinks: false },
+        });
+        const paths = Object.keys(result.manifest.filePathToModuleMetadata);
+        expect(paths.some((p) => p.endsWith('/symlink-client/linked/SymlinkButton.js'))).toBe(
+          true,
+        );
+        expect(paths.some((p) => p.endsWith('/symlink-target/SymlinkButton.js'))).toBe(false);
+        entryEndingWith(result.manifest, '/SymlinkButton.js');
+        expectNoWarnings(result);
+      });
+    });
+
+    it('fails visibly when a string entry cannot be resolved', () => {
+      expect(() =>
+        run('split-shared', {
+          chunkName: 'client-[request]',
+          clientReferences: ['./MissingButton.js'],
+        }),
+      ).toThrow(/MissingButton\.js|Can't resolve/);
     });
   });
 
@@ -629,6 +690,21 @@ describe('ReactFlightWebpackPlugin (real webpack)', () => {
       expect(result.manifest.moduleLoading.prefix).toBe('');
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0]).toContain("output.publicPath is 'auto'");
+      expect(result.warnings[0]).toContain('CSS files are omitted from the RSC manifest');
+    });
+
+    it('warns and avoids serializing function-valued publicPath', () => {
+      const result = run('css-import', {
+        chunkName: 'client-[request]',
+        publicPathAsFunction: true,
+        withCss: true,
+      });
+
+      const button = entryEndingWith(result.manifest, '/Button.js');
+      expect(button.css).toEqual([]);
+      expect(result.manifest.moduleLoading.prefix).toBe('');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('output.publicPath is a function');
       expect(result.warnings[0]).toContain('CSS files are omitted from the RSC manifest');
     });
   });


### PR DESCRIPTION
## Summary

- Mirrors rspack's dynamic `output.publicPath` handling in `RSCWebpackPlugin`: function-valued public paths now warn, emit `moduleLoading.prefix: ""`, and omit CSS hints instead of silently serializing an unusable prefix.
- Resolves direct string `clientReferences` through webpack's normal resolver so default builds realpath symlinked files, while `resolve.symlinks: false` builds keep symlink-preserved resource keys.
- Watches both the configured string reference path and the resolved path, preserves webpack's visible module-not-found behavior for missing string references, and makes the symlink integration test skip gracefully when the platform cannot create the test symlink.
- Documents the chunk-order parity decision in the webpack manifest code: webpack keeps graph-order chunk pairs, while rspack sorts generated pairs for deterministic rspack output; Flight ignores pair order, so no byte-order behavior change is needed for #181.

Fixes #181.

## Validation

- `yarn` passed in the new worktree and rebuilt `dist` via `build-if-needed`.
- `yarn build` passed.
- Focused webpack integration tests passed: `yarn jest tests/webpack-plugin/plugin-integration.test.ts --runInBand -t "clientReferences string entries|CSS chunk files"`.
- `.agents/bin/validate` passed: `yarn build` plus `yarn test` (7 RSC suites / 15 tests; 25 non-RSC suites / 263 tests).
- `git diff --check origin/main...HEAD` and `git diff --check` passed.

## Codex Decision Log

- **Non-blocking:** Whether to sort webpack manifest chunk pairs to match rspack byte-for-byte.
  - **Decision:** Documented the divergence and left webpack graph-order pairs unchanged.
  - **Why:** Flight ignores pair order, rspack sorts because its generated chunk iteration order is less stable, and changing webpack order would be cosmetic churn without user-visible behavior.
  - **Review later:** Only revisit if maintainers decide byte-level cross-bundler manifest parity is valuable.
- **Non-blocking:** Whether to change rspack symlink policy for an equivalent `resolve.symlinks: false` mode.
  - **Decision:** Left rspack unchanged because #181 is the webpack-side residual and rspack has no webpack `resolve.symlinks` option in this plugin API.
  - **Why:** Webpack should respect webpack resolver policy; changing rspack's filesystem walker would broaden scope beyond this issue.
  - **Review later:** File or schedule a separate rspack parity issue if maintainers want a configurable symlink-preservation mode there.

## QA Evidence

```text
qa-evidence v1
scope: #181 webpack parity residuals
base: origin/main @ 0533d53e21575a10a80e63235c090e6ce6739205
head: acdc320
implemented:
  - webpack function-valued output.publicPath warning and empty manifest prefix behavior
  - webpack direct string clientReferences resolved through webpack's normal resolver, preserving default symlink realpath behavior and resolve.symlinks:false behavior
  - configured string reference path plus resolved path are watched
  - missing string clientReferences keep webpack's visible module-not-found behavior instead of being silently dropped
  - symlink integration setup skips gracefully when symlink creation is unsupported
  - chunk-order parity documented/skip decision, no behavior change
fixtures_created:
  - tests/webpack-plugin/fixtures/symlink-client/index.js
  - tests/webpack-plugin/fixtures/symlink-target/SymlinkButton.js
local_validation:
  - yarn: pass, rebuilt dist through build-if-needed
  - yarn build: pass
  - focused webpack clientReferences/CSS publicPath tests: pass (7 passed / 45 skipped)
  - .agents/bin/validate: pass (yarn build; yarn test with 7 RSC suites / 15 tests and 25 non-RSC suites / 263 tests)
  - git diff --check origin/main...HEAD: pass
  - git diff --check: pass
review_gate:
  - manual self-review completed against origin/main...HEAD
  - review-fix pushes addressed Greptile/Codex symlink policy, symlink setup, Claude unresolved-string, and Claude watch-mode findings
  - read-only subagent review was launched but did not return before the verified branch was ready; hosted review remains the current-head gate after PR update
coordination:
  - SECURITY_PREFLIGHT_OK for #181
  - live open PR collision sweep before branch: none
  - agent-coord private claim failed before mutation because shakacode/agent-coordination@state returned 404; public fallback claim posted on #181, private coordination claim/heartbeat remains UNKNOWN/degraded
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dynamic asset paths so warnings appear correctly and manifest output stays consistent.
  * Fixed string-based client reference resolution to respect symlinks and resolver settings, with clearer failures when a path can’t be resolved.
* **Tests**
  * Added coverage for symlinked client references and dynamic public path behavior.
  * Expanded fixture support to verify real filesystem symlink scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->