### PR TITLE
Add cssWrapper option for native React CSS FOUC prevention

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
   },
   "dependencies": {
     "acorn-loose": "^8.3.0",
+    "es-module-lexer": "^1.6.0",
     "neo-async": "^2.6.1",
     "react-server-dom-webpack": "~19.2.7",
     "webpack-sources": "^3.2.0"

--- a/src/css-wrapper-runtime.ts
+++ b/src/css-wrapper-runtime.ts
@@ -1,0 +1,88 @@
+/*
+ * Runtime for the RSC CSS wrapper (issue #4598).
+ *
+ * The webpack/rspack plugin redirects each `'use client'` module's client-reference
+ * resolution (in the SSR-server and browser-client bundles only) to a generated
+ * wrapper module. That wrapper wraps each export with `withRscCss`, which renders a
+ * render-blocking `<link rel="stylesheet" precedence="rsc-css">` for the component's
+ * CSS before the component itself. React's native stylesheet handling then gates
+ * commit/reveal on the stylesheet load — preventing FOUC in every rendering mode
+ * (SSR streaming, hydration, client navigation, non-SSR fetch) without any of the
+ * former stream-injection / waitForStylesheet machinery.
+ *
+ * The CSS hrefs are only known after chunking, so they are not baked into the wrapper
+ * source. Instead the plugin emits a webpack RuntimeModule that populates a global map
+ * keyed by the client module's stable key; `withRscCss` looks the hrefs up at render
+ * time. `preinit` is intentionally NOT used — it downloads/applies CSS but does not
+ * block rendering, so it does not prevent FOUC (verified experimentally).
+ */
+import * as React from 'react';
+
+export const RSC_CSS_PRECEDENCE = 'rsc-css';
+
+/** Global (per JS runtime) map: client-module key -> array of CSS hrefs. */
+export const RSC_CSS_HREFS_GLOBAL = '__RSC_CSS_HREFS__';
+
+type HrefMap = Record<string, string[] | undefined>;
+
+function hrefsForKey(key: string): string[] {
+  const map = (globalThis as unknown as Record<string, HrefMap | undefined>)[RSC_CSS_HREFS_GLOBAL];
+  const hrefs = map && map[key];
+  return Array.isArray(hrefs) ? hrefs : [];
+}
+
+/** Render the render-blocking stylesheet links for a client module's CSS. */
+function cssLinks(key: string): React.ReactElement[] {
+  return hrefsForKey(key).map((href) =>
+    React.createElement('link', {
+      key: href,
+      rel: 'stylesheet',
+      href,
+      precedence: RSC_CSS_PRECEDENCE,
+    }),
+  );
+}
+
+/**
+ * Wrap a single client-module export so that, when React renders it, the module's
+ * CSS `<link precedence>` renders alongside it. Non-function exports (constants,
+ * objects) are returned unchanged so ordinary consumers are unaffected. Refs are
+ * forwarded; useful statics are copied.
+ */
+const FORWARD_REF = Symbol.for('react.forward_ref');
+const MEMO = Symbol.for('react.memo');
+
+function isComponentLike(value: unknown): boolean {
+  if (typeof value === 'function') return true;
+  if (value != null && typeof value === 'object') {
+    const t = (value as { $$typeof?: symbol }).$$typeof;
+    return t === FORWARD_REF || t === MEMO;
+  }
+  return false;
+}
+
+export function withRscCss<T>(value: T, key: string): T {
+  // Only component-like exports are wrapped. `forwardRef`/`memo` components are
+  // objects (not functions), so a plain typeof check would miss them (FOUC).
+  if (!isComponentLike(value)) {
+    return value;
+  }
+  const Component = value as unknown as React.ComponentType<Record<string, unknown>>;
+
+  const Wrapped = React.forwardRef<unknown, Record<string, unknown>>((props, ref) =>
+    React.createElement(
+      React.Fragment,
+      null,
+      ...cssLinks(key),
+      React.createElement(Component, ref == null ? props : { ...props, ref }),
+    ),
+  );
+
+  // Preserve identity/debugging affordances.
+  const name =
+    (Component as { displayName?: string; name?: string }).displayName ||
+    (Component as { name?: string }).name ||
+    'Component';
+  Wrapped.displayName = `withRscCss(${name})`;
+  return Wrapped as unknown as T;
+}

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -36,13 +36,19 @@ import { getGeneratedChunkName } from './shared';
 export let _discoveredClientFiles: string[] = [];
 export let _chunkName = 'client[index]';
 export let _generatedChunkNames: Set<string> = new Set();
+let _cssWrapper = false;
 
 type CompilerKey = object;
+
+// Wrapper loader that renders each client component's CSS <link precedence>
+// (issue #4598). Same loader used by the webpack plugin.
+const RSC_CSS_WRAPPER_LOADER = require.resolve('../webpack/rscCssWrapperLoader');
 
 export type InjectionState = {
   discoveredClientFiles: string[];
   chunkName: string;
   generatedChunkNames: Set<string>;
+  cssWrapper: boolean;
 };
 
 const compilerInjectionState = new WeakMap<CompilerKey, InjectionState>();
@@ -53,28 +59,33 @@ const emptyInjectionState = (): InjectionState => ({
   discoveredClientFiles: [],
   chunkName: _chunkName,
   generatedChunkNames: new Set(),
+  cssWrapper: _cssWrapper,
 });
 
 const fallbackInjectionState = (): InjectionState => ({
   discoveredClientFiles: _discoveredClientFiles,
   chunkName: _chunkName,
   generatedChunkNames: _generatedChunkNames,
+  cssWrapper: _cssWrapper,
 });
 
 export function setInjectionStateForCompiler(
   compiler: CompilerKey,
   discoveredClientFiles: string[],
   chunkName: string,
+  cssWrapper = false,
 ): void {
   const nextDiscoveredClientFiles = discoveredClientFiles.slice();
   _discoveredClientFiles = nextDiscoveredClientFiles;
   _chunkName = chunkName;
   _generatedChunkNames = new Set();
+  _cssWrapper = cssWrapper;
 
   compilerInjectionState.set(compiler, {
     discoveredClientFiles: nextDiscoveredClientFiles,
     chunkName,
     generatedChunkNames: new Set(),
+    cssWrapper,
   });
 }
 
@@ -110,6 +121,7 @@ export function setGeneratedChunkNamesForCompiler(
     discoveredClientFiles: [],
     chunkName: _chunkName,
     generatedChunkNames: nextGeneratedChunkNames,
+    cssWrapper: _cssWrapper,
   });
 }
 
@@ -152,7 +164,7 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
     );
   }
 
-  const { discoveredClientFiles, chunkName } = getInjectionStateForCompiler(compiler);
+  const { discoveredClientFiles, chunkName, cssWrapper } = getInjectionStateForCompiler(compiler);
 
   if (!discoveredClientFiles.length) {
     setGeneratedChunkNamesForCompiler(compiler, []);
@@ -163,7 +175,10 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
   const imports = discoveredClientFiles.map((file, i) => {
     const name = getGeneratedChunkName(chunkName, file, i);
     names.push(name);
-    return `import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(file)});`;
+    // With cssWrapper, import the generated wrapper (which renders the client
+    // component's CSS <link precedence>) instead of the client file directly.
+    const request = cssWrapper ? `!!${RSC_CSS_WRAPPER_LOADER}!${file}` : file;
+    return `import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(request)});`;
   });
 
   setGeneratedChunkNamesForCompiler(compiler, names);

--- a/src/react-server-dom-rspack/plugin.ts
+++ b/src/react-server-dom-rspack/plugin.ts
@@ -74,7 +74,12 @@ type AnyCompiler = {
   };
   context: string;
   hooks: {
-    beforeCompile: { tapAsync: (name: string, fn: (params: unknown, cb: (err?: Error | null) => void) => void) => void };
+    beforeCompile: {
+      tapAsync: (
+        name: string,
+        fn: (params: unknown, cb: (err?: Error | null) => void) => void
+      ) => void;
+    };
     environment?: { tap: (name: TapName, fn: () => void) => void };
     afterEnvironment?: {
       tap: (name: TapName, fn: () => void) => void;
@@ -158,7 +163,7 @@ function createClientReferenceWatchDependencies(): ClientReferenceWatchDependenc
 
 function addClientReferenceWatchDependencies(
   compilation: AnyCompilation,
-  dependencies: ClientReferenceWatchDependencies,
+  dependencies: ClientReferenceWatchDependencies
 ): void {
   for (const file of dependencies.files) {
     compilation.fileDependencies?.add(file);
@@ -259,6 +264,13 @@ export interface Options {
    * per-route client-reference metadata. Disabled by default.
    */
   entryClientReferencesFilename?: string | false;
+  /**
+   * When true, each client reference resolves (in this SSR-server/browser-client
+   * build) to a generated wrapper module that renders a render-blocking
+   * `<link rel="stylesheet" precedence="rsc-css">` for the component's CSS before
+   * the component, so React natively prevents CSS FOUC (issue #4598).
+   */
+  cssWrapper?: boolean;
 }
 
 // Legacy rule export kept for consumers that imported the historical symbol.
@@ -278,9 +290,7 @@ export class RSCRspackPlugin {
 
   constructor(options: Options) {
     if (!options || typeof options.isServer !== 'boolean') {
-      throw new Error(
-        'RSCRspackPlugin: You must specify the `isServer` option as a boolean.',
-      );
+      throw new Error('RSCRspackPlugin: You must specify the `isServer` option as a boolean.');
     }
     this.options = options;
 
@@ -298,7 +308,7 @@ export class RSCRspackPlugin {
       this.clientReferences = raw.map((ref) =>
         typeof ref === 'string'
           ? ref // keep as string — resolved in resolveAllClientFiles
-          : ref,
+          : ref
       );
     } else {
       this.clientReferences = [
@@ -339,16 +349,21 @@ export class RSCRspackPlugin {
           const nextWatchDependencies = createClientReferenceWatchDependencies();
           discoveredClientFiles = this.resolveAllClientFiles(
             compiler.context,
-            nextWatchDependencies,
+            nextWatchDependencies
           );
           clientReferenceWatchDependencies = nextWatchDependencies;
           this._resolvedClientFiles = discoveredClientFiles;
-          setInjectionStateForCompiler(compiler, discoveredClientFiles, this.chunkName);
+          setInjectionStateForCompiler(
+            compiler,
+            discoveredClientFiles,
+            this.chunkName,
+            this.options.cssWrapper === true
+          );
           callback();
         } catch (err) {
           callback(err instanceof Error ? err : new Error(String(err)));
         }
-      },
+      }
     );
 
     // ── Phase 2: inject discovered client files as async chunks ─────
@@ -465,7 +480,7 @@ export class RSCRspackPlugin {
           if (resolvedClientCount === 0) {
             logger?.info(
               'No RSC client references resolved; emitting empty manifest. ' +
-                'If this is unexpected, check the RSCRspackPlugin clientReferences option.',
+                'If this is unexpected, check the RSCRspackPlugin clientReferences option.'
             );
           } else {
             logger?.debug(`Resolved ${resolvedClientCount} RSC client reference(s)`);
@@ -475,23 +490,23 @@ export class RSCRspackPlugin {
             compilation,
             bundler,
             diagnosticsCssFiles,
-            resolvedClientFiles,
+            resolvedClientFiles
           );
           if (!clientRuntimeFound) return;
           logger?.debug(
             `Emitting ${manifestFilename} with ` +
-              `${Object.keys(manifest.filePathToModuleMetadata).length} entries`,
+              `${Object.keys(manifest.filePathToModuleMetadata).length} entries`
           );
           if (typeof this.options.clientReferenceDiagnosticsFilename === 'string') {
             const diagnostics = this.buildDiagnostics(
               compilation,
               manifest,
               manifestFilename,
-              diagnosticsCssFiles,
+              diagnosticsCssFiles
             );
             compilation.emitAsset(
               this.options.clientReferenceDiagnosticsFilename,
-              new bundler.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false),
+              new bundler.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false)
             );
           }
           if (typeof this.options.entryClientReferencesFilename === 'string') {
@@ -500,16 +515,67 @@ export class RSCRspackPlugin {
               bundler,
               compiler.context,
               this.options.entryClientReferencesFilename,
-              resolvedClientFiles,
+              resolvedClientFiles
             );
           }
           compilation.emitAsset(
             manifestFilename,
-            new bundler.sources.RawSource(JSON.stringify(manifest, null, 2), false),
+            new bundler.sources.RawSource(JSON.stringify(manifest, null, 2), false)
           );
-        },
+
+          // Publish per-client-module CSS hrefs into a global the generated
+          // wrapper modules read at render time (see webpack plugin for details).
+          if (this.options.cssWrapper === true) {
+            this.injectCssHrefGlobal(compilation, manifest.filePathToModuleMetadata, bundler);
+          }
+        }
       );
     });
+  }
+
+  private injectCssHrefGlobal(
+    compilation: unknown,
+    filePathToModuleMetadata: Record<string, ModuleMetadata>,
+    bundler: { sources: { RawSource: new (source: string, convert?: boolean) => unknown } }
+  ): void {
+    const hrefMap: Record<string, string[]> = {};
+    for (const [fileUrl, meta] of Object.entries(filePathToModuleMetadata)) {
+      if (meta.css && meta.css.length > 0) hrefMap[fileUrl] = meta.css;
+    }
+    if (Object.keys(hrefMap).length === 0) return;
+
+    const prelude =
+      `(function(){var g=(typeof globalThis!=='undefined')?globalThis:` +
+      `(typeof self!=='undefined')?self:this;` +
+      `g['__RSC_CSS_HREFS__']=Object.assign(g['__RSC_CSS_HREFS__']||{},` +
+      `${JSON.stringify(hrefMap)});})();\n`;
+
+    const comp = compilation as {
+      chunks: Iterable<{ hasRuntime?(): boolean; files: Iterable<string> }>;
+      updateAsset?(file: string, updater: (old: unknown) => unknown): void;
+      getAsset?(file: string): { source: { source(): string | Buffer } } | undefined;
+      emitAsset(file: string, source: unknown): void;
+    };
+    for (const chunk of comp.chunks) {
+      if (typeof chunk.hasRuntime !== 'function' || !chunk.hasRuntime()) continue;
+      for (const file of chunk.files) {
+        if (!file.endsWith('.js')) continue;
+        const updater = (old: unknown): unknown => {
+          const oldStr =
+            old && typeof (old as { source?: () => unknown }).source === 'function'
+              ? String((old as { source: () => unknown }).source())
+              : '';
+          return new bundler.sources.RawSource(prelude + oldStr, false);
+        };
+        if (typeof comp.updateAsset === 'function') {
+          comp.updateAsset(file, updater);
+        } else if (typeof comp.getAsset === 'function') {
+          const asset = comp.getAsset(file);
+          const oldStr = asset ? String(asset.source.source()) : '';
+          comp.emitAsset(file, new bundler.sources.RawSource(prelude + oldStr, false));
+        }
+      }
+    }
   }
 
   // ── FS-walk discovery ───────────────────────────────────────────────
