### PR TITLE
Fix frozen Yarn install for CSS wrapper dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,6 +2217,11 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-module-lexer@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-module-lexer@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz#1dfcbb5ea3bbfb63f28e1fc3676c3676d1c9624c"


### PR DESCRIPTION
## Summary

- restore Yarn Classic frozen installs by recording the missing `es-module-lexer@^1.6.0` resolution required by the existing dependency graph
- keep the prerequisite to one Yarn-generated `yarn.lock` stanza; no package manifest, product code, or changelog changes
- unblock the downstream marketplace E2E job that currently fails during setup before its own test suite starts

## Verification

- reproduced before the change with Yarn 1.22.22 and a fresh cache/modules directory: `yarn install --frozen-lockfile --ignore-scripts` exited 1 because the lockfile needed updating
- repeated the same isolated frozen install after the change: passed
- `yarn build`: passed
- non-RSC Jest suites: 27 suites / 278 tests passed
- `git diff --check` and exact-scope assertions: passed; one file, 5 insertions
- local report-only review: no blocking findings; simplification review found no safe reduction

## Existing main-head test failure

`.agents/bin/validate` still exits nonzero in `tests/rsc-css-remap.rsc.test.ts` because `Foo.wrapper.js` is not found in generated `main.js`. The identical focused failure reproduces from an untouched detached checkout of base `fd5cf50d140b73ad9c1113e84311daeca056275d` under Node 20.19.0 / Yarn 1.22.22 after `yarn install --no-lockfile --ignore-scripts` and `yarn build` (1 failed, 2 passed). That checkout remained clean, so this is inherited from the current base rather than introduced by the lockfile repair.

## Scope and risk

- only `yarn.lock` changes
- resolution is the Yarn-generated `es-module-lexer` 1.7.0 tarball and integrity metadata
- root Dependabot npm coverage already includes `/`
- no user-visible behavior or changelog entry

This PR is intentionally separate from broader open dependency/release changes so the frozen-install prerequisite can be evaluated on its own.
