### PR TITLE
Coalesce 19.2.1 changelog for stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,42 +4,25 @@ All notable changes to this package will be documented in this file.
 
 ## [19.2.1] - 2026-07-14
 
-### Changed
-- Changed the published npm license metadata to `SEE LICENSE IN LICENSE.md` and included the license file in the package. Starting with `19.2.1`, the package uses the React on Rails Pro v2.3 terms: Production Use requires an appropriate paid subscription or Complimentary OSS License, while the defined non-commercial, educational, and demo uses remain free. See [LICENSE.md](LICENSE.md) for the exact terms and the Meta notice that applies to the derived Webpack plugin portions. ([#193])
-
-## [19.2.1-rc.1] - 2026-07-11
-
 ### Added
+- Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
+- Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. Diagnostics-off builds skip CSS collection, and emitted CSS is scoped to the owning client-reference chunks. ([#144]) ([#152]) ([#166])
 - Added an opt-in `entryClientReferencesFilename` option to `RSCWebpackPlugin` and `RSCRspackPlugin` that emits, for each entrypoint, the client references statically reachable from its module graph, keyed by the same `file://` hrefs as the client manifests. The client manifests themselves are unchanged; a downstream consumer can join the asset against the client manifest to scope per-route client-reference metadata, so static RSC pages stop needing a global `clientReferences: []` workaround. ([#176])
 
 ### Changed
-- Declared the optional `@rspack/core` peer range as Rspack 1.x or 2.x and added explicit Rspack 2.x compatibility coverage. ([#183])
+- Changed the published npm license metadata to `SEE LICENSE IN LICENSE.md` and included the license file in the package. Starting with `19.2.1`, the package uses the React on Rails Pro v2.3 terms: Production Use requires an appropriate paid subscription or Complimentary OSS License, while the defined non-commercial, educational, and demo uses remain free. See [LICENSE.md](LICENSE.md) for the exact terms and the Meta notice that applies to the derived Webpack plugin portions. ([#193])
+- Declared the optional `@rspack/core` peer range as Rspack 1.x or 2.x, added explicit Rspack 2.x compatibility coverage, and made Rspack 2 client-manifest chunk ordering deterministic while preserving the full sibling chunk set. ([#140]) ([#183])
+- Stopped `RSCRspackPlugin` from injecting a no-op `"use client"` tagging loader into every first-party module, preserving Rspack incremental caching while keeping filesystem-based client-reference discovery. ([#167])
 
 ### Fixed
-- Recovered RSC stylesheet hints for a plain (non-`"use client"`) child component's CSS when the child is shared by two or more client references and SplitChunks hoists it into a shared async chunk. The manifest now attaches the shared chunk's CSS to every referencing client reference instead of dropping it, fixing a flash of unstyled content on the shared component; initial (entry-loaded) chunks stay excluded to preserve the #108 render-blocking fix. ([#190])
-- Fixed Webpack parity for function-valued `output.publicPath` warnings and symlinked string `clientReferences` realpath matching. ([#185])
-- Recovered RSC stylesheet hints for CSS imported by a client reference's child module when a CSS-merging SplitChunks cache group moves the stylesheet into a CSS-only split chunk. ([#184])
-- Fixed `RSCRspackPlugin` to skip manifest and diagnostics emission when the Flight client runtime is missing, matching the Webpack plugin's misconfiguration behavior instead of writing unusable assets. ([#176])
-
-## [19.2.1-rc.0] - 2026-07-05
-
-### Added
-- Added RSC server resource hint helpers for preloading assets, styles, scripts, fonts, and images, plus preconnect and DNS-prefetch support for already-resolved production asset URLs. The default `react-on-rails-rsc/server` fallback keeps failing fast at import time without the `react-server` condition while still publishing the expanded type surface. ([#143])
-- Added opt-in client-reference diagnostics that emit RSC client reference JS/CSS asset files, byte sizes, and de-duplicated total byte counts for static island performance audits. ([#144])
-
-### Changed
-- Stopped `RSCRspackPlugin` from injecting a no-op `"use client"` tagging loader into every first-party module, preserving rspack incremental caching while keeping filesystem-based client-reference discovery. ([#167])
-- Skipped rspack diagnostics CSS collection when client-reference diagnostics are disabled, avoiding dead per-chunk-group CSS scans on the default build path. ([#152])
-
-### Fixed
-- Fixed Webpack client-reference string paths to resolve relative to the compiler context and warned when `output.publicPath: "auto"` cannot be serialized into the RSC manifest. ([#171])
-- Fixed Rspack client-reference manifests to emit deterministic chunk pair ordering under Rspack 2 while preserving the full sibling chunk set. ([#140])
+- Fixed Webpack string `clientReferences` to resolve relative to the compiler context and match symlink realpaths, and warned when `output.publicPath` values such as `"auto"` or functions cannot be serialized safely into the RSC manifest. ([#171]) ([#185])
 - Fixed Rspack client manifests to emit stylesheet hints, normalize unserializable `output.publicPath: "auto"`, preserve `.mjs` chunk files, and match webpack split-runtime chunk metadata. ([#172])
 - Fixed `RSCRspackPlugin` runtime injection state to be scoped by compiler, avoiding MultiCompiler and sequential-build cross-talk between rspack client/server builds with different client references or chunk names. ([#168])
 - Fixed `RSCRspackPlugin` to install the generated client-reference `splitChunks` guard after Rspack applies option defaults, so default optimization configs keep generated client chunks self-contained. ([#165])
 - Fixed watch rebuilds so rspack and webpack refresh client-reference runtime injections when `"use client"` files are added or removed without restarting the dev server. ([#164])
-- Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group, such as mini-css-extract's `styles` group, moves a client reference's own CSS into a CSS-only split chunk. ([#151])
-- Scoped Rspack diagnostics CSS to the generated chunk group for the reported client reference, avoiding importer-island CSS being counted against an imported child reference. ([#166])
+- Restored RSC stylesheet hints when a CSS-merging SplitChunks cache group moves a client reference's own CSS or a child module's CSS into a CSS-only split chunk. ([#151]) ([#184])
+- Recovered RSC stylesheet hints for a plain (non-`"use client"`) child component's CSS when the child is shared by two or more client references and SplitChunks hoists it into a shared async chunk. The manifest now attaches the shared chunk's CSS to every referencing client reference instead of dropping it, fixing a flash of unstyled content on the shared component; initial (entry-loaded) chunks stay excluded to preserve the #108 render-blocking fix. ([#190])
+- Fixed `RSCRspackPlugin` to skip manifest and diagnostics emission when the Flight client runtime is missing, matching the Webpack plugin's misconfiguration behavior instead of writing unusable assets. ([#176])
 
 ## [19.2.0] - 2026-06-28
 
@@ -84,9 +67,7 @@ All notable changes to this package will be documented in this file.
 ### Security
 - Updated the vendored `react-server-dom-webpack` runtime from React 19.0.3 to the React 19.0.7 security level, applying the React 19.0.4 fixes for CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779 plus the React 19.0.7 reply-decoding denial-of-service fixes for CVE-2026-23869 (GHSA-479c-33wc-g2pg) and CVE-2026-23870 (GHSA-rv78-f8rc-xrxh). Note: the upstream CVE-2026-23869 fix changes the reply wire format for nested `FormData`, so client and server must both run the patched runtime shipped by this package. ([#48]) ([#86])
 
-[19.2.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.1-rc.1...19.2.1
-[19.2.1-rc.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.1-rc.0...19.2.1-rc.1
-[19.2.1-rc.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...19.2.1-rc.0
+[19.2.1]: https://github.com/shakacode/react_on_rails_rsc/compare/19.2.0...19.2.1
 [19.2.0]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.5...19.2.0
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 


### PR DESCRIPTION
## Summary

- Coalesces the `19.2.1-rc.0` and `19.2.1-rc.1` changelog sections into the final `19.2.1` stable section.
- Curates prerelease-only refinements into the final feature and compatibility descriptions while retaining every user-visible PR reference.
- Reanchors the stable compare link at `19.2.0...19.2.1` and removes the orphaned RC compare links.
- Leaves `package.json` unchanged because merged PR #193 already set it to `19.2.1`, matching the stable changelog header.

## Classification sweep

Range: `19.2.0..origin/main`

| PR | Title | Result | Category | Reason |
| --- | --- | --- | --- | --- |
| #138 | Bump the github-actions group with 2 updates | no-entry | release-process | Updated CI action versions only. |
| #144 | Add static RSC island diagnostics | entry-needed | product code | Added opt-in client-reference JS/CSS size diagnostics. |
| #143 | Add RSC resource hint helpers | entry-needed | product code | Added public server helpers and types for production resource hints. |
| #139 | Bump the root-minor-patch group across 1 directory with 2 updates | no-entry | internal | Updated development/release dependencies without package behavior changes. |
| #151 | Restore CSS hints for CSS-only split chunks | entry-needed | product code | Restored manifest stylesheet hints for direct CSS-only split chunks. |
| #164 | Refresh client references during watch rebuilds | entry-needed | product code | Fixed webpack/rspack watch builds to refresh added or removed client references. |
| #152 | Skip rspack diagnostics CSS work when disabled | entry-needed | perf-reliability | Removed unused CSS scanning from the default diagnostics-off build path. |
| #165 | Install rspack splitChunks guard after defaults | entry-needed | product code | Preserved generated Rspack client chunks when option defaults are applied. |
| #166 | Scope rspack diagnostics CSS to owner chunks | entry-needed | product code | Corrected CSS ownership in emitted client-reference diagnostics. |
| #163 | Fail closed before Dependabot auto-merge | no-entry | release-process | Hardened repository automation without changing the package. |
| #167 | Stop rspack client discovery from disabling cache | entry-needed | perf-reliability | Preserved Rspack incremental caching during client-reference discovery. |
| #168 | Scope rspack injection state by compiler | entry-needed | product code | Prevented cross-talk between sequential and MultiCompiler builds. |
| #169 | Fix Claude OAuth token env for Actions | no-entry | release-process | Changed advisory review workflow token wiring only. |
| #170 | Update post-final RSC release docs | no-entry | release-process | Updated maintainer release instructions only. |
| #140 | Bump @rspack/core from 1.7.11 to 2.1.2 | entry-needed | product code | Added Rspack 2 manifest compatibility fixes alongside the dependency update. |
| #173 | Document tiny browser sidecars for static RSC pages | no-entry | internal | Added integration documentation only. |
| #174 | Document streamed RSC system spec transport | no-entry | internal | Added downstream testing documentation only. |
| #171 | Fix webpack RSC runtime parity gaps | entry-needed | product code | Fixed Webpack client-reference path and dynamic public-path behavior. |
| #175 | Deduplicate RSC agent skill picker entries | no-entry | internal | Changed agent workflows and contributor documentation only. |
| #172 | Fix rspack runtime manifest parity gaps | entry-needed | product code | Fixed Rspack CSS, public-path, `.mjs`, and runtime chunk manifest behavior. |
| #177 | Prepare 19.2.1-rc.0 release | no-entry | release-process | Stamped prerelease metadata without changing product behavior. |
| #178 | Organize package docs as internal | no-entry | internal | Reorganized maintainer documentation only. |
| #176 | Add opt-in entry-scoped client-reference discovery asset | entry-needed | product code | Added a public plugin option and corrected Rspack misconfiguration behavior. |
| #183 | Declare rspack 1.x and 2.x support | entry-needed | product code | Expanded the optional peer contract and compatibility coverage. |
| #184 | Recover transitive CSS-only split chunk styles | entry-needed | product code | Restored hints for child-module CSS moved into CSS-only chunks. |
| #185 | Restore webpack parity for dynamic public paths | entry-needed | product code | Completed safe dynamic public-path and symlink resolution behavior. |
| #189 | Harden Claude workflow permission gate | no-entry | release-process | Hardened a secret-bearing GitHub workflow only. |
| #190 | Recover shared client-reference child CSS | entry-needed | product code | Fixed missing stylesheet hints and FOUC for shared child CSS. |
| #191 | Prepare 19.2.1-rc.1 release | no-entry | release-process | Stamped prerelease metadata without changing product behavior. |
| #193 | Prepare commercially licensed react-on-rails-rsc 19.2.1 | entry-needed | product code | Changed the published license metadata and stable package terms. |

## Codex Decision Log

- **Non-blocking:** Should `package.json` receive another edit?
  - **Decision:** No; it already contains `19.2.1` on `origin/main` and matches the stable changelog header.
  - **Why:** A no-op package edit would add churn without changing release metadata.
  - **Review later:** None.
- **Non-blocking:** Should prerelease-only refinement history remain as separate stable `Fixed` entries?
  - **Decision:** No; merged the refinements into the final stable feature/compatibility descriptions.
  - **Why:** The update-changelog workflow requires stable releases to describe the final shipped state rather than intermediate RC history.
  - **Review later:** None.

## Validation

- `yarn build`
- `yarn test`: 7 RSC suites / 15 tests and 25 non-RSC suites / 268 tests passed.
- `git diff --check origin/main...HEAD`
- Changelog structure, version/header parity, PR-link definitions, stable compare link, and trailing newline checks passed.
- `yarn release:check` confirmed `react-on-rails-rsc@19.2.1` metadata, unused local/origin tag, and unpublished npm version. Its only failure is the expected feature-branch gate; rerun it from clean synced `main` after merge.

## Pre-push review and churn

- Manual self-review: clean after two editorial corrections.
- Primary `codex review --base origin/main`: unavailable because the installed CLI is too old for its configured `gpt-5.6-sol` model.
- Local Claude review: accepted heading-spacing consistency and preserved #140's full-sibling-chunk guarantee; the final pass had no accepted/actionable findings after applying the stable-release curation rules.
- `/simplify`: skipped because this is a focused release-note consolidation and further automated rewriting would risk losing verified user-visible nuance.
- Post-push review-fix commits: 0.

## Hosted closeout

- Current head: `c3c863ad2c25fc96191b0e9d305a57a97335f4b6`.
- Full `gh pr checks 195` list is green; `React canary signal` and `auto-merge` are intentionally skipped.
- Greptile: 5/5 confidence, safe to merge, no blocking issues.
- Claude: verified all 18 user-visible PRs, references, and compare-link changes; its only awareness note matches the documented stable-release curation decision and requests no change.
- CodeRabbit: review quota was exhausted, so no review ran and no findings were posted; it was not re-requested.
- Inline review comments: none. Unresolved review threads: none.
- GitHub merge state: `CLEAN`.

## Release handoff

After this PR merges, run `yarn release:check` from a clean, synced `main` checkout and then run the `gh workflow run release.yml ...` command it prints.