@@ -520,7 +586,7 @@ export class RSCRspackPlugin {
   //   - search descriptor → walk directory, read files, check for directive
   private resolveAllClientFiles(
     compilerContext: string,
-    watchDependencies: ClientReferenceWatchDependencies,
+    watchDependencies: ClientReferenceWatchDependencies
   ): string[] {
     const results = new Set<string>();
     for (const ref of this.clientReferences) {
@@ -555,7 +621,7 @@ export class RSCRspackPlugin {
     walkRoot: string,
     ref: ClientReferenceSearchPath,
     out: Set<string>,
-    watchDependencies = createClientReferenceWatchDependencies(),
+    watchDependencies = createClientReferenceWatchDependencies()
   ): void {
     watchDependencies.contexts.add(dir);
     let entries: fs.Dirent[];
@@ -571,7 +637,11 @@ export class RSCRspackPlugin {
       // return false for symlinks). This matches the webpack plugin's
       // behavior which resolves symlinks via the normal resolver.
       let stat: fs.Stats;
-      try { stat = fs.statSync(full); } catch { continue; }
+      try {
+        stat = fs.statSync(full);
+      } catch {
+        continue;
+      }
 
       if (stat.isDirectory()) {
         const relPath = './' + toRelativePosixPath(walkRoot, full);
@@ -618,7 +688,7 @@ export class RSCRspackPlugin {
    * convention-standard `Compilation` and `sources` types.
    */
   private resolveBundler(compiler: AnyCompiler): Bundler {
-    const maybe = (compiler as unknown as { rspack?: Bundler; webpack?: Bundler });
+    const maybe = compiler as unknown as { rspack?: Bundler; webpack?: Bundler };
     if (maybe.rspack && isBundler(maybe.rspack)) return maybe.rspack;
     if (maybe.webpack && isBundler(maybe.webpack)) return maybe.webpack;
     // Last resort: try `@rspack/core` and `webpack` at runtime. We try rspack
@@ -666,7 +736,7 @@ export class RSCRspackPlugin {
     compilation: AnyCompilation,
     bundler: Bundler,
     diagnosticsCssFiles: Map<string, string[]>,
-    resolvedClientFiles: ReadonlySet<string>,
+    resolvedClientFiles: ReadonlySet<string>
   ): {
     manifest: {
       moduleLoading: { prefix: string; crossOrigin: string | null };
@@ -703,17 +773,26 @@ export class RSCRspackPlugin {
         ? new bundler.WebpackError(
             `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest. ` +
               'moduleLoading.prefix will be emitted as an empty string, and CSS files are omitted from the RSC manifest because their final URLs are only known at runtime. ' +
-              'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.',
+              'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.'
           )
         : new Error(
-            `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest.`,
+            `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest.`
           );
       compilation.warnings.push(warning);
     }
-    let cssPrefix =
-      typeof configuredPublicPath === 'string' && !publicPathIsAuto
-        ? configuredPublicPath
-        : null;
+    // CSS hrefs are needed for diagnostics AND for the cssWrapper feature. When
+    // cssWrapper is on, always record CSS (publicPath 'auto'/non-string -> document
+    // relative ''), matching the webpack plugin's publicPath handling.
+    let cssPrefix: string | null;
+    if (typeof configuredPublicPath === 'string' && !publicPathIsAuto) {
+      cssPrefix = configuredPublicPath;
+    } else if (this.options.cssWrapper === true) {
+      // When publicPath is 'auto' or undefined but cssWrapper is on, emit document-relative
+      // CSS paths so the wrapper's <link precedence> works even without a static publicPath.
+      cssPrefix = '';
+    } else {
+      cssPrefix = null;
+    }
     if (cssPrefix && !cssPrefix.endsWith('/')) {
       cssPrefix += '/';
     }
@@ -736,8 +815,9 @@ export class RSCRspackPlugin {
         }
         return cached;
       };
-      const getOutgoingConnections =
-        compilation.moduleGraph?.getOutgoingConnections?.bind(compilation.moduleGraph);
+      const getOutgoingConnections = compilation.moduleGraph?.getOutgoingConnections?.bind(
+        compilation.moduleGraph
+      );
 
       const directCssDepFiles = (module: AnyModule): string[] => {
         if (!getOutgoingConnections || cssPrefix === null) return [];
@@ -745,7 +825,7 @@ export class RSCRspackPlugin {
         const moduleChunks = new Set(
           [...compilation.chunkGraph.getModuleChunks(module)]
             .map((chunk) => chunk as AnyChunk)
-            .filter((chunk) => groupChunkSet.has(chunk)),
+            .filter((chunk) => groupChunkSet.has(chunk))
         );
         const addCssFromModuleChunks = (cssModule: AnyModule): void => {
           for (const cssChunkUnknown of compilation.chunkGraph.getModuleChunks(cssModule)) {
@@ -816,7 +896,8 @@ export class RSCRspackPlugin {
           const moduleId = compilation.chunkGraph.getModuleId(mod);
           const mayBeClientReference =
             isResolvedClientReference(mod.resource) ||
-            (!!mod.modules && mod.modules.some((inner) => isResolvedClientReference(inner.resource)));
+            (!!mod.modules &&
+              mod.modules.some((inner) => isResolvedClientReference(inner.resource)));
           // Match the webpack plugin: client references are injected as async
           // boundaries, so any concatenated wrapper owns the CSS dependency
           // edges needed for sibling CSS-only chunk recovery.
@@ -829,7 +910,7 @@ export class RSCRspackPlugin {
               manifestCss,
               directCss,
               generatedChunkNamesByResource,
-              availableChunkGroupNames,
+              availableChunkGroupNames
             );
             this.recordModule(
               mod,
@@ -838,12 +919,13 @@ export class RSCRspackPlugin {
               moduleCss,
               resolvedClientFiles,
               filePathToModuleMetadata,
-              diagnosticsCssFiles,
+              diagnosticsCssFiles
             );
           }
           if (mod.modules) {
             for (const inner of mod.modules) {
-              if (isRuntimeResource(inner.resource, this.options.isServer)) clientFileNameFound = true;
+              if (isRuntimeResource(inner.resource, this.options.isServer))
+                clientFileNameFound = true;
               if (!isResolvedClientReference(inner.resource)) continue;
               // Rspack can fold an eager "use client" module in as an inner
               // module; recover its direct CSS without inheriting wrapper CSS.
@@ -855,7 +937,7 @@ export class RSCRspackPlugin {
                 innerManifestCss,
                 innerDirectCss,
                 generatedChunkNamesByResource,
-                availableChunkGroupNames,
+                availableChunkGroupNames
               );
               this.recordModule(
                 inner,
@@ -864,7 +946,7 @@ export class RSCRspackPlugin {
                 moduleCss,
                 resolvedClientFiles,
                 filePathToModuleMetadata,
-                diagnosticsCssFiles,
+                diagnosticsCssFiles
               );
             }
           }
@@ -878,11 +960,9 @@ export class RSCRspackPlugin {
       const warning = bundler.WebpackError
         ? new bundler.WebpackError(
             `Client runtime at react-on-rails-rsc/client was not found. ` +
-              `React Server Components module map file ${this.options.clientManifestFilename ?? '(default)'} was not created.`,
+              `React Server Components module map file ${this.options.clientManifestFilename ?? '(default)'} was not created.`
           )
-        : new Error(
-            `Client runtime at react-on-rails-rsc/client was not found.`,
-        );
+        : new Error(`Client runtime at react-on-rails-rsc/client was not found.`);
       compilation.warnings.push(warning);
     }
     const crossOriginRaw = compilation.outputOptions.crossOriginLoading;
@@ -922,7 +1002,7 @@ export class RSCRspackPlugin {
     bundler: Bundler,
     compilerContext: string,
     filename: string,
-    resolvedClientFiles: ReadonlySet<string>,
+    resolvedClientFiles: ReadonlySet<string>
   ): void {
     emitEntryClientReferencesAsset({
       compilation: compilation as unknown as EntryClientReferencesCompilation,
@@ -933,7 +1013,7 @@ export class RSCRspackPlugin {
       isTraversalBoundary: (resource) => isRuntimeResource(resource, this.options.isServer),
       emitWarning: (message) => {
         compilation.warnings.push(
-          bundler.WebpackError ? new bundler.WebpackError(message) : new Error(message),
+          bundler.WebpackError ? new bundler.WebpackError(message) : new Error(message)
         );
       },
       emitAsset: (assetFilename, source) => {
@@ -949,7 +1029,7 @@ export class RSCRspackPlugin {
       filePathToModuleMetadata: Record<string, ModuleMetadata>;
     },
     manifestFilename: string,
-    diagnosticsCssFiles: ReadonlyMap<string, string[]>,
+    diagnosticsCssFiles: ReadonlyMap<string, string[]>
   ): {
     version: 1;
     manifestFilename: string;
@@ -982,12 +1062,16 @@ export class RSCRspackPlugin {
           cssFiles && cssFiles.length > 0
             ? cssFiles.map((fileName) => ({
                 file: fileName,
-                bytes: getCompilationAssetSize(compilation, fileName, manifest.moduleLoading.prefix),
+                bytes: getCompilationAssetSize(
+                  compilation,
+                  fileName,
+                  manifest.moduleLoading.prefix
+                ),
               }))
             : undefined;
         const totalBytes = [...chunks, ...(css || [])].reduce(
           (sum, entry) => sum + (entry.bytes ?? 0),
-          0,
+          0
         );
         return {
           file,
@@ -1015,7 +1099,7 @@ export class RSCRspackPlugin {
   /** Build the chunks array from all async-loadable chunks in a chunk group. */
   private getGroupAssets(
     chunkGroup: AnyChunkGroup,
-    runtimeChunkFiles: ReadonlySet<string>,
+    runtimeChunkFiles: ReadonlySet<string>
   ): (string | number | null)[] {
     const chunks: (string | number | null)[] = [];
     for (const chunkUnknown of chunkGroup.chunks) {
@@ -1044,7 +1128,7 @@ export class RSCRspackPlugin {
   private getChunkCss(
     chunk: AnyChunk,
     runtimeChunkFiles: ReadonlySet<string>,
-    cssPrefix: string | null,
+    cssPrefix: string | null
   ): string[] {
     if (cssPrefix === null) return [];
     const css: string[] = [];
@@ -1066,7 +1150,7 @@ export class RSCRspackPlugin {
       (this._resolvedClientFiles ?? []).map((file, index) => [
         file,
         getGeneratedChunkName(this.chunkName, file, index),
-      ]),
+      ])
     );
   }
 
@@ -1076,7 +1160,7 @@ export class RSCRspackPlugin {
     css: string[],
     fallbackCss: string[],
     generatedChunkNamesByResource: ReadonlyMap<string, string>,
-    availableChunkGroupNames: ReadonlySet<string>,
+    availableChunkGroupNames: ReadonlySet<string>
   ): string[] {
     if (!resource || css.length === 0) return css;
     const generatedChunkName = generatedChunkNamesByResource.get(resource);
@@ -1139,9 +1223,7 @@ export class RSCRspackPlugin {
     const runtimeChunkFiles = new Set<string>();
     for (const entrypoint of compilation.entrypoints?.values() ?? []) {
       const runtimeChunk =
-        typeof entrypoint.getRuntimeChunk === 'function'
-          ? entrypoint.getRuntimeChunk()
-          : null;
+        typeof entrypoint.getRuntimeChunk === 'function' ? entrypoint.getRuntimeChunk() : null;
       if (!runtimeChunk) continue;
       for (const file of runtimeChunk.files) runtimeChunkFiles.add(file);
     }
@@ -1160,7 +1242,7 @@ export class RSCRspackPlugin {
     css: string[],
     resolvedClientFiles: ReadonlySet<string>,
     filePathToModuleMetadata: Record<string, ModuleMetadata>,
-    diagnosticsCssFiles: Map<string, string[]>,
+    diagnosticsCssFiles: Map<string, string[]>
   ): void {
     if (!module.resource) return;
     if (!resolvedClientFiles.has(module.resource)) return;
@@ -1168,7 +1250,7 @@ export class RSCRspackPlugin {
 
     const href = url.pathToFileURL(module.resource).href;
     if (filePathToModuleMetadata[href]) {
-      // Collision — merge chunks without duplicates (same as webpack)
+      // Collision — merge chunks and CSS without duplicates (same as webpack)
       const existing = filePathToModuleMetadata[href];
       const seen = new Set<string | number>();
       for (let i = 0; i < existing.chunks.length; i += 2) seen.add(existing.chunks[i]!);
@@ -1201,7 +1283,7 @@ export class RSCRspackPlugin {
   private recordDiagnosticsCssFiles(
     href: string,
     css: string[],
-    diagnosticsCssFiles: Map<string, string[]>,
+    diagnosticsCssFiles: Map<string, string[]>
   ): void {
     if (css.length === 0) return;
     const existing = diagnosticsCssFiles.get(href) ?? [];
@@ -1216,7 +1298,7 @@ function sumUniqueKnownBytes(
   clientReferences: Array<{
     chunks: Array<{ file: string; bytes: number | null }>;
     css?: Array<{ file: string; bytes: number | null }>;
-  }>,
+  }>
 ): number {
   const seen = new Set<string>();
   let total = 0;
@@ -1233,7 +1315,7 @@ function sumUniqueKnownBytes(
 function getCompilationAssetSize(
   compilation: AnyCompilation,
   file: string,
-  publicPath: string,
+  publicPath: string
 ): number | null {
   const candidates = new Set<string>();
   const addCandidate = (candidate: string): void => {
@@ -1283,7 +1365,8 @@ function isBundler(b: unknown): b is Bundler {
     typeof (obj.sources as { RawSource?: unknown }).RawSource === 'function' &&
     !!obj.Compilation &&
     typeof obj.Compilation === 'function' &&
-    typeof (obj.Compilation as { PROCESS_ASSETS_STAGE_REPORT?: unknown }).PROCESS_ASSETS_STAGE_REPORT === 'number'
+    typeof (obj.Compilation as { PROCESS_ASSETS_STAGE_REPORT?: unknown })
+      .PROCESS_ASSETS_STAGE_REPORT === 'number'
   );
 }
 
@@ -1342,7 +1425,7 @@ function detectRuntimeResource(resource: string, isServer: boolean): boolean {
   const normalizedResource = path.normalize(resource);
   const expectedSuffix = path.join(
     'react-server-dom-webpack',
-    isServer ? 'client.node.js' : 'client.browser.js',
+    isServer ? 'client.node.js' : 'client.browser.js'
   );
   if (!normalizedResource.endsWith(path.sep + expectedSuffix)) return false;
 

--- a/src/webpack/RSCWebpackPlugin.ts
+++ b/src/webpack/RSCWebpackPlugin.ts
@@ -75,18 +75,18 @@ const asyncLib = require('neo-async') as {
   map<T, R>(
     arr: ReadonlyArray<T>,
     iterator: (item: T, callback: (err: Error | null, result?: R) => void) => void,
-    callback: (err: Error | null, results?: R[]) => void,
+    callback: (err: Error | null, results?: R[]) => void
   ): void;
   mapLimit<T, R>(
     arr: ReadonlyArray<T>,
     limit: number,
     iterator: (item: T, callback: (err: Error | null, result?: R) => void) => void,
-    callback: (err: Error | null, results?: R[]) => void,
+    callback: (err: Error | null, results?: R[]) => void
   ): void;
   filter<T>(
     arr: ReadonlyArray<T>,
     iterator: (item: T, callback: (err: Error | null, keep?: boolean) => void) => void,
-    callback: (err: Error | null, results?: T[]) => void,
+    callback: (err: Error | null, results?: T[]) => void
   ): void;
 };
 
@@ -113,6 +113,11 @@ export class ClientReferenceDependency extends ModuleDependency {
 const clientFileNameOnClient = require.resolve('react-server-dom-webpack/client.browser');
 const clientFileNameOnServer = require.resolve('react-server-dom-webpack/client.node');
 
+// Loader that generates the CSS wrapper module for a client reference (issue #4598).
+const RSC_CSS_WRAPPER_LOADER = require.resolve('./rscCssWrapperLoader');
+// Global (per JS runtime) populated by the plugin with { clientFileURL: cssHref[] }.
+const RSC_CSS_HREFS_GLOBAL = '__RSC_CSS_HREFS__';
+
 const runtimeResourceDetectionCache = new Map<string, boolean>();
 
 // Style-import source extensions a client reference may import directly and
@@ -126,7 +131,10 @@ const STYLE_SOURCE_RE = /\.(css|scss|sass|less|styl|pcss)$/i;
  * the plugin keys its client-reference injection on. Results are memoized
  * because the parser hook runs for every module in the compilation.
  */
-function isReactOnRailsRSCRuntimeResource(resource: string | undefined, isServer: boolean): boolean {
+function isReactOnRailsRSCRuntimeResource(
+  resource: string | undefined,
+  isServer: boolean
+): boolean {
   const cacheKey = `${isServer}\0${resource}`;
   const cached = runtimeResourceDetectionCache.get(cacheKey);
   if (cached !== undefined) return cached;
@@ -137,7 +145,7 @@ function isReactOnRailsRSCRuntimeResource(resource: string | undefined, isServer
 
 function detectReactOnRailsRSCRuntimeResource(
   resource: string | undefined,
-  isServer: boolean,
+  isServer: boolean
 ): boolean {
   // Fast path: the runtime module of THIS package install.
   if (resource === (isServer ? clientFileNameOnServer : clientFileNameOnClient)) {
@@ -152,7 +160,7 @@ function detectReactOnRailsRSCRuntimeResource(
   const normalizedResource = path.normalize(resource);
   const expectedSuffix = path.join(
     'react-server-dom-webpack',
-    isServer ? 'client.node.js' : 'client.browser.js',
+    isServer ? 'client.node.js' : 'client.browser.js'
   );
   if (!normalizedResource.endsWith(path.sep + expectedSuffix)) return false;
 
@@ -195,6 +203,14 @@ export type Options = {
   serverConsumerManifestFilename?: string;
   clientReferenceDiagnosticsFilename?: string | false;
   entryClientReferencesFilename?: string | false;
+  /**
+   * When true, each client reference resolves (in this SSR-server/browser-client
+   * build) to a generated wrapper module that renders a render-blocking
+   * `<link rel="stylesheet" precedence="rsc-css">` for the component's CSS before
+   * the component, so React natively prevents CSS FOUC (issue #4598). Never applied
+   * to the RSC/react-server build, so client references keep their metadata.
+   */
+  cssWrapper?: boolean;
 };
 
 const DEFAULT_CHUNK_GROUP_WARNING_THRESHOLD = 4;
@@ -203,7 +219,7 @@ const CHUNK_GROUP_WARNING_DOCS =
   'https://github.com/shakacode/react_on_rails/blob/main/docs/oss/migrating/rsc-troubleshooting.md';
 
 function normalizeChunkGroupWarningThreshold(
-  threshold: number | false | undefined,
+  threshold: number | false | undefined
 ): number | false {
   if (threshold === undefined) {
     return DEFAULT_CHUNK_GROUP_WARNING_THRESHOLD;
@@ -220,7 +236,7 @@ function normalizeChunkGroupWarningThreshold(
     threshold < 2
   ) {
     throw new Error(
-      'React Server Components: chunkGroupWarningThreshold must be false/0 to disable, or an integer at least 2.',
+      'React Server Components: chunkGroupWarningThreshold must be false/0 to disable, or an integer at least 2.'
     );
   }
   return threshold;
@@ -280,6 +296,7 @@ type FlightChunk = {
   // Real webpack only; absent in the unit-test mocks, which are treated as
   // non-initial (see `isInitialChunk` in `clientReferences.ts`).
   canBeInitial?: () => boolean;
+  hasRuntime?(): boolean;
 };
 
 type FlightChunkGroup = {
@@ -320,17 +337,19 @@ type FlightCompilation = {
   // sibling-chunk CSS recovery pass (see #112).
   moduleGraph?: {
     getOutgoingConnections(
-      module: FlightModule,
+      module: FlightModule
     ): Iterable<{ module?: FlightModule | null; resolvedModule?: FlightModule | null }>;
   };
   assets?: Record<string, AssetSource>;
   getAsset?: (filename: string) => FlightAsset | undefined;
+  chunks: Iterable<FlightChunk>;
   hooks: {
     processAssets: {
       tap(options: { name: string; stage: number }, fn: () => void): void;
     };
   };
   emitAsset(filename: string, source: unknown): void;
+  updateAsset(filename: string, updater: (source: unknown) => unknown): void;
 };
 
 type FlightParser = {
@@ -360,7 +379,7 @@ function createClientReferenceWatchDependencies(): ClientReferenceWatchDependenc
 
 function addClientReferenceWatchDependencies(
   compilation: FlightCompilation,
-  dependencies: ClientReferenceWatchDependencies,
+  dependencies: ClientReferenceWatchDependencies
 ): void {
   for (const file of dependencies.files) {
     compilation.fileDependencies?.add(file);
@@ -387,7 +406,7 @@ type FlightResolver = {
     basePath: string,
     request: string,
     resolveContext: object,
-    callback: (err: Error | null, result?: unknown) => void,
+    callback: (err: Error | null, result?: unknown) => void
   ): void;
 };
 
@@ -402,7 +421,7 @@ type FlightContextModuleFactory = {
       include: undefined;
       exclude: RegExp | undefined;
     },
-    callback: (err: Error | null, dependencies?: Array<{ userRequest: string }>) => void,
+    callback: (err: Error | null, dependencies?: Array<{ userRequest: string }>) => void
   ): void;
 };
 
@@ -418,8 +437,8 @@ type FlightCompiler = {
         name: string,
         fn: (
           params: { contextModuleFactory: FlightContextModuleFactory },
-          callback: (err?: Error | null) => void,
-        ) => void,
+          callback: (err?: Error | null) => void
+        ) => void
       ): void;
     };
     thisCompilation: {
@@ -427,8 +446,8 @@ type FlightCompiler = {
         name: string,
         fn: (
           compilation: FlightCompilation,
-          params: { normalModuleFactory: FlightNormalModuleFactory },
-        ) => void,
+          params: { normalModuleFactory: FlightNormalModuleFactory }
+        ) => void
       ): void;
     };
     make: {
@@ -441,22 +460,22 @@ type ReadFileFs = {
   readFile(
     filePath: string,
     encoding: string,
-    callback: (err: Error | null, content?: string) => void,
+    callback: (err: Error | null, content?: string) => void
   ): void;
 };
 
 type WatchInputFileSystem = ReadFileFs & {
   readdir(
     filePath: string,
-    callback: (err: NodeJS.ErrnoException | null, files?: string[]) => void,
+    callback: (err: NodeJS.ErrnoException | null, files?: string[]) => void
   ): void;
   realpath?(
     filePath: string,
-    callback: (err: NodeJS.ErrnoException | null, realPath?: string) => void,
+    callback: (err: NodeJS.ErrnoException | null, realPath?: string) => void
   ): void;
   stat(
     filePath: string,
-    callback: (err: NodeJS.ErrnoException | null, stats?: { isDirectory(): boolean }) => void,
+    callback: (err: NodeJS.ErrnoException | null, stats?: { isDirectory(): boolean }) => void
   ): void;
 };
 
@@ -492,13 +511,13 @@ export class RSCWebpackPlugin {
    */
   readonly entryClientReferencesFilename: string | false | undefined;
 
+  readonly cssWrapper: boolean;
+
   static __internal_isReactOnRailsRSCRuntimeResource = isReactOnRailsRSCRuntimeResource;
 
   constructor(options: Options) {
     if (!options || typeof options.isServer !== 'boolean') {
-      throw new Error(
-        'React Server Plugin: You must specify the isServer option as a boolean.',
-      );
+      throw new Error('React Server Plugin: You must specify the isServer option as a boolean.');
     }
     this.isServer = options.isServer;
 
@@ -526,18 +545,18 @@ export class RSCWebpackPlugin {
     }
 
     this.chunkGroupWarningThreshold = normalizeChunkGroupWarningThreshold(
-      options.chunkGroupWarningThreshold,
+      options.chunkGroupWarningThreshold
     );
 
     const defaultClientManifestFilename = this.isServer
       ? 'react-server-client-manifest.json'
       : 'react-client-manifest.json';
-    this.clientManifestFilename =
-      options.clientManifestFilename || defaultClientManifestFilename;
+    this.clientManifestFilename = options.clientManifestFilename || defaultClientManifestFilename;
     this.serverConsumerManifestFilename =
       options.serverConsumerManifestFilename || 'react-ssr-manifest.json';
     this.clientReferenceDiagnosticsFilename = options.clientReferenceDiagnosticsFilename;
     this.entryClientReferencesFilename = options.entryClientReferencesFilename;
+    this.cssWrapper = options.cssWrapper === true;
   }
 
   apply(compiler: webpack.Compiler): void {
@@ -568,7 +587,7 @@ export class RSCWebpackPlugin {
           resolvedClientReferences = resolvedClientRefs;
           callback();
         },
-        nextWatchDependencies,
+        nextWatchDependencies
       );
     });
 
@@ -581,10 +600,7 @@ export class RSCWebpackPlugin {
 
       const normalModuleFactory = params.normalModuleFactory;
       compilation.dependencyFactories.set(ClientReferenceDependency, normalModuleFactory);
-      compilation.dependencyTemplates.set(
-        ClientReferenceDependency,
-        new NullDependency.Template(),
-      );
+      compilation.dependencyTemplates.set(ClientReferenceDependency, new NullDependency.Template());
 
       const handler = (parser: FlightParser) => {
         parser.hooks.program.tap(PLUGIN_NAME, () => {
@@ -606,12 +622,30 @@ export class RSCWebpackPlugin {
             const chunkName = this.chunkName
               .replace(/\[index\]/g, `${i}`)
               .replace(/\[request\]/g, Template.toPath(dep.userRequest));
+            // With cssWrapper, the async block builds a generated wrapper module
+            // (which imports the original client module and renders its CSS
+            // <link precedence>) instead of the client module directly. The
+            // wrapper's resource is still the client file, so the manifest entry
+            // (recorded by `module.resource`) points at the wrapper module id; the
+            // dep keeps `userRequest` = client file so chunk-group matching and
+            // `resolvedClientFiles` membership are unchanged.
+            let blockDep: ClientReferenceDependency = dep;
+            let blockRequest = dep.request;
+            if (this.cssWrapper) {
+              blockRequest = `!!${RSC_CSS_WRAPPER_LOADER}!${dep.request}`;
+              blockDep = new ClientReferenceDependency(blockRequest);
+              blockDep.userRequest = dep.userRequest;
+              // Record the original client file this wrapper stands in for, so
+              // chunk-group matching resolves it back to the real client file.
+              (blockDep as unknown as { clientFileRequest?: string }).clientFileRequest =
+                dep.request;
+            }
             const block = new webpack.AsyncDependenciesBlock(
               { name: chunkName },
               undefined,
-              dep.request,
+              blockRequest
             );
-            block.addDependency(dep);
+            block.addDependency(blockDep);
             module.addBlock!(block);
           }
         });
@@ -637,8 +671,8 @@ export class RSCWebpackPlugin {
               new webpack.WebpackError(
                 'Client runtime at react-on-rails-rsc/client was not found. React Server Components module map file ' +
                   this.clientManifestFilename +
-                  ' was not created.',
-              ),
+                  ' was not created.'
+              )
             );
             return;
           }
@@ -652,7 +686,7 @@ export class RSCWebpackPlugin {
               : null;
 
           const resolvedClientFiles = new Set(
-            (resolvedClientReferences || []).map((ref) => ref.request),
+            (resolvedClientReferences || []).map((ref) => ref.request)
           );
           const configuredPublicPath = compilation.outputOptions.publicPath;
           const publicPathIsAuto = configuredPublicPath === 'auto';
@@ -666,8 +700,8 @@ export class RSCWebpackPlugin {
               new webpack.WebpackError(
                 `React Server Components: ${publicPathDescription}, which cannot be serialized into the RSC manifest. ` +
                   'moduleLoading.prefix will be emitted as an empty string, and CSS files are omitted from the RSC manifest because their final URLs are only known at runtime. ' +
-                  'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.',
-              ),
+                  'Set output.publicPath to a concrete URL or path to enable Flight chunk loading and stylesheet hints.'
+              )
             );
           }
           const moduleLoadingPrefix =
@@ -696,10 +730,18 @@ export class RSCWebpackPlugin {
             }
           });
 
-          let cssPrefix =
-            typeof configuredPublicPath === 'string' && configuredPublicPath !== 'auto'
-              ? configuredPublicPath
-              : null;
+          let cssPrefix: string | null;
+          if (typeof configuredPublicPath === 'string' && configuredPublicPath !== 'auto') {
+            cssPrefix = configuredPublicPath;
+          } else if (this.cssWrapper) {
+            // When publicPath is 'auto' or undefined but cssWrapper is on, emit document-
+            // relative CSS paths so the wrapper's <link precedence> works even without a
+            // static publicPath. The browser resolves these paths relative to the document.
+            cssPrefix = '';
+          } else {
+            // Without cssWrapper, unknown publicPath means we cannot serialize CSS hrefs.
+            cssPrefix = null;
+          }
           if (cssPrefix && !cssPrefix.endsWith('/')) {
             cssPrefix += '/';
           }
@@ -719,7 +761,7 @@ export class RSCWebpackPlugin {
           const recordChunkGroup = (
             chunkGroup: FlightChunkGroup,
             chunkResolvedClientFiles: Set<string>,
-            trackClientReferencePresence = false,
+            trackClientReferencePresence = false
           ): void => {
             const chunks: (string | number | null)[] = [];
 
@@ -735,7 +777,7 @@ export class RSCWebpackPlugin {
             const recordModule = (
               id: string | number | null,
               module: FlightModule,
-              moduleCss: readonly string[],
+              moduleCss: readonly string[]
             ): void => {
               if (!module.resource || !chunkResolvedClientFiles.has(module.resource)) {
                 return;
@@ -844,13 +886,14 @@ export class RSCWebpackPlugin {
             // Guarded on `moduleGraph`/`getModuleChunksIterable`, which the
             // unit-test mocks omit (they exercise the per-chunk pass only).
             const moduleGraph = compilation.moduleGraph;
-            const getModuleChunksIterable =
-              compilation.chunkGraph.getModuleChunksIterable?.bind(compilation.chunkGraph);
+            const getModuleChunksIterable = compilation.chunkGraph.getModuleChunksIterable?.bind(
+              compilation.chunkGraph
+            );
             const directCssDepFiles = (module: FlightModule): string[] => {
               if (!moduleGraph || !getModuleChunksIterable || cssPrefix === null) return [];
               const files = new Set<string>();
               const moduleChunks = new Set(
-                [...getModuleChunksIterable(module)].filter((chunk) => groupChunks.has(chunk)),
+                [...getModuleChunksIterable(module)].filter((chunk) => groupChunks.has(chunk))
               );
               const addCssFromModuleChunks = (cssModule: FlightModule): void => {
                 for (const cssChunk of getModuleChunksIterable(cssModule)) {
@@ -970,8 +1013,8 @@ export class RSCWebpackPlugin {
                   compilation.warnings.push(
                     new webpack.WebpackError(
                       'Client reference blocks were unavailable for one or more chunk groups. ' +
-                        'React Server Components client manifest entries for affected chunk groups were skipped.',
-                    ),
+                        'React Server Components client manifest entries for affected chunk groups were skipped.'
+                    )
                   );
                 }
                 continue;
@@ -985,13 +1028,17 @@ export class RSCWebpackPlugin {
                   // The `type` check matches dependencies created by a
                   // duplicate copy of this plugin module (e.g. two
                   // node_modules instances), where `instanceof` fails.
+                  // With cssWrapper the dep.request is the wrapper loader request;
+                  // the original client file it stands in for is stored on the dep.
+                  // Without it this is exactly the previous behavior (dep.request).
+                  const clientFileRequest =
+                    (dep as { clientFileRequest?: string }).clientFileRequest ?? dep.request;
                   if (
-                    (dep instanceof ClientReferenceDependency ||
-                      dep.type === 'client-reference') &&
-                    typeof dep.request === 'string' &&
-                    resolvedClientFiles.has(dep.request)
+                    (dep instanceof ClientReferenceDependency || dep.type === 'client-reference') &&
+                    typeof clientFileRequest === 'string' &&
+                    resolvedClientFiles.has(clientFileRequest)
                   ) {
-                    chunkResolvedClientFiles.add(dep.request);
+                    chunkResolvedClientFiles.add(clientFileRequest);
                   }
                 }
               }
@@ -1050,8 +1097,8 @@ export class RSCWebpackPlugin {
                     'React Server Components: no client manifest entry could be created for ' +
                       missing.length +
                       ' client reference(s). Rendering them will fail at runtime with a missing manifest entry:\n  ' +
-                      missing.join('\n  '),
-                  ),
+                      missing.join('\n  ')
+                  )
                 );
               }
             }
@@ -1087,8 +1134,8 @@ export class RSCWebpackPlugin {
                       'This can duplicate its client JS/CSS across routes; consider a thin client wrapper or isolating imports to avoid chunk contamination. ' +
                       'See ' +
                       CHUNK_GROUP_WARNING_DOCS +
-                      ' for mitigation guidance.',
-                  ),
+                      ' for mitigation guidance.'
+                  )
                 );
               }
 
@@ -1101,8 +1148,8 @@ export class RSCWebpackPlugin {
                       'Increase chunkGroupWarningThreshold or inspect the module graph to narrow duplicated client references. ' +
                       'See ' +
                       CHUNK_GROUP_WARNING_DOCS +
-                      ' for mitigation guidance.',
-                  ),
+                      ' for mitigation guidance.'
+                  )
                 );
               }
             }
@@ -1112,7 +1159,7 @@ export class RSCWebpackPlugin {
             const diagnostics = this.buildDiagnostics(compilation, manifest);
             compilation.emitAsset(
               this.clientReferenceDiagnosticsFilename,
-              new webpack.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false),
+              new webpack.sources.RawSource(`${JSON.stringify(diagnostics, null, 2)}\n`, false)
             );
           }
 
@@ -1129,19 +1176,51 @@ export class RSCWebpackPlugin {
                 compilation.warnings.push(new webpack.WebpackError(message));
               },
               emitAsset: (filename, source) => {
-                compilation.emitAsset(
-                  filename,
-                  new webpack.sources.RawSource(source, false),
-                );
+                compilation.emitAsset(filename, new webpack.sources.RawSource(source, false));
               },
             });
           }
 
           compilation.emitAsset(
             this.clientManifestFilename,
-            new webpack.sources.RawSource(JSON.stringify(manifest, null, 2), false),
+            new webpack.sources.RawSource(JSON.stringify(manifest, null, 2), false)
           );
-        },
+
+          // With cssWrapper, publish the per-client-module CSS hrefs into a global
+          // map the generated wrapper modules read at render time. The hrefs are
+          // only known now (post-chunking), so they are injected at the top of each
+          // runtime chunk (runs at bundle init, before any wrapper renders).
+          if (this.cssWrapper) {
+            const hrefMap: Record<string, string[]> = {};
+            for (const [fileUrl, meta] of Object.entries(filePathToModuleMetadata)) {
+              if (meta.css && meta.css.length > 0) {
+                hrefMap[fileUrl] = meta.css;
+              }
+            }
+            if (Object.keys(hrefMap).length > 0) {
+              const g = RSC_CSS_HREFS_GLOBAL;
+              const prelude =
+                `(function(){var g=(typeof globalThis!=='undefined')?globalThis:` +
+                `(typeof self!=='undefined')?self:this;` +
+                `g[${JSON.stringify(g)}]=Object.assign(g[${JSON.stringify(g)}]||{},` +
+                `${JSON.stringify(hrefMap)});})();\n`;
+              for (const chunk of compilation.chunks) {
+                if (typeof chunk.hasRuntime !== 'function' || !chunk.hasRuntime()) continue;
+                for (const file of chunk.files) {
+                  if (!file.endsWith('.js')) continue;
+                  compilation.updateAsset(
+                    file,
+                    (old: unknown) =>
+                      new webpack.sources.ConcatSource(
+                        new webpack.sources.RawSource(prelude),
+                        old as InstanceType<typeof webpack.sources.RawSource>
+                      )
+                  );
+                }
+              }
+            }
+          }
+        }
       );
     });
   }
@@ -1151,7 +1230,7 @@ export class RSCWebpackPlugin {
     manifest: {
       moduleLoading: { prefix: string; crossOrigin: string | null };
       filePathToModuleMetadata: Record<string, ModuleMetadata>;
-    },
+    }
   ): ClientReferenceDiagnostics {
     const clientReferences = Object.entries(manifest.filePathToModuleMetadata)
       .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
@@ -1170,12 +1249,16 @@ export class RSCWebpackPlugin {
           metadata.css && metadata.css.length > 0
             ? metadata.css.map((fileName) => ({
                 file: fileName,
-                bytes: getCompilationAssetSize(compilation, fileName, manifest.moduleLoading.prefix),
+                bytes: getCompilationAssetSize(
+                  compilation,
+                  fileName,
+                  manifest.moduleLoading.prefix
+                ),
               }))
             : undefined;
         const totalBytes = [...chunks, ...(css || [])].reduce(
           (sum, entry) => sum + (entry.bytes ?? 0),
-          0,
+          0
         );
 
         return {
@@ -1213,7 +1296,7 @@ export class RSCWebpackPlugin {
     fs: unknown,
     contextModuleFactory: FlightContextModuleFactory,
     callback: (err: Error | null, result?: ClientReferenceDependency[]) => void,
-    watchDependencies = createClientReferenceWatchDependencies(),
+    watchDependencies = createClientReferenceWatchDependencies()
   ): void {
     asyncLib.map<ClientReferencePath, ClientReferenceDependency[]>(
       this.clientReferences,
@@ -1233,8 +1316,8 @@ export class RSCWebpackPlugin {
               watchDependencies.missing.add(configuredRequest);
               cb(
                 new Error(
-                  `React Server Components: clientReferences entry "${clientReferencePath}" resolved to a non-file request.`,
-                ),
+                  `React Server Components: clientReferences entry "${clientReferencePath}" resolved to a non-file request.`
+                )
               );
               return;
             }
@@ -1299,26 +1382,22 @@ export class RSCWebpackPlugin {
                               return filterCb(null, false);
                             }
                             watchDependencies.files.add(resolvedPath);
-                            (fs as ReadFileFs).readFile(
-                              resolvedPath,
-                              'utf-8',
-                              (err4, content) => {
-                                if (err4 || typeof content !== 'string') {
-                                  return filterCb(null, false);
-                                }
-                                filterCb(null, hasUseClientDirective(content));
-                              },
-                            );
-                          },
+                            (fs as ReadFileFs).readFile(resolvedPath, 'utf-8', (err4, content) => {
+                              if (err4 || typeof content !== 'string') {
+                                return filterCb(null, false);
+                              }
+                              filterCb(null, hasUseClientDirective(content));
+                            });
+                          }
                         );
                       },
-                      cb,
+                      cb
                     );
-                  },
+                  }
                 );
-              },
+              }
             );
-          },
+          }
         );
       },
       (err, result) => {
@@ -1328,7 +1407,7 @@ export class RSCWebpackPlugin {
           flattened.push(...deps);
         }
         callback(null, flattened);
-      },
+      }
     );
   }
 
@@ -1337,7 +1416,7 @@ export class RSCWebpackPlugin {
     rootDirectory: string,
     clientReferencePath: ClientReferenceSearchPath,
     watchDependencies: ClientReferenceWatchDependencies,
-    callback: (err: Error | null) => void,
+    callback: (err: Error | null) => void
   ): void {
     const inputFs = fs as WatchInputFileSystem;
     const recursive = clientReferencePath.recursive !== false;
@@ -1384,7 +1463,7 @@ export class RSCWebpackPlugin {
                 mapDone(null);
               });
             },
-            (err) => done(err),
+            (err) => done(err)
           );
         });
       };
@@ -1409,7 +1488,7 @@ export class RSCWebpackPlugin {
 }
 
 function sumUniqueKnownBytes(
-  clientReferences: ClientReferenceDiagnostics['clientReferences'],
+  clientReferences: ClientReferenceDiagnostics['clientReferences']
 ): number {
   const seen = new Set<string>();
   let total = 0;
@@ -1426,7 +1505,7 @@ function sumUniqueKnownBytes(
 function getCompilationAssetSize(
   compilation: FlightCompilation,
   file: string,
-  publicPath: string,
+  publicPath: string
 ): number | null {
   const candidates = new Set<string>();
   const addCandidate = (candidate: string): void => {

--- a/src/webpack/rscCssWrapperLoader.ts
+++ b/src/webpack/rscCssWrapperLoader.ts
@@ -1,0 +1,113 @@
+/*
+ * Webpack/rspack loader that generates the RSC CSS wrapper module for a
+ * `'use client'` file (issue #4598). Applied ONLY to the client-reference async
+ * block in the SSR-server and browser-client builds (never the RSC bundle), so
+ * client references keep their metadata. The generated module imports the ORIGINAL
+ * client module and re-exports each export wrapped so that rendering it also renders
+ * a render-blocking `<link rel="stylesheet" precedence="rsc-css">` for the module's
+ * CSS (hrefs looked up at render time from a plugin-populated global map).
+ *
+ * The wrapper is self-contained (no runtime-package import) so it resolves in any
+ * host build; it depends only on `react`, which is always present in these bundles.
+ */
+import type { LoaderContext } from 'webpack';
+import { pathToFileURL } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+interface Options {
+  /** Stable key for this client module (matches the manifest key). Defaults to the file URL. */
+  key?: string;
+}
+
+// Bare `export * from 'x'` (NOT `export * as N from 'x'`, which lexes as a named export).
+const STAR_REEXPORT_RE = /export\s*\*\s*from\s*(['"])([^'"]+)\1/g;
+
+export default function rscCssWrapperLoader(this: LoaderContext<Options>, source: string): void {
+  const callback = this.async();
+  const loaderContext = this;
+  const resourcePath = this.resourcePath;
+  const options = (typeof this.getOptions === 'function' ? this.getOptions() : {}) as Options;
+  const key = options.key || pathToFileURL(resourcePath).href;
+
+  const resolve = (request: string): Promise<string> =>
+    new Promise((res, rej) =>
+      loaderContext.resolve(dirname(resourcePath), request, (err, result) =>
+        err || !result ? rej(err || new Error(`cannot resolve ${request}`)) : res(result),
+      ),
+    );
+
+  // es-module-lexer is ESM-only; load it dynamically from this CommonJS loader.
+  import('es-module-lexer')
+    .then(async ({ init, parse }) => {
+      await init;
+      const exportNames: string[] = [];
+      try {
+        const [, exports] = parse(source, resourcePath);
+        for (const e of exports) {
+          if (e.n) exportNames.push(e.n);
+        }
+        // Resolve bare `export * from` sources one level and collect their named
+        // exports (all available on this module's namespace via the re-export), so
+        // re-exported components are wrapped too rather than leaking unwrapped (FOUC).
+        const starSources = [...source.matchAll(STAR_REEXPORT_RE)].map((m) => m[2]!);
+        for (const starSource of starSources) {
+          try {
+            const resolved = await resolve(starSource);
+            loaderContext.addDependency(resolved);
+            const [, starExports] = parse(readFileSync(resolved, 'utf8'), resolved);
+            for (const e of starExports) {
+              // `export *` does not re-export the default.
+              if (e.n && e.n !== 'default' && !exportNames.includes(e.n)) {
+                exportNames.push(e.n);
+              }
+            }
+          } catch {
+            // If a star source can't be resolved/parsed, skip it (best effort).
+          }
+        }
+      } catch {
+        // If parsing fails, fall back to wrapping default only.
+        exportNames.length = 0;
+        exportNames.push('default');
+      }
+
+      // Import the original with a distinct query so it is a different webpack
+      // resource than the wrapper (whose resource is the bare client file). This
+      // keeps the manifest entry pointing at the wrapper module id, while the
+      // wrapper still renders the real component.
+      const origRequest = JSON.stringify(`${resourcePath}?__rsc_orig`);
+      const keyLit = JSON.stringify(key);
+      const named = exportNames.filter((n) => n !== 'default');
+      const hasDefault = exportNames.includes('default');
+
+      const lines: string[] = [
+        `import * as React from 'react';`,
+        `import * as __orig from ${origRequest};`,
+        `var __k = ${keyLit};`,
+        `function __rscHrefs(){ var m = globalThis['__RSC_CSS_HREFS__']; var h = m && m[__k]; return Array.isArray(h) ? h : []; }`,
+        `var __FR = Symbol.for('react.forward_ref'), __MEMO = Symbol.for('react.memo');`,
+        `function __rscIsComponent(v){ return typeof v === 'function' || (v != null && typeof v === 'object' && (v.$$typeof === __FR || v.$$typeof === __MEMO)); }`,
+        `function __rscWrap(v){`,
+        `  if (!__rscIsComponent(v)) return v;`,
+        `  var W = React.forwardRef(function(props, ref){`,
+        `    var links = __rscHrefs().map(function(href){ return React.createElement('link', { key: href, rel: 'stylesheet', href: href, precedence: 'rsc-css' }); });`,
+        `    var el = React.createElement(v, ref == null ? props : Object.assign({}, props, { ref: ref }));`,
+        `    return React.createElement(React.Fragment, null, links, el);`,
+        `  });`,
+        `  W.displayName = 'withRscCss(' + ((v.displayName || v.name) || 'Component') + ')';`,
+        `  return W;`,
+        `}`,
+      ];
+
+      for (const n of named) {
+        lines.push(`export var ${n} = __rscWrap(__orig[${JSON.stringify(n)}]);`);
+      }
+      if (hasDefault) {
+        lines.push(`export default __rscWrap(__orig['default']);`);
+      }
+
+      callback(null, lines.join('\n'));
+    })
+    .catch((err: unknown) => callback(err as Error));
+}

--- a/tests/css-wrapper-runtime.test.ts
+++ b/tests/css-wrapper-runtime.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Issue #4598 — `withRscCss` must wrap every component-export shape so each emits
+ * its render-blocking `<link precedence>`, and must pass non-component exports
+ * through unchanged. forwardRef/memo components are OBJECTS, not functions, so a
+ * naive typeof check would miss them (a real FOUC path).
+ */
+import * as React from 'react';
+import { withRscCss, RSC_CSS_PRECEDENCE } from '../src/css-wrapper-runtime';
+
+const KEY = 'file:///app/Shapes.js';
+const FORWARD_REF = Symbol.for('react.forward_ref');
+
+beforeEach(() => {
+  (globalThis as unknown as Record<string, unknown>).__RSC_CSS_HREFS__ = { [KEY]: ['/a.css', '/b.css'] };
+});
+afterEach(() => {
+  delete (globalThis as unknown as Record<string, unknown>).__RSC_CSS_HREFS__;
+});
+
+/** Render a wrapped component (always a forwardRef) and collect its <link> children. */
+function linksOf(Wrapped: unknown): Array<{ rel?: string; precedence?: string; href?: string }> {
+  const w = Wrapped as { $$typeof?: symbol; render?: (p: unknown, r: unknown) => React.ReactElement };
+  expect(w.$$typeof).toBe(FORWARD_REF);
+  const tree = w.render!({ title: 'x' }, null);
+  const children = React.Children.toArray((tree as React.ReactElement<{ children: React.ReactNode }>).props.children);
+  return children
+    .filter((c): c is React.ReactElement => React.isValidElement(c) && c.type === 'link')
+    .map((c) => {
+      const p = c.props as { rel?: string; precedence?: string; href?: string };
+      return { rel: p.rel, precedence: p.precedence, href: p.href };
+    });
+}
+
+describe('withRscCss export-shape coverage', () => {
+  const expectedLinks = [
+    { rel: 'stylesheet', precedence: RSC_CSS_PRECEDENCE, href: '/a.css' },
+    { rel: 'stylesheet', precedence: RSC_CSS_PRECEDENCE, href: '/b.css' },
+  ];
+
+  it('wraps a plain function component', () => {
+    const Fn = (props: { title: string }) => React.createElement('div', null, props.title);
+    expect(linksOf(withRscCss(Fn, KEY))).toEqual(expectedLinks);
+  });
+
+  it('wraps a forwardRef component (object, not function)', () => {
+    const Ref = React.forwardRef<HTMLDivElement, { title: string }>((props, ref) =>
+      React.createElement('div', { ref }, props.title),
+    );
+    expect(linksOf(withRscCss(Ref, KEY))).toEqual(expectedLinks);
+  });
+
+  it('wraps a memo component (object)', () => {
+    const Memo = React.memo((props: { title: string }) => React.createElement('div', null, props.title));
+    expect(linksOf(withRscCss(Memo, KEY))).toEqual(expectedLinks);
+  });
+
+  it('wraps a memo(forwardRef) component', () => {
+    const MemoRef = React.memo(
+      React.forwardRef<HTMLDivElement, { title: string }>((props, ref) =>
+        React.createElement('div', { ref }, props.title),
+      ),
+    );
+    expect(linksOf(withRscCss(MemoRef, KEY))).toEqual(expectedLinks);
+  });
+
+  it('passes non-component exports through unchanged', () => {
+    const constant = { some: 'value' };
+    expect(withRscCss(constant, KEY)).toBe(constant);
+    expect(withRscCss(42, KEY)).toBe(42);
+    expect(withRscCss('hello', KEY)).toBe('hello');
+    expect(withRscCss(null, KEY)).toBe(null);
+  });
+
+  it('forwards props and ref through the wrapper', () => {
+    const seen: { props?: unknown; ref?: unknown } = {};
+    const Ref = React.forwardRef<unknown, { title: string }>((props, ref) => {
+      seen.props = props;
+      seen.ref = ref;
+      return React.createElement('div', null, props.title);
+    });
+    const Wrapped = withRscCss(Ref, KEY) as unknown as {
+      render: (p: unknown, r: unknown) => React.ReactElement;
+    };
+    const ref = React.createRef();
+    const tree = Wrapped.render({ title: 'Hi' }, ref);
+    // The last child is the original component element with props + ref forwarded.
+    const children = React.Children.toArray(
+      (tree as React.ReactElement<{ children: React.ReactNode }>).props.children,
+    );
+    const compEl = children[children.length - 1] as React.ReactElement<{ title: string }> & { ref?: unknown };
+    expect(compEl.props.title).toBe('Hi');
+    expect(compEl.ref).toBe(ref);
+  });
+
+  it('renders no links when the href map has no entry for the key', () => {
+    const Fn = (props: { title: string }) => React.createElement('div', null, props.title);
+    expect(linksOf(withRscCss(Fn, 'file:///app/Unknown.js'))).toEqual([]);
+  });
+});

--- a/tests/react-flight-webpack-plugin-css-order.test.ts
+++ b/tests/react-flight-webpack-plugin-css-order.test.ts
@@ -19,22 +19,25 @@ const emitManifestMetadata = ({
   files,
   publicPath = '/assets/',
   isServer = false,
+  cssWrapper = false,
   chunks: chunkDefs,
   entrypoints: entrypointDefs,
 }: {
   files?: string[];
   publicPath?: string;
   isServer?: boolean;
+  cssWrapper?: boolean;
   chunks?: ChunkDef[];
   entrypoints?: Array<{ runtimeChunk: ChunkDef }>;
 }) => {
   const clientFile = '/app/components/ClientComponent.js';
   // The plugin matches this specific runtime resource to inject client-reference dependency blocks.
   const runtimeFile = require.resolve(
-    isServer ? 'react-server-dom-webpack/client.node' : 'react-server-dom-webpack/client.browser',
+    isServer ? 'react-server-dom-webpack/client.node' : 'react-server-dom-webpack/client.browser'
   );
   const plugin = new ReactFlightWebpackPlugin({
     isServer,
+    cssWrapper,
     clientReferences: [clientFile],
   });
 
@@ -46,12 +49,12 @@ const emitManifestMetadata = ({
       _normalResolver: unknown,
       _fs: unknown,
       _contextModuleFactory: unknown,
-      callback: (error: Error | null, refs?: ClientReference[]) => void,
+      callback: (error: Error | null, refs?: ClientReference[]) => void
     ) => {
       callback(null, [
         { request: clientFile, type: 'client-reference', userRequest: './ClientComponent.js' },
       ]);
-    },
+    }
   );
 
   const beforeCompileCallbacks: AsyncHookCallback[] = [];
@@ -85,12 +88,9 @@ const emitManifestMetadata = ({
   plugin.apply(compiler);
 
   expect(beforeCompileCallbacks).toHaveLength(1);
-  beforeCompileCallbacks[0]!(
-    { contextModuleFactory: {} },
-    (error?: Error | null) => {
-      if (error) throw error;
-    },
-  );
+  beforeCompileCallbacks[0]!({ contextModuleFactory: {} }, (error?: Error | null) => {
+    if (error) throw error;
+  });
 
   const programCallbacks: Array<() => void> = [];
   const clientReferenceBlocks: unknown[] = [];
@@ -131,10 +131,15 @@ const emitManifestMetadata = ({
   const module = {
     resource: clientFile,
   };
-  const entrypoints = new Map<string, { getRuntimeChunk: () => (typeof resolvedChunks)[0] | null }>();
+  const entrypoints = new Map<
+    string,
+    { getRuntimeChunk: () => (typeof resolvedChunks)[0] | null }
+  >();
   if (entrypointDefs) {
     for (let i = 0; i < entrypointDefs.length; i++) {
-      const runtimeChunkObj = resolvedChunks.find((c) => c.id === entrypointDefs[i]!.runtimeChunk.id) ?? {
+      const runtimeChunkObj = resolvedChunks.find(
+        (c) => c.id === entrypointDefs[i]!.runtimeChunk.id
+      ) ?? {
         id: entrypointDefs[i]!.runtimeChunk.id,
         files: new Set(entrypointDefs[i]!.runtimeChunk.files),
       };
@@ -155,6 +160,7 @@ const emitManifestMetadata = ({
         chunks: resolvedChunks,
       },
     ],
+    chunks: resolvedChunks,
     chunkGraph: {
       getChunkModulesIterable: jest.fn(() => [module]),
       getModuleId: jest.fn(() => './ClientComponent.js'),
@@ -169,6 +175,7 @@ const emitManifestMetadata = ({
     emitAsset: (filename: string, source: { source(): string | Buffer }) => {
       emittedAssets.set(filename, source);
     },
+    updateAsset: jest.fn(),
   };
 
   expect(thisCompilationCallbacks).toHaveLength(1);
@@ -182,7 +189,7 @@ const emitManifestMetadata = ({
   processAssetCallbacks[0]!();
 
   const manifestAsset = emittedAssets.get(
-    isServer ? 'react-server-client-manifest.json' : 'react-client-manifest.json',
+    isServer ? 'react-server-client-manifest.json' : 'react-client-manifest.json'
   );
   expect(manifestAsset).toBeDefined();
   const manifestSource = manifestAsset!.source().toString();
@@ -265,16 +272,17 @@ describe('ReactFlightWebpackPlugin manifest chunk files', () => {
     });
   });
 
-  it('does not record document-relative CSS hrefs for the webpack publicPath auto sentinel', () => {
+  it('records document-relative CSS hrefs when webpack publicPath is auto with cssWrapper', () => {
     const metadata = emitManifestMetadata({
       files: ['client.css', 'client.js'],
       publicPath: 'auto',
+      cssWrapper: true,
     });
 
     expect(metadata).toEqual({
       id: './ClientComponent.js',
       chunks: ['client-chunk', 'client.js'],
-      css: [],
+      css: ['client.css'],
       name: '*',
     });
   });

--- a/tests/rsc-css-auto-rspack.test.ts
+++ b/tests/rsc-css-auto-rspack.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #4598 — rspack parity for the cssWrapper feature: a plain `'use client'`
+ * component compiled with `cssWrapper: true` must resolve (via the manifest) to a
+ * generated wrapper module, with CSS recorded and the href global injected into the
+ * runtime bundle — the same structure the webpack plugin produces (whose decode-time
+ * render behavior is verified in the webpack rsc tests).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { pathToFileURL } from 'node:url';
+import { compile, cleanupOutputDirs, type CompileResult } from './rspack-plugin/helpers/compile';
+
+const FIXTURE = 'rsc-css-auto';
+const fixtureUrl = (file: string): string =>
+  pathToFileURL(path.join(__dirname, 'rspack-plugin/fixtures', FIXTURE, file)).href;
+
+function entry(result: CompileResult, suffix: string) {
+  const entries = result.manifest.filePathToModuleMetadata as Record<
+    string,
+    { id: unknown; chunks: unknown[]; css?: string[]; name: string }
+  >;
+  const key = Object.keys(entries).find((k) => k.endsWith(suffix));
+  if (!key) throw new Error(`no manifest entry ending with ${suffix}`);
+  return entries[key]!;
+}
+
+const created: CompileResult[] = [];
+let client: CompileResult;
+
+beforeAll(() => {
+  client = compile(FIXTURE, {
+    chunkName: 'client-[request]',
+    withCss: true,
+    publicPath: '/assets/',
+    cssWrapper: true,
+  });
+  created.push(client);
+});
+afterAll(() => cleanupOutputDirs(created));
+
+describe('rspack cssWrapper parity (real rspack)', () => {
+  it('remaps the client reference to the generated wrapper module and records CSS', () => {
+    const styled = entry(client, '/Styled.js');
+    expect(String(styled.id)).toContain('rscCssWrapperLoader');
+    expect(styled.css && styled.css.length).toBeGreaterThan(0);
+    expect(styled.css![0]).toMatch(/\.css$/);
+  });
+
+  it('injects the CSS href global (map with the real href) into the runtime bundle', () => {
+    const cssHref = entry(client, '/Styled.js').css![0]!;
+    const files = fs.readdirSync(client.outputPath).filter((f) => f.endsWith('.js'));
+    // The runtime chunk carries the injected setter: Object.assign of a map that
+    // contains BOTH the client file URL key AND the real css href value. (The async
+    // wrapper chunk references __RSC_CSS_HREFS__ but does not inline the href.)
+    const runtimeWithGlobal = files.find((f) => {
+      const src = fs.readFileSync(path.join(client.outputPath, f), 'utf8');
+      return (
+        src.includes('__RSC_CSS_HREFS__') &&
+        src.includes('Object.assign') &&
+        src.includes(fixtureUrl('Styled.js')) &&
+        src.includes(cssHref)
+      );
+    });
+    expect(runtimeWithGlobal).toBeDefined();
+  });
+
+  it('emits the generated wrapper code (renders <link precedence>) into the bundle', () => {
+    const allJs = fs
+      .readdirSync(client.outputPath)
+      .filter((f) => f.endsWith('.js'))
+      .map((f) => fs.readFileSync(path.join(client.outputPath, f), 'utf8'))
+      .join('\n');
+    // The wrapper's self-contained render logic markers.
+    expect(allJs).toContain('__rscHrefs');
+    expect(allJs).toContain('rsc-css');
+  });
+});

--- a/tests/rsc-css-auto.rsc.test.ts
+++ b/tests/rsc-css-auto.rsc.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Issue #4598 — the plugin's `cssWrapper` option AUTO-GENERATES the CSS wrapper.
+ * A plain `'use client'` component (which does not render its own <link>) must, on
+ * the consume side, resolve to a generated wrapper that renders a render-blocking
+ * `<link rel="stylesheet" precedence="rsc-css">` for the component's CSS. Proven on
+ * a real webpack build + real Flight round-trip.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { PassThrough } from 'node:stream';
+import { text } from 'node:stream/consumers';
+import { pathToFileURL } from 'node:url';
+import * as React from 'react';
+import { renderToPipeableStream } from '../src/server.node';
+import { buildClientRenderer } from '../src/client.node';
+import type { BundleManifest } from '../src/types';
+import { compile, cleanupOutputDirs, entryEndingWith, type CompileResult } from './webpack-plugin/helpers/compile';
+
+const { registerClientReference } = require('react-server-dom-webpack/server.node') as {
+  registerClientReference: (impl: () => never, id: string, exportName: string) => unknown;
+};
+
+jest.setTimeout(180_000);
+
+const FIXTURE = 'rsc-css-auto';
+const fixtureUrl = (file: string): string =>
+  pathToFileURL(path.join(__dirname, 'webpack-plugin/fixtures', FIXTURE, file)).href;
+
+const created: CompileResult[] = [];
+let client: CompileResult;
+let server: CompileResult;
+
+const common = { chunkName: 'client-[request]', withCss: true, publicPath: '/assets/', cssWrapper: true } as const;
+
+beforeAll(() => {
+  client = compile(FIXTURE, { ...common });
+  created.push(client);
+  server = compile(FIXTURE, {
+    ...common,
+    isServer: true,
+    exposeClientRuntime: true,
+    outputExtra: { library: { type: 'commonjs2' } },
+  });
+  created.push(server);
+});
+
+afterAll(() => cleanupOutputDirs(created));
+
+describe('cssWrapper auto-generation (real webpack)', () => {
+  it('records the component CSS and injects the href global into the runtime bundle', () => {
+    const styled = entryEndingWith(client.manifest, '/Styled.js');
+    expect(styled.css && styled.css.length).toBeGreaterThan(0);
+    const main = fs.readFileSync(path.join(client.outputPath, 'main.js'), 'utf8');
+    // The plugin injected the CSS-href global keyed by the client module's file URL.
+    expect(main).toContain('__RSC_CSS_HREFS__');
+    expect(main).toContain(fixtureUrl('Styled.js'));
+    expect(main).toContain(styled.css![0]!);
+  });
+
+  it('resolves the reference to the generated wrapper, rendering <link precedence> + component', async () => {
+    const styled = entryEndingWith(client.manifest, '/Styled.js');
+    const realCssHref = styled.css![0]!;
+
+    const Styled = registerClientReference(
+      () => {
+        throw new Error('client reference must not run on server');
+      },
+      fixtureUrl('Styled.js'),
+      'default',
+    ) as React.ComponentType<{ title: string }>;
+
+    const model = React.createElement(Styled, { title: 'Hi' });
+    const stream = renderToPipeableStream(model, client.manifest as BundleManifest);
+    const readable = new PassThrough();
+    stream.pipe(readable);
+    const payload = await text(readable);
+
+    const { ssrManifest } = buildClientRenderer(
+      client.manifest as BundleManifest,
+      server.manifest as BundleManifest,
+    );
+    fs.writeFileSync(path.join(server.outputPath, 'payload.txt'), payload);
+    fs.writeFileSync(path.join(server.outputPath, 'ssr-manifest.json'), JSON.stringify(ssrManifest));
+    fs.writeFileSync(path.join(server.outputPath, 'decode.js'), DECODE_SCRIPT);
+
+    const out = execFileSync(process.execPath, ['decode.js'], {
+      cwd: server.outputPath,
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const result = JSON.parse(out) as {
+      ok: boolean;
+      error?: string;
+      links?: Array<{ rel?: string; precedence?: string; href?: string }>;
+      text?: string;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    // The generated wrapper rendered the render-blocking stylesheet link (href from
+    // the injected global) before the component, and forwarded props.
+    expect(result.links).toEqual([{ rel: 'stylesheet', precedence: 'rsc-css', href: realCssHref }]);
+    expect(result.text).toContain('Hi');
+  });
+});
+
+const DECODE_SCRIPT = `
+'use strict';
+const fs = require('fs');
+const { Readable } = require('stream');
+const { createFromNodeStream } = require('./main.js');
+const ssrManifest = JSON.parse(fs.readFileSync('./ssr-manifest.json', 'utf8'));
+const stream = Readable.from([fs.readFileSync('./payload.txt')]);
+const LAZY = Symbol.for('react.lazy');
+const FORWARD_REF = Symbol.for('react.forward_ref');
+const MEMO = Symbol.for('react.memo');
+const resolveLazy = async (v) => (v && v.$$typeof === LAZY ? await v._payload : v);
+const links = [];
+let textOut = '';
+const walk = async (node) => {
+  node = await resolveLazy(node);
+  if (node == null || typeof node === 'boolean') return;
+  if (typeof node !== 'object') { textOut += String(node); return; }
+  if (Array.isArray(node)) { for (const c of node) await walk(c); return; }
+  if (node.$$typeof) {
+    let type = await resolveLazy(node.type);
+    if (type && type.$$typeof === MEMO) type = type.type;
+    if (type === 'link') { const p = node.props || {}; links.push({ rel: p.rel, precedence: p.precedence, href: p.href }); return; }
+    if (type && type.$$typeof === FORWARD_REF) { await walk(type.render(node.props, null)); return; }
+    if (typeof type === 'function') { await walk(type(node.props)); return; }
+    await walk(node.props && node.props.children);
+    return;
+  }
+};
+(async () => {
+  try {
+    const root = await createFromNodeStream(stream, ssrManifest);
+    await walk(root);
+    process.stdout.write(JSON.stringify({ ok: true, links, text: textOut }));
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String((e && e.stack) || e) }));
+  }
+})();
+`;

--- a/tests/rsc-css-barrel.rsc.test.ts
+++ b/tests/rsc-css-barrel.rsc.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Issue #4598 — a `'use client'` barrel that `export *`s a styled component must
+ * still wrap the re-exported component so it emits its <link precedence> (no FOUC).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { PassThrough } from 'node:stream';
+import { text } from 'node:stream/consumers';
+import { pathToFileURL } from 'node:url';
+import * as React from 'react';
+import { renderToPipeableStream } from '../src/server.node';
+import { buildClientRenderer } from '../src/client.node';
+import type { BundleManifest } from '../src/types';
+import { compile, cleanupOutputDirs, entryEndingWith, type CompileResult } from './webpack-plugin/helpers/compile';
+
+const { registerClientReference } = require('react-server-dom-webpack/server.node') as {
+  registerClientReference: (impl: () => never, id: string, exportName: string) => unknown;
+};
+
+jest.setTimeout(180_000);
+
+const FIXTURE = 'rsc-css-barrel';
+const fixtureUrl = (file: string): string =>
+  pathToFileURL(path.join(__dirname, 'webpack-plugin/fixtures', FIXTURE, file)).href;
+
+const created: CompileResult[] = [];
+let client: CompileResult;
+let server: CompileResult;
+
+const common = { chunkName: 'client-[request]', withCss: true, publicPath: '/assets/', cssWrapper: true } as const;
+
+beforeAll(() => {
+  client = compile(FIXTURE, { ...common });
+  created.push(client);
+  server = compile(FIXTURE, {
+    ...common,
+    isServer: true,
+    exposeClientRuntime: true,
+    outputExtra: { library: { type: 'commonjs2' } },
+  });
+  created.push(server);
+});
+
+afterAll(() => cleanupOutputDirs(created));
+
+it('wraps a component re-exported through an export * barrel', async () => {
+  const barrel = entryEndingWith(client.manifest, '/Barrel.client.js');
+  expect(barrel.css && barrel.css.length).toBeGreaterThan(0);
+
+  // The client reference is the barrel's re-exported `Styled` export.
+  const Styled = registerClientReference(
+    () => {
+      throw new Error('client reference must not run on server');
+    },
+    fixtureUrl('Barrel.client.js'),
+    'Styled',
+  ) as React.ComponentType<{ title: string }>;
+
+  const stream = renderToPipeableStream(React.createElement(Styled, { title: 'Hi' }), client.manifest as BundleManifest);
+  const readable = new PassThrough();
+  stream.pipe(readable);
+  const payload = await text(readable);
+
+  const { ssrManifest } = buildClientRenderer(client.manifest as BundleManifest, server.manifest as BundleManifest);
+  fs.writeFileSync(path.join(server.outputPath, 'payload.txt'), payload);
+  fs.writeFileSync(path.join(server.outputPath, 'ssr-manifest.json'), JSON.stringify(ssrManifest));
+  fs.writeFileSync(path.join(server.outputPath, 'decode.js'), DECODE_SCRIPT);
+  const out = execFileSync(process.execPath, ['decode.js'], { cwd: server.outputPath, encoding: 'utf8', timeout: 30_000 });
+  const result = JSON.parse(out) as {
+    ok: boolean;
+    error?: string;
+    links?: Array<{ rel?: string; precedence?: string; href?: string }>;
+    text?: string;
+  };
+
+  expect(result.error).toBeUndefined();
+  expect(result.ok).toBe(true);
+  expect(result.links).toEqual([{ rel: 'stylesheet', precedence: 'rsc-css', href: barrel.css![0]! }]);
+  expect(result.text).toContain('Hi');
+});
+
+const DECODE_SCRIPT = `
+'use strict';
+const fs = require('fs');
+const { Readable } = require('stream');
+const { createFromNodeStream } = require('./main.js');
+const ssrManifest = JSON.parse(fs.readFileSync('./ssr-manifest.json', 'utf8'));
+const stream = Readable.from([fs.readFileSync('./payload.txt')]);
+const LAZY = Symbol.for('react.lazy');
+const FORWARD_REF = Symbol.for('react.forward_ref');
+const MEMO = Symbol.for('react.memo');
+const resolveLazy = async (v) => (v && v.$$typeof === LAZY ? await v._payload : v);
+const links = [];
+let textOut = '';
+const walk = async (node) => {
+  node = await resolveLazy(node);
+  if (node == null || typeof node === 'boolean') return;
+  if (typeof node !== 'object') { textOut += String(node); return; }
+  if (Array.isArray(node)) { for (const c of node) await walk(c); return; }
+  if (node.$$typeof) {
+    let type = await resolveLazy(node.type);
+    if (type && type.$$typeof === MEMO) type = type.type;
+    if (type === 'link') { const p = node.props || {}; links.push({ rel: p.rel, precedence: p.precedence, href: p.href }); return; }
+    if (type && type.$$typeof === FORWARD_REF) { await walk(type.render(node.props, null)); return; }
+    if (typeof type === 'function') { await walk(type(node.props)); return; }
+    await walk(node.props && node.props.children);
+    return;
+  }
+};
+(async () => {
+  try {
+    const root = await createFromNodeStream(stream, ssrManifest);
+    await walk(root);
+    process.stdout.write(JSON.stringify({ ok: true, links, text: textOut }));
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String((e && e.stack) || e) }));
+  }
+})();
+`;

--- a/tests/rsc-css-remap.rsc.test.ts
+++ b/tests/rsc-css-remap.rsc.test.ts
@@ -1,0 +1,188 @@
+/**
+ * PROTOTYPE (issue #4598) — proves the REMAP MECHANISM on real webpack:
+ * a SEPARATE wrapper module (Foo.wrapper.js) imports the original client
+ * component (Foo.js); the generated client-reference manifest entry for Foo is
+ * remapped so Flight resolves the reference to the WRAPPER module (loaded by
+ * real webpack), which renders <link rel=stylesheet precedence=rsc-css> + the
+ * original Foo with props forwarded. The RSC reference keeps its original
+ * $$id/name, and the non-component export stays intact for ordinary imports.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { PassThrough } from 'node:stream';
+import { text } from 'node:stream/consumers';
+import { pathToFileURL } from 'node:url';
+import * as React from 'react';
+import { renderToPipeableStream } from '../src/server.node';
+import { buildClientRenderer } from '../src/client.node';
+import type { BundleManifest } from '../src/types';
+import { compile, cleanupOutputDirs, entryEndingWith, type CompileResult } from './webpack-plugin/helpers/compile';
+
+const { registerClientReference } = require('react-server-dom-webpack/server.node') as {
+  registerClientReference: (impl: () => never, id: string, exportName: string) => unknown;
+};
+
+jest.setTimeout(180_000);
+
+const FIXTURE = 'rsc-css-remap';
+const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
+const fixtureUrl = (file: string): string =>
+  pathToFileURL(path.join(__dirname, 'webpack-plugin/fixtures', FIXTURE, file)).href;
+
+const created: CompileResult[] = [];
+let client: CompileResult;
+let server: CompileResult;
+
+// Single-chunk builds so every module is in main.js and resolvable by
+// __webpack_require__(id) without async chunk loading (keeps the remap proof focused).
+const common = { chunkName: 'client-[request]', withCss: true, publicPath: '/assets/', maxChunks: 1 } as const;
+
+beforeAll(() => {
+  client = compile(FIXTURE, { ...common });
+  created.push(client);
+  server = compile(FIXTURE, {
+    ...common,
+    isServer: true,
+    exposeClientRuntime: true,
+    outputExtra: { library: { type: 'commonjs2' } },
+  });
+  created.push(server);
+});
+
+afterAll(() => cleanupOutputDirs(created));
+
+/** Find the webpack (named) module id of a module by scanning the built bundle. */
+function findModuleId(outputPath: string, suffix: string): string {
+  const main = fs.readFileSync(path.join(outputPath, 'main.js'), 'utf8');
+  // Named modules are registered as `"<id>": (\n/*...*/ ... )` — the id ends with the file path.
+  const re = new RegExp(`["']([^"']*${suffix.replace(/[.]/g, '\\.')})["']\\s*:`, 'g');
+  const ids = new Set<string>();
+  for (const m of main.matchAll(re)) ids.add(m[1]!);
+  const arr = [...ids];
+  if (arr.length === 0) throw new Error(`module id for ${suffix} not found in ${outputPath}/main.js`);
+  return arr[0]!;
+}
+
+describe('rsc css remap prototype (real webpack)', () => {
+  it('keeps the RSC reference tagged with original $$id/name', () => {
+    const Foo = registerClientReference(
+      () => {
+        throw new Error('client reference must not run on server');
+      },
+      fixtureUrl('Foo.js'),
+      'default',
+    ) as { $$typeof?: symbol; $$id?: string };
+    expect(Foo.$$typeof).toBe(CLIENT_REFERENCE_TAG);
+    expect(Foo.$$id).toBe(`${fixtureUrl('Foo.js')}#default`);
+  });
+
+  it('non-component export from the original module survives in the real client bundle', () => {
+    // The wrapper re-renders Foo but does not replace the original module: normal
+    // imports of Foo.js keep all its exports. The original module (with its
+    // non-component export value) is present verbatim in the built client bundle.
+    const main = fs.readFileSync(path.join(client.outputPath, 'main.js'), 'utf8');
+    expect(main).toContain('helper-value-42');
+  });
+
+  it('remaps BOTH manifests: wire I-row carries the wrapper id, and decode resolves the wrapper', async () => {
+    // This is the REAL remap the plugin will do at recordModule: rewrite the
+    // client + server manifest entries for the client reference to the wrapper
+    // module's id/chunks. The client-manifest id flows onto the Flight I-row
+    // (browser createFromReadableStream path) AND, via createSSRManifest joining
+    // by file URL, into the SSR moduleMap (createFromNodeStream path).
+    const clientFoo = entryEndingWith(client.manifest, '/Foo.js');
+    const serverFoo = entryEndingWith(server.manifest, '/Foo.js');
+    const realCssHref = clientFoo.css![0]!;
+    const originalClientFooId = clientFoo.id as string;
+    const wrapperClientId = findModuleId(client.outputPath, 'Foo.wrapper.js');
+    const wrapperServerId = findModuleId(server.outputPath, 'Foo.wrapper.js');
+
+    // Remap in place (single chunk => wrapper already loadable, no extra chunks).
+    clientFoo.id = wrapperClientId;
+    clientFoo.chunks = [];
+    serverFoo.id = wrapperServerId;
+    serverFoo.chunks = [];
+
+    const Foo = registerClientReference(
+      () => {
+        throw new Error('client reference must not run on server');
+      },
+      fixtureUrl('Foo.js'),
+      'default',
+    ) as React.ComponentType<{ title: string; __cssHref: string }>;
+
+    const model = React.createElement(Foo, { title: 'Hi', __cssHref: realCssHref });
+    const stream = renderToPipeableStream(model, client.manifest as BundleManifest);
+    const readable = new PassThrough();
+    stream.pipe(readable);
+    const payload = await text(readable);
+
+    // (browser path) The wire I-row metadata must carry the WRAPPER id, not the original.
+    const iRow = [...payload.matchAll(/^[0-9a-f]+:I(\[.*\])$/gm)].map(
+      (m) => JSON.parse(m[1]!) as [string, string[], string],
+    )[0];
+    expect(iRow).toBeDefined();
+    expect(iRow![0]).toBe(wrapperClientId);
+    expect(iRow![0]).not.toBe(originalClientFooId);
+
+    // (SSR-node path) Decode through the real webpack runtime + generated SSR manifest.
+    const { ssrManifest } = buildClientRenderer(
+      client.manifest as BundleManifest,
+      server.manifest as BundleManifest,
+    );
+    fs.writeFileSync(path.join(server.outputPath, 'payload.txt'), payload);
+    fs.writeFileSync(path.join(server.outputPath, 'ssr-manifest.json'), JSON.stringify(ssrManifest));
+    fs.writeFileSync(path.join(server.outputPath, 'decode.js'), DECODE_SCRIPT);
+    const out = execFileSync(process.execPath, ['decode.js'], {
+      cwd: server.outputPath,
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const result = JSON.parse(out) as {
+      ok: boolean;
+      error?: string;
+      links?: Array<{ rel?: string; precedence?: string; href?: string }>;
+      text?: string;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.links).toEqual([{ rel: 'stylesheet', precedence: 'rsc-css', href: realCssHref }]);
+    expect(result.text).toContain('Hi');
+  });
+});
+
+const DECODE_SCRIPT = `
+'use strict';
+const fs = require('fs');
+const { Readable } = require('stream');
+const { createFromNodeStream } = require('./main.js');
+const ssrManifest = JSON.parse(fs.readFileSync('./ssr-manifest.json', 'utf8'));
+const stream = Readable.from([fs.readFileSync('./payload.txt')]);
+const LAZY = Symbol.for('react.lazy');
+const resolveLazy = async (v) => (v && v.$$typeof === LAZY ? await v._payload : v);
+const links = [];
+let textOut = '';
+const walk = async (node) => {
+  node = await resolveLazy(node);
+  if (node == null || typeof node === 'boolean') return;
+  if (typeof node !== 'object') { textOut += String(node); return; }
+  if (Array.isArray(node)) { for (const c of node) await walk(c); return; }
+  if (node.$$typeof) {
+    const type = await resolveLazy(node.type);
+    if (type === 'link') { const p = node.props || {}; links.push({ rel: p.rel, precedence: p.precedence, href: p.href }); return; }
+    if (typeof type === 'function') { await walk(type(node.props)); return; }
+    await walk(node.props && node.props.children);
+    return;
+  }
+};
+(async () => {
+  try {
+    const root = await createFromNodeStream(stream, ssrManifest);
+    await walk(root);
+    process.stdout.write(JSON.stringify({ ok: true, links, text: textOut }));
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String((e && e.stack) || e) }));
+  }
+})();
+`;

--- a/tests/rsc-css-shapes.rsc.test.ts
+++ b/tests/rsc-css-shapes.rsc.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Issue #4598 — real-webpack coverage for the loader's __rscWrap across export
+ * shapes, and for the injected href global across multiple runtime chunks.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { PassThrough } from 'node:stream';
+import { text } from 'node:stream/consumers';
+import { pathToFileURL } from 'node:url';
+import * as React from 'react';
+import { renderToPipeableStream } from '../src/server.node';
+import { buildClientRenderer } from '../src/client.node';
+import type { BundleManifest } from '../src/types';
+import { compile, cleanupOutputDirs, entryEndingWith, type CompileResult } from './webpack-plugin/helpers/compile';
+
+const { registerClientReference } = require('react-server-dom-webpack/server.node') as {
+  registerClientReference: (impl: () => never, id: string, exportName: string) => unknown;
+};
+
+jest.setTimeout(180_000);
+
+const FIXTURE = 'rsc-css-shapes';
+const fixtureUrl = (file: string): string =>
+  pathToFileURL(path.join(__dirname, 'webpack-plugin/fixtures', FIXTURE, file)).href;
+
+const created: CompileResult[] = [];
+let client: CompileResult;
+let server: CompileResult;
+
+const common = { chunkName: 'client-[request]', withCss: true, publicPath: '/assets/', cssWrapper: true } as const;
+
+beforeAll(() => {
+  client = compile(FIXTURE, { ...common, extraEntries: { entry2: './entry2.js' } });
+  created.push(client);
+  server = compile(FIXTURE, {
+    ...common,
+    isServer: true,
+    exposeClientRuntime: true,
+    outputExtra: { library: { type: 'commonjs2' } },
+  });
+  created.push(server);
+});
+
+afterAll(() => cleanupOutputDirs(created));
+
+async function resolveExport(exportName: string): Promise<{
+  links: Array<{ rel?: string; precedence?: string; href?: string }>;
+  text: string;
+}> {
+  const ref = registerClientReference(
+    () => {
+      throw new Error('client reference must not run on server');
+    },
+    fixtureUrl('Shapes.js'),
+    exportName,
+  ) as React.ComponentType<{ title: string }>;
+  const stream = renderToPipeableStream(React.createElement(ref, { title: 'Hi' }), client.manifest as BundleManifest);
+  const readable = new PassThrough();
+  stream.pipe(readable);
+  const payload = await text(readable);
+  const { ssrManifest } = buildClientRenderer(client.manifest as BundleManifest, server.manifest as BundleManifest);
+  fs.writeFileSync(path.join(server.outputPath, 'payload.txt'), payload);
+  fs.writeFileSync(path.join(server.outputPath, 'ssr-manifest.json'), JSON.stringify(ssrManifest));
+  fs.writeFileSync(path.join(server.outputPath, 'decode.js'), DECODE_SCRIPT);
+  const out = execFileSync(process.execPath, ['decode.js'], { cwd: server.outputPath, encoding: 'utf8', timeout: 30_000 });
+  const result = JSON.parse(out) as { ok: boolean; error?: string; links?: []; text?: string };
+  expect(result.error).toBeUndefined();
+  expect(result.ok).toBe(true);
+  return { links: result.links ?? [], text: result.text ?? '' };
+}
+
+describe('cssWrapper export-shape + multi-runtime coverage (real webpack)', () => {
+  it('wraps a forwardRef default export (renders <link precedence>)', async () => {
+    const styled = entryEndingWith(client.manifest, '/Shapes.js');
+    const { links, text: t } = await resolveExport('default');
+    expect(links).toEqual([{ rel: 'stylesheet', precedence: 'rsc-css', href: styled.css![0]! }]);
+    expect(t).toContain('Hi');
+  });
+
+  it('wraps a memo named export (renders <link precedence>)', async () => {
+    const styled = entryEndingWith(client.manifest, '/Shapes.js');
+    const { links, text: t } = await resolveExport('MemoBox');
+    expect(links).toEqual([{ rel: 'stylesheet', precedence: 'rsc-css', href: styled.css![0]! }]);
+    expect(t).toContain('Hi');
+  });
+
+  it('injects the merging href global into every runtime chunk without clobbering', () => {
+    const key = fixtureUrl('Shapes.js');
+    for (const file of ['main.js', 'entry2.js']) {
+      const src = fs.readFileSync(path.join(client.outputPath, file), 'utf8');
+      expect(src).toContain('__RSC_CSS_HREFS__');
+      // Object.assign(...||{}, ...) => merges rather than replaces.
+      expect(src).toContain('Object.assign');
+      expect(src).toContain(key);
+    }
+  });
+});
+
+const DECODE_SCRIPT = `
+'use strict';
+const fs = require('fs');
+const { Readable } = require('stream');
+const { createFromNodeStream } = require('./main.js');
+const ssrManifest = JSON.parse(fs.readFileSync('./ssr-manifest.json', 'utf8'));
+const stream = Readable.from([fs.readFileSync('./payload.txt')]);
+const LAZY = Symbol.for('react.lazy');
+const FORWARD_REF = Symbol.for('react.forward_ref');
+const MEMO = Symbol.for('react.memo');
+const resolveLazy = async (v) => (v && v.$$typeof === LAZY ? await v._payload : v);
+const links = [];
+let textOut = '';
+const walk = async (node) => {
+  node = await resolveLazy(node);
+  if (node == null || typeof node === 'boolean') return;
+  if (typeof node !== 'object') { textOut += String(node); return; }
+  if (Array.isArray(node)) { for (const c of node) await walk(c); return; }
+  if (node.$$typeof) {
+    let type = await resolveLazy(node.type);
+    if (type && type.$$typeof === MEMO) type = type.type;
+    if (type === 'link') { const p = node.props || {}; links.push({ rel: p.rel, precedence: p.precedence, href: p.href }); return; }
+    if (type && type.$$typeof === FORWARD_REF) { await walk(type.render(node.props, null)); return; }
+    if (typeof type === 'function') { await walk(type(node.props)); return; }
+    await walk(node.props && node.props.children);
+    return;
+  }
+};
+(async () => {
+  try {
+    const root = await createFromNodeStream(stream, ssrManifest);
+    await walk(root);
+    process.stdout.write(JSON.stringify({ ok: true, links, text: textOut }));
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String((e && e.stack) || e) }));
+  }
+})();
+`;

--- a/tests/rsc-css-wrapper-proto.rsc.test.ts
+++ b/tests/rsc-css-wrapper-proto.rsc.test.ts
@@ -1,0 +1,161 @@
+/**
+ * PROTOTYPE (issue #4598): proves on a REAL webpack RSC build that a client
+ * component which renders its own <link rel="stylesheet" precedence="rsc-css">
+ * (i.e. the OUTPUT of the planned CSS wrapper) works end-to-end:
+ *   - RSC build turns it into a tagged client reference (body never runs on server);
+ *   - client/SSR build compiles the real component;
+ *   - Flight encode -> decode through the GENERATED manifests + REAL webpack chunk
+ *     loading resolves the component, which renders the <link> with the real
+ *     manifest CSS href, with props forwarded;
+ *   - the non-component named export is unaffected.
+ * (React's actual FOUC blocking on such a <link> is already proven separately.)
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { PassThrough } from 'node:stream';
+import { text } from 'node:stream/consumers';
+import { pathToFileURL } from 'node:url';
+import * as React from 'react';
+import { renderToPipeableStream } from '../src/server.node';
+import { buildClientRenderer } from '../src/client.node';
+import type { BundleManifest } from '../src/types';
+import { compile, cleanupOutputDirs, entryEndingWith, type CompileResult } from './webpack-plugin/helpers/compile';
+
+const { registerClientReference } = require('react-server-dom-webpack/server.node') as {
+  registerClientReference: (impl: () => never, id: string, exportName: string) => unknown;
+};
+
+jest.setTimeout(180_000);
+
+const FIXTURE = 'rsc-css-proto';
+const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
+const fixtureUrl = (file: string): string =>
+  pathToFileURL(path.join(__dirname, 'webpack-plugin/fixtures', FIXTURE, file)).href;
+
+const created: CompileResult[] = [];
+let client: CompileResult;
+let server: CompileResult;
+
+beforeAll(() => {
+  client = compile(FIXTURE, { chunkName: 'client-[request]', withCss: true, publicPath: '/assets/' });
+  created.push(client);
+  server = compile(FIXTURE, {
+    isServer: true,
+    chunkName: 'client-[request]',
+    withCss: true,
+    publicPath: '/assets/',
+    exposeClientRuntime: true,
+    outputExtra: { library: { type: 'commonjs2' } },
+  });
+  created.push(server);
+});
+
+afterAll(() => cleanupOutputDirs(created));
+
+describe('rsc css wrapper prototype (real webpack)', () => {
+  it('records the client component CSS in the generated manifest', () => {
+    const styled = entryEndingWith(client.manifest, '/Styled.js');
+    expect(styled.css && styled.css.length).toBeGreaterThan(0);
+    expect(styled.css![0]).toMatch(/\.css$/);
+  });
+
+  it('keeps the client reference tagged on the RSC server', () => {
+    const Styled = registerClientReference(
+      () => {
+        throw new Error('client reference must not run on server');
+      },
+      fixtureUrl('Styled.js'),
+      'default',
+    ) as { $$typeof?: symbol };
+    expect(Styled.$$typeof).toBe(CLIENT_REFERENCE_TAG);
+  });
+
+  it('decodes through real webpack and renders the <link precedence> + forwarded props', async () => {
+    const styled = entryEndingWith(client.manifest, '/Styled.js');
+    const realCssHref = styled.css![0]!;
+
+    const Styled = registerClientReference(
+      () => {
+        throw new Error('client reference must not run on server');
+      },
+      fixtureUrl('Styled.js'),
+      'default',
+    ) as React.ComponentType<{ title: string; cssHref: string }>;
+
+    const model = React.createElement(Styled, { title: 'Hi', cssHref: realCssHref });
+    const stream = renderToPipeableStream(model, client.manifest as BundleManifest);
+    const readable = new PassThrough();
+    stream.pipe(readable);
+    const payload = await text(readable);
+
+    const { ssrManifest } = buildClientRenderer(
+      client.manifest as BundleManifest,
+      server.manifest as BundleManifest,
+    );
+    fs.writeFileSync(path.join(server.outputPath, 'payload.txt'), payload);
+    fs.writeFileSync(path.join(server.outputPath, 'ssr-manifest.json'), JSON.stringify(ssrManifest));
+    fs.writeFileSync(path.join(server.outputPath, 'decode.js'), DECODE_SCRIPT);
+
+    const out = execFileSync(process.execPath, ['decode.js'], {
+      cwd: server.outputPath,
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const result = JSON.parse(out) as {
+      ok: boolean;
+      error?: string;
+      links?: Array<{ rel?: string; precedence?: string; href?: string }>;
+      text?: string;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    // The client component, loaded via REAL webpack chunk loading, rendered its
+    // <link rel="stylesheet" precedence="rsc-css" href={realManifestCss}>.
+    expect(result.links).toEqual([
+      { rel: 'stylesheet', precedence: 'rsc-css', href: realCssHref },
+    ]);
+    // Props forwarded through the reference resolution.
+    expect(result.text).toContain('Hi');
+  });
+});
+
+const DECODE_SCRIPT = `
+'use strict';
+const fs = require('fs');
+const { Readable } = require('stream');
+const { createFromNodeStream } = require('./main.js');
+const ssrManifest = JSON.parse(fs.readFileSync('./ssr-manifest.json', 'utf8'));
+const stream = Readable.from([fs.readFileSync('./payload.txt')]);
+const LAZY = Symbol.for('react.lazy');
+const resolveLazy = async (v) => (v && v.$$typeof === LAZY ? await v._payload : v);
+const links = [];
+let textOut = '';
+const walk = async (node) => {
+  node = await resolveLazy(node);
+  if (node == null || typeof node === 'boolean') return;
+  if (typeof node !== 'object') { textOut += String(node); return; }
+  if (Array.isArray(node)) { for (const c of node) await walk(c); return; }
+  if (node.$$typeof) {
+    const type = await resolveLazy(node.type);
+    if (type === 'link') {
+      const p = node.props || {};
+      links.push({ rel: p.rel, precedence: p.precedence, href: p.href });
+      return;
+    }
+    if (typeof type === 'function') { await walk(type(node.props)); return; }
+    await walk(node.props && node.props.children);
+    return;
+  }
+};
+(async () => {
+  try {
+    const root = await createFromNodeStream(stream, ssrManifest);
+    await walk(root);
+    process.stdout.write(JSON.stringify({ ok: true, links, text: textOut }));
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String((e && e.stack) || e) }));
+  }
+})();
+`;

--- a/tests/rspack-plugin/fixtures/rsc-css-auto/Styled.css
+++ b/tests/rspack-plugin/fixtures/rsc-css-auto/Styled.css
@@ -1,0 +1,1 @@
+.exp-box { --sentinel: styled; background-color: rgb(0, 128, 0); }

--- a/tests/rspack-plugin/fixtures/rsc-css-auto/Styled.js
+++ b/tests/rspack-plugin/fixtures/rsc-css-auto/Styled.js
@@ -1,0 +1,7 @@
+'use client';
+import * as React from 'react';
+import './Styled.css';
+export default function Styled(props) {
+  return React.createElement('div', { id: 'box', className: 'exp-box' }, props.title);
+}
+export const HELPER_CONSTANT = 'helper-value-42';

--- a/tests/rspack-plugin/fixtures/rsc-css-auto/index.js
+++ b/tests/rspack-plugin/fixtures/rsc-css-auto/index.js
@@ -1,0 +1,1 @@
+export const app = 'rsc-css-auto';

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -25,6 +25,8 @@ export interface CompileOptions {
   crossOriginLoading?: false | 'anonymous' | 'use-credentials';
   clientReferences?: unknown;
   withCss?: boolean;
+  cssWrapper?: boolean;
+  chunkName?: string;
   /** Applies rspack.optimize.LimitChunkCountPlugin({ maxChunks }). */
   maxChunks?: number;
   outputFilename?: string;
@@ -122,6 +124,8 @@ const compileInto = (
     publicPath: options.publicPath,
     crossOriginLoading: options.crossOriginLoading,
     withCss: options.withCss,
+    cssWrapper: options.cssWrapper,
+    chunkName: options.chunkName,
     maxChunks: options.maxChunks,
     outputFilename: options.outputFilename,
     outputChunkFilename: options.outputChunkFilename,

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -53,6 +53,8 @@ const {
   publicPath,
   crossOriginLoading,
   withCss,
+  cssWrapper,
+  chunkName,
   maxChunks,
   outputFilename,
   outputChunkFilename,
@@ -91,6 +93,8 @@ const plugins = [
     clientReferenceDiagnosticsFilename: clientReferenceDiagnosticsFilename,
     entryClientReferencesFilename: entryClientReferencesFilename,
     clientReferences: clientReferences,
+    cssWrapper: cssWrapper,
+    ...(chunkName ? { chunkName } : {}),
   }),
 ];
 if (withCss) {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -21,8 +21,7 @@ const run = (fixture: string, options?: Parameters<typeof compile>[1]): CompileR
   return r;
 };
 
-type ManifestChunks =
-  CompileResult['manifest']['filePathToModuleMetadata'][string]['chunks'];
+type ManifestChunks = CompileResult['manifest']['filePathToModuleMetadata'][string]['chunks'];
 
 // Manifest chunks are encoded as [id, file, id, file, ...].
 const manifestChunkFiles = (chunks: ManifestChunks): string[] =>
@@ -30,7 +29,7 @@ const manifestChunkFiles = (chunks: ManifestChunks): string[] =>
 
 const readDiagnosticCss = (result: CompileResult, entryFileSuffix: string): string => {
   const entry = result.clientReferenceDiagnostics?.clientReferences.find((reference) =>
-    reference.file.endsWith(entryFileSuffix),
+    reference.file.endsWith(entryFileSuffix)
   );
   expect(entry).toBeTruthy();
   return (entry!.css ?? [])
@@ -43,10 +42,10 @@ const readDiagnosticCss = (result: CompileResult, entryFileSuffix: string): stri
 
 const manifestMetadataFor = (
   result: CompileResult,
-  entryFileSuffix: string,
+  entryFileSuffix: string
 ): CompileResult['manifest']['filePathToModuleMetadata'][string] => {
   const entry = Object.entries(result.manifest.filePathToModuleMetadata).find(([file]) =>
-    file.endsWith(entryFileSuffix),
+    file.endsWith(entryFileSuffix)
   );
   expect(entry).toBeTruthy();
   return entry![1];
@@ -131,21 +130,16 @@ afterAll(() => cleanupOutputDirs(created));
 const DIST_PLUGIN = path.resolve(__dirname, '../../dist/react-server-dom-rspack/plugin.js');
 const DIST_INJECTION_LOADER = path.resolve(
   __dirname,
-  '../../dist/react-server-dom-rspack/injection-loader.js',
+  '../../dist/react-server-dom-rspack/injection-loader.js'
 );
-const DIST_RSPACK_LOADER = path.resolve(
-  __dirname,
-  '../../dist/react-server-dom-rspack/loader.js',
-);
+const DIST_RSPACK_LOADER = path.resolve(__dirname, '../../dist/react-server-dom-rspack/loader.js');
 const MULTICOMPILER_CHILD_TIMEOUT_MS = 30_000;
 const MULTICOMPILER_JEST_TIMEOUT_MS = MULTICOMPILER_CHILD_TIMEOUT_MS + 5_000;
 
 describe('RSCRspackPlugin', () => {
   beforeAll(() => {
     if (!fs.existsSync(DIST_PLUGIN)) {
-      throw new Error(
-        `Precondition: ${DIST_PLUGIN} does not exist. Run \`yarn build\` first.`,
-      );
+      throw new Error(`Precondition: ${DIST_PLUGIN} does not exist. Run \`yarn build\` first.`);
     }
   });
 
@@ -223,7 +217,7 @@ describe('RSCRspackPlugin', () => {
 
       expect(result.assets).toContain('vendors-app.js');
       const tinyKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('/TinyIsland.js'),
+        p.endsWith('/TinyIsland.js')
       );
       expect(tinyKey).toBeTruthy();
       const tiny = result.manifest.filePathToModuleMetadata[tinyKey!]!;
@@ -252,7 +246,7 @@ describe('RSCRspackPlugin', () => {
       expect(heavyEntry.chunks).toHaveLength(1);
       expect(heavyEntry.chunks[0]!.bytes).toBeGreaterThan(0);
       expect(heavyEntry.totalBytes).toBeGreaterThan(
-        tinyResult.clientReferenceDiagnostics!.clientReferences[0]!.totalBytes,
+        tinyResult.clientReferenceDiagnostics!.clientReferences[0]!.totalBytes
       );
       expect(heavyResult.clientReferenceDiagnostics?.totalChunkBytes).toBe(heavyEntry.totalBytes);
     });
@@ -267,8 +261,8 @@ describe('RSCRspackPlugin', () => {
 
       expect(result.assets).toContain('client0.chunk.css');
 
-      const manifestEntry = Object.entries(result.manifest.filePathToModuleMetadata).find(([file]) =>
-        file.endsWith('/StyledIsland.js'),
+      const manifestEntry = Object.entries(result.manifest.filePathToModuleMetadata).find(
+        ([file]) => file.endsWith('/StyledIsland.js')
       )?.[1];
       expect(manifestEntry?.css).toEqual(['/assets/client0.chunk.css']);
 
@@ -281,7 +275,7 @@ describe('RSCRspackPlugin', () => {
         },
       ]);
       expect(diagnosticEntry.totalBytes).toBe(
-        diagnosticEntry.chunks[0]!.bytes! + diagnosticEntry.css![0]!.bytes!,
+        diagnosticEntry.chunks[0]!.bytes! + diagnosticEntry.css![0]!.bytes!
       );
       expect(result.clientReferenceDiagnostics?.totalChunkBytes).toBe(diagnosticEntry.totalBytes);
     });
@@ -289,7 +283,7 @@ describe('RSCRspackPlugin', () => {
     it("does not attach an importing island's CSS to an imported client reference", () => {
       const result = run('static-islands', {
         clientReferences: staticIslandClientReferences(
-          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/
         ),
         clientReferenceDiagnosticsFilename: diagnosticsFilename,
         publicPath: '/assets',
@@ -307,7 +301,7 @@ describe('RSCRspackPlugin', () => {
     it("scopes manifest CSS to the referenced island's chunk group when diagnostics are disabled", () => {
       const result = run('static-islands', {
         clientReferences: staticIslandClientReferences(
-          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/
         ),
         publicPath: '/assets',
         withCss: true,
@@ -347,9 +341,7 @@ describe('RSCRspackPlugin', () => {
       });
 
       expect(result.assets).toContain('styles.chunk.css');
-      expect(manifestMetadataFor(result, '/Button.js').css).toEqual([
-        '/assets/styles.chunk.css',
-      ]);
+      expect(manifestMetadataFor(result, '/Button.js').css).toEqual(['/assets/styles.chunk.css']);
       expect(readManifestCss(result, '/Button.js')).toContain('.panel');
     });
 
@@ -402,10 +394,10 @@ describe('RSCRspackPlugin', () => {
 
       const cssFiles = manifestMetadataFor(result, '/MixedStyledIsland.js').css ?? [];
       expect(result.assets).toEqual(
-        expect.arrayContaining(['client0.chunk.css', 'styles.chunk.css']),
+        expect.arrayContaining(['client0.chunk.css', 'styles.chunk.css'])
       );
       expect(cssFiles).toEqual(
-        expect.arrayContaining(['/assets/client0.chunk.css', '/assets/styles.chunk.css']),
+        expect.arrayContaining(['/assets/client0.chunk.css', '/assets/styles.chunk.css'])
       );
       expect(cssFiles).toHaveLength(2);
 
@@ -418,7 +410,7 @@ describe('RSCRspackPlugin', () => {
       const result = run('static-islands', {
         isServer: true,
         clientReferences: staticIslandClientReferences(
-          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/
         ),
         clientReferenceDiagnosticsFilename: diagnosticsFilename,
         publicPath: '/assets',
@@ -438,7 +430,7 @@ describe('RSCRspackPlugin', () => {
       const result = run('static-islands', {
         isServer: true,
         clientReferences: staticIslandClientReferences(
-          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/,
+          /^\.\/(?:ParentStyledIsland|StyledIsland)\.js$/
         ),
         clientReferenceDiagnosticsFilename: diagnosticsFilename,
         publicPath: '/assets',
@@ -493,9 +485,7 @@ describe('RSCRspackPlugin', () => {
 
     it("attaches a shared async chunk's CSS to every referencing client reference", () => {
       const result = run('split-shared-css', {
-        clientReferences: staticIslandClientReferences(
-          /^\.\/(?:Button|SettingsPage)\.js$/,
-        ),
+        clientReferences: staticIslandClientReferences(/^\.\/(?:Button|SettingsPage)\.js$/),
         publicPath: '/assets',
         withCss: true,
         configExtra: sharedJsCssSplit,
@@ -520,23 +510,17 @@ describe('RSCRspackPlugin', () => {
       // regression. (Compilation-global, so conservative for a `main`-only
       // page — a documented known limitation, no worse than the old guard.)
       const result = run('split-shared-css', {
-        clientReferences: staticIslandClientReferences(
-          /^\.\/(?:Button|SettingsPage)\.js$/,
-        ),
+        clientReferences: staticIslandClientReferences(/^\.\/(?:Button|SettingsPage)\.js$/),
         publicPath: '/assets',
         withCss: true,
         extraEntries: { vendor: './vendorEntry.js' },
         configExtra: sharedJsCssSplit,
       });
 
-      const sharedCssAsset = result.assets.find(
-        (asset) => /^shared(\.chunk)?\.css$/.test(asset),
-      );
+      const sharedCssAsset = result.assets.find((asset) => /^shared(\.chunk)?\.css$/.test(asset));
       expect(sharedCssAsset).toBeTruthy();
       const sharedCssUrl = `/assets/${sharedCssAsset!}`;
-      const sharedJsAsset = result.assets.find(
-        (asset) => /^shared(\.chunk)?\.js$/.test(asset),
-      );
+      const sharedJsAsset = result.assets.find((asset) => /^shared(\.chunk)?\.js$/.test(asset));
       expect(sharedJsAsset).toBeTruthy();
       const button = manifestMetadataFor(result, '/Button.js');
       const settings = manifestMetadataFor(result, '/SettingsPage.js');
@@ -650,7 +634,7 @@ describe('RSCRspackPlugin', () => {
     it('excludes default initial entry chunks for statically imported client references', () => {
       const result = run('basic-client');
       const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientButton.js'),
+        p.endsWith('ClientButton.js')
       );
       expect(key).toBeTruthy();
 
@@ -675,14 +659,14 @@ describe('RSCRspackPlugin', () => {
         },
       });
       const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientButton.js'),
+        p.endsWith('ClientButton.js')
       );
       expect(key).toBeTruthy();
 
       const entry = result.manifest.filePathToModuleMetadata[key!]!;
       const chunkFiles = manifestChunkFiles(entry.chunks);
       const initialAssets = new Set<string>(
-        result.assets.filter((asset) => asset === 'main.js' || asset === 'runtime.js'),
+        result.assets.filter((asset) => asset === 'main.js' || asset === 'runtime.js')
       );
 
       expect(entry.id).toBe('./ClientButton.js');
@@ -715,7 +699,7 @@ describe('RSCRspackPlugin', () => {
         },
       });
       const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientWidget.js'),
+        p.endsWith('ClientWidget.js')
       );
       expect(key).toBeTruthy();
 
@@ -893,7 +877,7 @@ describe('RSCRspackPlugin', () => {
       injectionLoader: { default?: unknown },
       compiler: object | undefined,
       source = 'runtime();',
-      context: { emitWarning?: (warning: Error) => void } = {},
+      context: { emitWarning?: (warning: Error) => void } = {}
     ): string => {
       const loader = (injectionLoader.default ?? injectionLoader) as (
         this: {
@@ -901,23 +885,25 @@ describe('RSCRspackPlugin', () => {
           _compiler?: object;
           emitWarning?: (warning: Error) => void;
         },
-        source: string,
+        source: string
       ) => string;
 
       return loader.call({ cacheable: jest.fn(), _compiler: compiler, ...context }, source);
     };
 
-    it('keeps client-reference injection scoped in a real rspack MultiCompiler build', () => {
-      const outputRoot = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'ror-rsc-rspack-plugin-multicompiler-'),
-      );
+    it(
+      'keeps client-reference injection scoped in a real rspack MultiCompiler build',
+      () => {
+        const outputRoot = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'ror-rsc-rspack-plugin-multicompiler-')
+        );
 
-      try {
-        const firstOutput = path.join(outputRoot, 'first');
-        const secondOutput = path.join(outputRoot, 'second');
-        const runtimeEntry = path.resolve(__dirname, '../../dist/client.browser.js');
-        const staticIslandsFixture = path.resolve(__dirname, 'fixtures/static-islands');
-        const script = `
+        try {
+          const firstOutput = path.join(outputRoot, 'first');
+          const secondOutput = path.join(outputRoot, 'second');
+          const runtimeEntry = path.resolve(__dirname, '../../dist/client.browser.js');
+          const staticIslandsFixture = path.resolve(__dirname, 'fixtures/static-islands');
+          const script = `
           const fs = require('fs');
           const path = require('path');
           const { rspack } = require('@rspack/core');
@@ -1023,50 +1009,55 @@ describe('RSCRspackPlugin', () => {
           });
         `;
 
-        let raw: string;
-        try {
-          raw = execFileSync(process.execPath, ['-e', script], {
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'pipe'],
-            timeout: MULTICOMPILER_CHILD_TIMEOUT_MS,
-          });
-        } catch (error) {
-          const childError = error as Error & { stdout?: string | Buffer; stderr?: string | Buffer };
-          const stdout = childError.stdout?.toString() ?? '';
-          const stderr = childError.stderr?.toString() ?? '';
-          throw new Error(
-            [
-              `rspack MultiCompiler child process failed: ${childError.message}`,
-              stdout && `stdout:\n${stdout}`,
-              stderr && `stderr:\n${stderr}`,
-            ]
-              .filter(Boolean)
-              .join('\n\n'),
-          );
-        }
-        const result = JSON.parse(raw) as {
-          ok: true;
-          first: { assets: string[]; manifest: CompileResult['manifest'] };
-          second: { assets: string[]; manifest: CompileResult['manifest'] };
-          warnings: string[];
-        };
-        const firstFiles = Object.keys(result.first.manifest.filePathToModuleMetadata);
-        const secondFiles = Object.keys(result.second.manifest.filePathToModuleMetadata);
+          let raw: string;
+          try {
+            raw = execFileSync(process.execPath, ['-e', script], {
+              encoding: 'utf8',
+              stdio: ['ignore', 'pipe', 'pipe'],
+              timeout: MULTICOMPILER_CHILD_TIMEOUT_MS,
+            });
+          } catch (error) {
+            const childError = error as Error & {
+              stdout?: string | Buffer;
+              stderr?: string | Buffer;
+            };
+            const stdout = childError.stdout?.toString() ?? '';
+            const stderr = childError.stderr?.toString() ?? '';
+            throw new Error(
+              [
+                `rspack MultiCompiler child process failed: ${childError.message}`,
+                stdout && `stdout:\n${stdout}`,
+                stderr && `stderr:\n${stderr}`,
+              ]
+                .filter(Boolean)
+                .join('\n\n')
+            );
+          }
+          const result = JSON.parse(raw) as {
+            ok: true;
+            first: { assets: string[]; manifest: CompileResult['manifest'] };
+            second: { assets: string[]; manifest: CompileResult['manifest'] };
+            warnings: string[];
+          };
+          const firstFiles = Object.keys(result.first.manifest.filePathToModuleMetadata);
+          const secondFiles = Object.keys(result.second.manifest.filePathToModuleMetadata);
 
-        expect(result.ok).toBe(true);
-        expect(result.warnings.join('\n')).not.toContain('RSCRspackPlugin injection loader');
-        expect(firstFiles.some((file) => file.endsWith('/TinyIsland.js'))).toBe(true);
-        expect(firstFiles.join('\n')).not.toContain('/HeavyIsland.js');
-        expect(secondFiles.some((file) => file.endsWith('/HeavyIsland.js'))).toBe(true);
-        expect(secondFiles.join('\n')).not.toContain('/TinyIsland.js');
-        expect(result.first.assets).toContain('first-0.chunk.js');
-        expect(result.first.assets).not.toContain('second-0.chunk.js');
-        expect(result.second.assets).toContain('second-0.chunk.js');
-        expect(result.second.assets).not.toContain('first-0.chunk.js');
-      } finally {
-        fs.rmSync(outputRoot, { recursive: true, force: true });
-      }
-    }, MULTICOMPILER_JEST_TIMEOUT_MS);
+          expect(result.ok).toBe(true);
+          expect(result.warnings.join('\n')).not.toContain('RSCRspackPlugin injection loader');
+          expect(firstFiles.some((file) => file.endsWith('/TinyIsland.js'))).toBe(true);
+          expect(firstFiles.join('\n')).not.toContain('/HeavyIsland.js');
+          expect(secondFiles.some((file) => file.endsWith('/HeavyIsland.js'))).toBe(true);
+          expect(secondFiles.join('\n')).not.toContain('/TinyIsland.js');
+          expect(result.first.assets).toContain('first-0.chunk.js');
+          expect(result.first.assets).not.toContain('second-0.chunk.js');
+          expect(result.second.assets).toContain('second-0.chunk.js');
+          expect(result.second.assets).not.toContain('first-0.chunk.js');
+        } finally {
+          fs.rmSync(outputRoot, { recursive: true, force: true });
+        }
+      },
+      MULTICOMPILER_JEST_TIMEOUT_MS
+    );
 
     it('scopes injected files and chunk names to the loader compiler context', () => {
       const injectionLoader = require(DIST_INJECTION_LOADER);
@@ -1087,12 +1078,12 @@ describe('RSCRspackPlugin', () => {
       expect(secondSource).toContain('webpackChunkName: "second-0"');
       expect(secondSource).toContain(JSON.stringify(secondFile));
       expect(secondSource).not.toContain(JSON.stringify(firstFile));
-      expect(
-        Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(firstCompiler)),
-      ).toEqual(['first-0']);
-      expect(
-        Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(secondCompiler)),
-      ).toEqual(['second-0']);
+      expect(Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(firstCompiler))).toEqual([
+        'first-0',
+      ]);
+      expect(Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(secondCompiler))).toEqual(
+        ['second-0']
+      );
     });
 
     it('keeps legacy fallback state populated when the loader has no compiler context', () => {
@@ -1121,7 +1112,7 @@ describe('RSCRspackPlugin', () => {
 
         expect(emitWarning).toHaveBeenCalledTimes(1);
         expect((emitWarning.mock.calls[0]![0] as Error).message).toContain(
-          'without a compiler context',
+          'without a compiler context'
         );
       });
     });
@@ -1145,11 +1136,11 @@ describe('RSCRspackPlugin', () => {
 
       expect(firstEmitWarning).toHaveBeenCalledTimes(1);
       expect((firstEmitWarning.mock.calls[0]![0] as Error).message).toContain(
-        'unknown compiler context',
+        'unknown compiler context'
       );
       expect(secondEmitWarning).toHaveBeenCalledTimes(1);
       expect((secondEmitWarning.mock.calls[0]![0] as Error).message).toContain(
-        'unknown compiler context',
+        'unknown compiler context'
       );
     });
 
@@ -1221,14 +1212,14 @@ describe('RSCRspackPlugin', () => {
         name?: string;
         canBeInitial?: () => boolean;
       }) => boolean;
-      expect(chunksCapturedByRspackOptionsApply({ name: 'client0', canBeInitial: () => false })).toBe(
-        false,
-      );
       expect(
-        chunksCapturedByRspackOptionsApply({ name: 'client99', canBeInitial: () => false }),
+        chunksCapturedByRspackOptionsApply({ name: 'client0', canBeInitial: () => false })
+      ).toBe(false);
+      expect(
+        chunksCapturedByRspackOptionsApply({ name: 'client99', canBeInitial: () => false })
       ).toBe(true);
       expect(chunksCapturedByRspackOptionsApply({ name: 'main', canBeInitial: () => true })).toBe(
-        true,
+        true
       );
     });
 
@@ -1241,15 +1232,15 @@ describe('RSCRspackPlugin', () => {
       expect(jsAssets.filter((asset) => /vendors|biglib|clientlib/.test(asset))).toEqual([]);
 
       const clientEntryKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientWidget.js'),
+        p.endsWith('ClientWidget.js')
       );
       expect(clientEntryKey).toBeTruthy();
 
       const clientChunkFiles = manifestChunkFiles(
-        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks,
+        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks
       );
       expect(clientChunkFiles).toEqual(
-        expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)]),
+        expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)])
       );
       expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
     });
@@ -1284,15 +1275,15 @@ describe('RSCRspackPlugin', () => {
       expect(jsAssets.filter((asset) => /vendors|biglib|clientlib/.test(asset))).toEqual([]);
 
       const clientEntryKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientWidget.js'),
+        p.endsWith('ClientWidget.js')
       );
       expect(clientEntryKey).toBeTruthy();
 
       const clientChunkFiles = manifestChunkFiles(
-        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks,
+        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks
       );
       expect(clientChunkFiles).toEqual(
-        expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)]),
+        expect.arrayContaining([expect.stringMatching(/^client\d+\.chunk\.js$/)])
       );
       expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
     });
@@ -1323,12 +1314,12 @@ describe('RSCRspackPlugin', () => {
       expect(jsAssets).toContain('vendors-biglib.js');
 
       const clientEntryKey = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientWidget.js'),
+        p.endsWith('ClientWidget.js')
       );
       expect(clientEntryKey).toBeTruthy();
 
       const clientChunkFiles = manifestChunkFiles(
-        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks,
+        result.manifest.filePathToModuleMetadata[clientEntryKey!]!.chunks
       );
       expect(clientChunkFiles.filter((file) => /vendors|clientlib/.test(file))).toEqual([]);
     });
@@ -1350,7 +1341,7 @@ describe('RSCRspackPlugin', () => {
           compilation: unknown,
           bundler: unknown,
           diagnosticsCssFiles: Map<string, string[]>,
-          resolvedClientFiles: ReadonlySet<string>,
+          resolvedClientFiles: ReadonlySet<string>
         ) => {
           manifest: { moduleLoading: { prefix: string } };
           clientRuntimeFound: boolean;
@@ -1367,13 +1358,13 @@ describe('RSCRspackPlugin', () => {
         },
         { WebpackError: Error },
         new Map(),
-        new Set(),
+        new Set()
       );
 
       expect(clientRuntimeFound).toBe(false);
       expect(manifest.moduleLoading.prefix).toBe('');
       expect(warnings.map((warning) => warning.message).join('\n')).toContain(
-        'output.publicPath is a function',
+        'output.publicPath is a function'
       );
     });
 
@@ -1381,9 +1372,7 @@ describe('RSCRspackPlugin', () => {
       const result = run('basic-client', {
         publicPath: 'https://cdn.example.com/packs/',
       });
-      expect(result.manifest.moduleLoading.prefix).toBe(
-        'https://cdn.example.com/packs/',
-      );
+      expect(result.manifest.moduleLoading.prefix).toBe('https://cdn.example.com/packs/');
     });
 
     it('uses empty string when publicPath is unset (default)', () => {
@@ -1499,13 +1488,11 @@ describe('RSCRspackPlugin', () => {
         },
       });
       const key = Object.keys(result.manifest.filePathToModuleMetadata).find((p) =>
-        p.endsWith('ClientButton.js'),
+        p.endsWith('ClientButton.js')
       );
       expect(key).toBeTruthy();
 
-      const chunkFiles = manifestChunkFiles(
-        result.manifest.filePathToModuleMetadata[key!]!.chunks,
-      );
+      const chunkFiles = manifestChunkFiles(result.manifest.filePathToModuleMetadata[key!]!.chunks);
       expect(chunkFiles).toEqual(['main.mjs']);
       expect(chunkFiles).not.toContain('runtime.mjs');
     });
@@ -1550,7 +1537,7 @@ describe('RSCRspackPlugin', () => {
           new RSCRspackPlugin({
             isServer: false,
             clientManifestFilename: 'custom.json',
-          }),
+          })
       ).not.toThrow();
     });
 
@@ -1577,11 +1564,9 @@ describe('RSCRspackPlugin', () => {
       const ruleLoaders = rules.flatMap((rule: { use?: unknown }) =>
         Array.isArray(rule.use)
           ? rule.use.map((entry) =>
-              typeof entry === 'string'
-                ? entry
-                : (entry as { loader?: string } | undefined)?.loader,
+              typeof entry === 'string' ? entry : (entry as { loader?: string } | undefined)?.loader
             )
-          : [],
+          : []
       );
 
       expect(ruleLoaders).not.toContain(DIST_RSPACK_LOADER);
@@ -1600,11 +1585,9 @@ describe('RSCRspackPlugin', () => {
       const url = require('url');
       const path = require('path');
       const expected = url.pathToFileURL(
-        path.join(__dirname, 'fixtures/basic-client/ClientButton.js'),
+        path.join(__dirname, 'fixtures/basic-client/ClientButton.js')
       ).href;
-      expect(
-        Object.keys(result.manifest.filePathToModuleMetadata),
-      ).toContain(expected);
+      expect(Object.keys(result.manifest.filePathToModuleMetadata)).toContain(expected);
     });
   });
 });

--- a/tests/webpack-plugin/fixtures/rsc-css-auto/Styled.css
+++ b/tests/webpack-plugin/fixtures/rsc-css-auto/Styled.css
@@ -1,0 +1,1 @@
+.exp-box { --sentinel: styled; background-color: rgb(0, 128, 0); color: #fff; }

--- a/tests/webpack-plugin/fixtures/rsc-css-auto/Styled.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-auto/Styled.js
@@ -1,0 +1,9 @@
+'use client';
+import * as React from 'react';
+import './Styled.css';
+// A plain client component — it does NOT render its own <link>. The plugin's
+// cssWrapper generates a wrapper that renders the CSS <link precedence> for it.
+export default function Styled(props) {
+  return React.createElement('div', { id: 'box', className: 'exp-box' }, props.title);
+}
+export const HELPER_CONSTANT = 'helper-value-42';

--- a/tests/webpack-plugin/fixtures/rsc-css-auto/index.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-auto/index.js
@@ -1,0 +1,1 @@
+export const app = 'rsc-css-auto';

--- a/tests/webpack-plugin/fixtures/rsc-css-barrel/Barrel.client.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-barrel/Barrel.client.js
@@ -1,0 +1,2 @@
+'use client';
+export * from './Styled.client';

--- a/tests/webpack-plugin/fixtures/rsc-css-barrel/Styled.client.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-barrel/Styled.client.js
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import './Styled.css';
+export function Styled(props) {
+  return React.createElement('div', { id: 'box', className: 'exp-box' }, props.title);
+}

--- a/tests/webpack-plugin/fixtures/rsc-css-barrel/Styled.css
+++ b/tests/webpack-plugin/fixtures/rsc-css-barrel/Styled.css
@@ -1,0 +1,1 @@
+.exp-box { --sentinel: styled; background-color: rgb(0, 128, 0); }

--- a/tests/webpack-plugin/fixtures/rsc-css-barrel/index.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-barrel/index.js
@@ -1,0 +1,1 @@
+export const app = 'rsc-css-barrel';

--- a/tests/webpack-plugin/fixtures/rsc-css-proto/Styled.css
+++ b/tests/webpack-plugin/fixtures/rsc-css-proto/Styled.css
@@ -1,0 +1,1 @@
+.exp-box { --sentinel: styled; background-color: rgb(0, 128, 0); color: #fff; }

--- a/tests/webpack-plugin/fixtures/rsc-css-proto/Styled.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-proto/Styled.js
@@ -1,0 +1,23 @@
+'use client';
+
+import * as React from 'react';
+import './Styled.css';
+
+// Models the OUTPUT of the CSS wrapper: a client component that renders its own
+// <link rel="stylesheet" precedence> alongside its content. In the RSC build this
+// body is replaced by registerClientReference; in the client/SSR build it renders.
+export default function Styled(props) {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement('link', {
+      rel: 'stylesheet',
+      precedence: 'rsc-css',
+      href: props.cssHref,
+    }),
+    React.createElement('div', { id: 'box', className: 'exp-box' }, props.title),
+  );
+}
+
+// A non-component named export must survive normal imports unaffected.
+export const HELPER_CONSTANT = 'helper-value-42';

--- a/tests/webpack-plugin/fixtures/rsc-css-proto/index.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-proto/index.js
@@ -1,0 +1,3 @@
+// Entry imports nothing: the 'use client' Styled component (and its CSS) reaches
+// the bundle only through the plugin's injected async block.
+export const app = 'rsc-css-proto';

--- a/tests/webpack-plugin/fixtures/rsc-css-remap/Foo.css
+++ b/tests/webpack-plugin/fixtures/rsc-css-remap/Foo.css
@@ -1,0 +1,1 @@
+.exp-box { --sentinel: styled; background-color: rgb(0, 128, 0); }

--- a/tests/webpack-plugin/fixtures/rsc-css-remap/Foo.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-remap/Foo.js
@@ -1,0 +1,7 @@
+'use client';
+import * as React from 'react';
+import './Foo.css';
+export default function Foo(props) {
+  return React.createElement('div', { id: 'box', className: 'exp-box' }, props.title);
+}
+export const HELPER_CONSTANT = 'helper-value-42';

--- a/tests/webpack-plugin/fixtures/rsc-css-remap/Foo.wrapper.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-remap/Foo.wrapper.js
@@ -1,0 +1,12 @@
+// The generated wrapper: imports the ORIGINAL client module and renders its
+// CSS <link precedence> + the original component, forwarding props.
+import * as React from 'react';
+import Foo from './Foo.js';
+export default function FooWithCss(props) {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement('link', { rel: 'stylesheet', precedence: 'rsc-css', href: props.__cssHref }),
+    React.createElement(Foo, props),
+  );
+}

--- a/tests/webpack-plugin/fixtures/rsc-css-remap/index.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-remap/index.js
@@ -1,0 +1,5 @@
+// Import the wrapper so it is bundled (the plugin also injects an async block for
+// the 'use client' Foo.js it discovers). The manifest is remapped in the test so
+// Foo's client reference resolves to Foo.wrapper.js instead of Foo.js.
+import './Foo.wrapper.js';
+export const app = 'rsc-css-remap';

--- a/tests/webpack-plugin/fixtures/rsc-css-shapes/Shapes.css
+++ b/tests/webpack-plugin/fixtures/rsc-css-shapes/Shapes.css
@@ -1,0 +1,1 @@
+.exp-box { --sentinel: styled; background-color: rgb(0, 128, 0); }

--- a/tests/webpack-plugin/fixtures/rsc-css-shapes/Shapes.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-shapes/Shapes.js
@@ -1,0 +1,14 @@
+'use client';
+import * as React from 'react';
+import './Shapes.css';
+// default is a forwardRef component (an OBJECT, not a function) — the loader's
+// __rscWrap must still wrap it so it emits its <link precedence>.
+export default React.forwardRef(function Shapes(props, ref) {
+  return React.createElement('div', { id: 'box', className: 'exp-box', ref }, props.title);
+});
+// a memo component export
+export const MemoBox = React.memo(function MemoBox(props) {
+  return React.createElement('div', { className: 'memo' }, props.title);
+});
+// a non-component export must be untouched
+export const HELPER_CONSTANT = 'helper-value-42';

--- a/tests/webpack-plugin/fixtures/rsc-css-shapes/entry2.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-shapes/entry2.js
@@ -1,0 +1,1 @@
+export const app2 = 'second-entry';

--- a/tests/webpack-plugin/fixtures/rsc-css-shapes/index.js
+++ b/tests/webpack-plugin/fixtures/rsc-css-shapes/index.js
@@ -1,0 +1,1 @@
+export const app = 'rsc-css-shapes';

--- a/tests/webpack-plugin/fixtures/split-transitive-css/Block.css
+++ b/tests/webpack-plugin/fixtures/split-transitive-css/Block.css
@@ -1,0 +1,3 @@
+.block {
+  color: orange;
+}

--- a/tests/webpack-plugin/fixtures/split-transitive-css/Block.js
+++ b/tests/webpack-plugin/fixtures/split-transitive-css/Block.js
@@ -1,0 +1,5 @@
+import './Block.css';
+
+export default function Block() {
+  return 'block';
+}

--- a/tests/webpack-plugin/fixtures/split-transitive-css/Other.js
+++ b/tests/webpack-plugin/fixtures/split-transitive-css/Other.js
@@ -1,0 +1,7 @@
+'use client';
+
+import Block from './Block';
+
+export default function Other() {
+  return 'other:' + Block();
+}

--- a/tests/webpack-plugin/fixtures/split-transitive-css/Page.js
+++ b/tests/webpack-plugin/fixtures/split-transitive-css/Page.js
@@ -1,0 +1,7 @@
+'use client';
+
+import Block from './Block';
+
+export default function Page() {
+  return 'page:' + Block();
+}

--- a/tests/webpack-plugin/fixtures/split-transitive-css/entryOnly.js
+++ b/tests/webpack-plugin/fixtures/split-transitive-css/entryOnly.js
@@ -1,0 +1,1 @@
+export const entryOnly = 'entry-only-module';

--- a/tests/webpack-plugin/fixtures/split-transitive-css/index.js
+++ b/tests/webpack-plugin/fixtures/split-transitive-css/index.js
@@ -1,0 +1,9 @@
+// Page and Other are 'use client' references that both import Block, a plain
+// dependency module carrying Block.css. splitChunks moves Block.js into a
+// shared JS chunk between both client-reference groups, while
+// MiniCssExtract keeps Block.css in the per-reference sibling chunks. The
+// plugin must recover that CSS by scanning all modules in each chunk rather
+// than only the client references.
+import { entryOnly } from './entryOnly';
+
+export const app = [entryOnly];

--- a/tests/webpack-plugin/helpers/compile.ts
+++ b/tests/webpack-plugin/helpers/compile.ts
@@ -38,6 +38,8 @@ export interface CompileOptions {
   extraEntries?: Record<string, string>;
   /** Wires css-loader + MiniCssExtractPlugin so fixtures can import CSS. */
   withCss?: boolean;
+  /** Enable the CSS FOUC wrapper (issue #4598). */
+  cssWrapper?: boolean;
   /**
    * Appends a re-export of the Flight node client to `main` so a build with
    * `output.library` exposes `createFromNodeStream` from inside the bundle's
@@ -144,6 +146,7 @@ const compileInto = (
     maxChunks: options.maxChunks,
     extraEntries: options.extraEntries,
     withCss: options.withCss,
+    cssWrapper: options.cssWrapper,
     exposeClientRuntime: options.exposeClientRuntime,
   };
   const argsFile = path.join(outputPath, '__args__.json');

--- a/tests/webpack-plugin/helpers/runWebpackWithPlugin.js
+++ b/tests/webpack-plugin/helpers/runWebpackWithPlugin.js
@@ -79,6 +79,7 @@ const {
   entryClientReferencesFilename,
   clientReferences: rawClientReferences,
   chunkName,
+  cssWrapper,
   publicPath,
   publicPathAsFunction,
   crossOriginLoading,
@@ -108,6 +109,7 @@ const plugins = [
     entryClientReferencesFilename,
     clientReferences,
     chunkName,
+    cssWrapper,
   }),
 ];
 if (typeof maxChunks === 'number') {


### PR DESCRIPTION
## Summary

Adds a `cssWrapper` build-plugin option (default off) for both webpack and rspack that prevents CSS FOUC by leveraging React 19's native stylesheet blocking mechanism.

### Problem (issue #4598)

Current RSC client components suffer from CSS FOUC (Flash of Unstyled Content) because:
- CSS is delivered as `ReactDOM.preinit()` hints, which **do not block rendering**
- Components paint unstyled, then CSS arrives → flash
- The existing ~2,800-line Pro CSS machinery is a hand-rolled workaround

### Solution

When `cssWrapper: true` is enabled:
1. Each `'use client'` component resolves to a **generated wrapper** (in SSR-server/browser-client builds only)
2. The wrapper renders `<link rel="stylesheet" precedence="rsc-css">` before the component
3. React's native machinery then blocks rendering until CSS loads — across SSR streaming, hydration, and client navigation

### Implementation

- `src/css-wrapper-runtime.ts` — Runtime wrapper generator (handles fn/forwardRef/memo/barrels)
- `src/webpack/rscCssWrapperLoader.ts` — Webpack loader that produces the wrapper modules
- Plugin edits to `RSCWebpackPlugin.ts` and rspack plugin — `cssWrapper` option, manifest CSS href injection via `__RSC_CSS_HREFS__` global

### Verification

| Check | Result |
|-------|--------|
| 60+ new tests (all export shapes) | ✅ |
| No regression (278 total tests) | ✅ |
| Webpack + rspack support | ✅ |
| Real browser FOUC test (E6/E7) | ✅ FOUC=false |
| Dummy-app `rsc_fouc.spec.ts` | ✅ 6/6 pass |

### What remains (Phase III — not this PR)

- Wrapper-alone dummy run (disable Pro CSS machinery, verify wrapper alone prevents FOUC)
- rspack 2 dummy run
- Remove superseded Pro CSS code (~2,800 lines)

## Test plan

- [x] `yarn test` passes (278/278)
- [x] `yarn build` succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in CSS wrapper mode for Webpack and Rspack.
  * Client components can now emit render-blocking stylesheet links during React Server Component rendering.
  * CSS handling now supports automatic public paths and barrel re-exports while preserving component props, refs, and export shapes.
* **Bug Fixes**
  * Improved CSS asset mapping across runtime chunks and split client references.
* **Tests**
  * Added comprehensive Webpack and Rspack coverage for CSS ordering, remapping, re-exports, and component variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->