### PR TITLE
Test compact-hashed IDs with Rspack 2.2.1

### DIFF
--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -86,6 +86,8 @@ if (missingRuntimeEntries.length > 0) {
 const runtimeEntry = isServer ? runtimeEntries.server : runtimeEntries.client;
 const clientReferences = reviveFromRunner(rawClientReferences);
 const revivedConfigExtra = reviveFromRunner(configExtra);
+const { output: outputExtra, exposeClientRuntime, ...remainingConfigExtra } =
+  revivedConfigExtra || {};
 const plugins = [
   new RSCRspackPlugin({
     isServer: isServer,
@@ -114,7 +116,11 @@ const config = {
   target: isServer ? 'node' : 'web',
   context,
   entry: {
-    main: omitRuntimeEntry ? ['./index.js'] : [runtimeEntry, './index.js'],
+    main: omitRuntimeEntry
+      ? ['./index.js']
+      : isServer && exposeClientRuntime
+        ? ['./index.js', runtimeEntry]
+        : [runtimeEntry, './index.js'],
     ...(extraEntries || {}),
   },
   output: {
@@ -123,6 +129,7 @@ const config = {
     chunkFilename: outputChunkFilename ?? '[name].chunk.js',
     publicPath: publicPath ?? '',
     crossOriginLoading: crossOriginLoading ?? false,
+    ...(outputExtra || {}),
   },
   optimization: {
     chunkIds: 'named',
@@ -138,7 +145,7 @@ const config = {
       }
     : {}),
   plugins,
-  ...(revivedConfigExtra || {}),
+  ...remainingConfigExtra,
 };
 
 rspack(config, (err, stats) => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -27,6 +27,16 @@ type ManifestChunks = CompileResult['manifest']['filePathToModuleMetadata'][stri
 const manifestChunkFiles = (chunks: ManifestChunks): string[] =>
   chunks.filter((_chunk, index) => index % 2 === 1).map(String);
 
+const manifestChunkIds = (chunks: ManifestChunks): string[] =>
+  chunks.filter((_chunk, index) => index % 2 === 0).map(String);
+
+const supportsCompactHashedIds = (() => {
+  const [major = 0, minor = 0, patch = 0] = require('@rspack/core/package.json').version
+    .split('.')
+    .map(Number);
+  return major > 2 || (major === 2 && (minor > 2 || (minor === 2 && patch >= 1)));
+})();
+
 const readDiagnosticCss = (result: CompileResult, entryFileSuffix: string): string => {
   const entry = result.clientReferenceDiagnostics?.clientReferences.find((reference) =>
     reference.file.endsWith(entryFileSuffix)
@@ -1496,6 +1506,100 @@ describe('RSCRspackPlugin', () => {
       expect(chunkFiles).toEqual(['main.mjs']);
       expect(chunkFiles).not.toContain('runtime.mjs');
     });
+
+    // compact-hashed was added in Rspack 2.2.1. Keep older supported Rspack
+    // installations green while exercising this identifier strategy when available.
+    (supportsCompactHashedIds ? it : it.skip)(
+      'loads a compact-hashed client reference through the generated manifest',
+      () => {
+        const clientReferences = staticIslandClientReferences(/^\.\/TinyIsland\.js$/);
+        const compactHashedOptimization = {
+          chunkIds: 'compact-hashed',
+          moduleIds: 'compact-hashed',
+          minimize: false,
+        };
+        const client = run('static-islands', {
+          clientReferences,
+          configExtra: { optimization: compactHashedOptimization },
+        });
+        const server = run('static-islands', {
+          isServer: true,
+          clientReferences,
+          configExtra: {
+            exposeClientRuntime: true,
+            output: { library: { type: 'commonjs2' } },
+            optimization: compactHashedOptimization,
+          },
+        });
+        const clientEntry = manifestMetadataFor(client, '/TinyIsland.js');
+        const serverEntry = manifestMetadataFor(server, '/TinyIsland.js');
+        const clientChunkIds = manifestChunkIds(clientEntry.chunks);
+
+        expect(clientEntry.id).toMatch(/^[A-Za-z0-9_-]+$/);
+        expect(clientEntry.id).not.toContain('TinyIsland');
+        expect(clientChunkIds).toHaveLength(1);
+        expect(clientChunkIds[0]).toMatch(/^[A-Za-z0-9_-]+$/);
+        expect(clientChunkIds[0]).not.toBe('client0');
+        expect(manifestChunkFiles(clientEntry.chunks)).toEqual(['client0.chunk.js']);
+        expect(serverEntry.chunks).toEqual(clientEntry.chunks);
+
+        const encodeScript = `
+          const fs = require('fs');
+          const { PassThrough } = require('stream');
+          const { text } = require('stream/consumers');
+          const React = require(${JSON.stringify(require.resolve('react'))});
+          const { renderToPipeableStream, registerClientReference } = require(${JSON.stringify(
+            require.resolve('react-server-dom-webpack/server.node')
+          )});
+          const manifest = JSON.parse(fs.readFileSync(${JSON.stringify(client.manifestPath)}, 'utf8'));
+          const clientReferencePath = Object.keys(manifest.filePathToModuleMetadata).find((entry) =>
+            entry.endsWith('/TinyIsland.js')
+          );
+          const TinyIsland = registerClientReference(
+            () => { throw new Error('client reference must not render on the server'); },
+            clientReferencePath,
+            'default'
+          );
+          (async () => {
+            const stream = renderToPipeableStream(
+              React.createElement(TinyIsland),
+              manifest.filePathToModuleMetadata
+            );
+            const sink = new PassThrough();
+            stream.pipe(sink);
+            process.stdout.write(await text(sink));
+          })().catch((error) => {
+            process.stderr.write(String(error.stack || error));
+            process.exit(1);
+          });
+        `;
+        const nodeOptions = [process.env.NODE_OPTIONS, '--conditions=react-server']
+          .filter(Boolean)
+          .join(' ');
+        const payload = execFileSync(process.execPath, ['-e', encodeScript], {
+          encoding: 'utf8',
+          env: { ...process.env, NODE_OPTIONS: nodeOptions },
+          timeout: MULTICOMPILER_CHILD_TIMEOUT_MS,
+        });
+
+        fs.writeFileSync(path.join(server.outputPath, 'payload.txt'), payload);
+        fs.writeFileSync(path.join(server.outputPath, 'client-manifest.json'), client.manifestSource);
+        fs.writeFileSync(path.join(server.outputPath, 'server-manifest.json'), server.manifestSource);
+        fs.writeFileSync(path.join(server.outputPath, 'decode.js'), COMPACT_HASHED_DECODE_SCRIPT);
+
+        const decoded = JSON.parse(
+          execFileSync(process.execPath, ['decode.js'], {
+            cwd: server.outputPath,
+            encoding: 'utf8',
+            timeout: MULTICOMPILER_CHILD_TIMEOUT_MS,
+          })
+        ) as { ok: boolean; text?: string; error?: string };
+        expect(decoded.error).toBeUndefined();
+        expect(decoded.ok).toBe(true);
+        expect(decoded.text).toBe('tiny interactive island');
+      },
+      MULTICOMPILER_JEST_TIMEOUT_MS
+    );
   });
 
   describe('plugin option validation', () => {
@@ -1591,3 +1695,24 @@ describe('RSCRspackPlugin', () => {
     });
   });
 });
+
+const COMPACT_HASHED_DECODE_SCRIPT = `
+'use strict';
+const fs = require('fs');
+const { Readable } = require('stream');
+const { buildClientRenderer } = require('./main.js');
+const clientManifest = JSON.parse(fs.readFileSync('./client-manifest.json', 'utf8'));
+const serverManifest = JSON.parse(fs.readFileSync('./server-manifest.json', 'utf8'));
+const { createFromNodeStream } = buildClientRenderer(clientManifest, serverManifest);
+const resolveLazy = async (value) =>
+  value && value.$$typeof === Symbol.for('react.lazy') ? await value._payload : value;
+(async () => {
+  try {
+    const root = await createFromNodeStream(Readable.from([fs.readFileSync('./payload.txt')]));
+    const type = await resolveLazy(root.type);
+    process.stdout.write(JSON.stringify({ ok: true, text: type(root.props) }));
+  } catch (error) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String(error.stack || error) }));
+  }
+})();
+`;


### PR DESCRIPTION
## Why

Rspack 2.2.1 added the `compact-hashed` module and chunk identifier strategies. The plugin does not select an application's optimization strategy, but it should remain compatible when an application opts into these IDs.

## What changed

- add a version-gated Rspack integration case with both `moduleIds` and `chunkIds` set to `compact-hashed`
- verify compact IDs are emitted consistently in the client and server manifests
- exercise a real Flight encode/decode path that loads and invokes the generated client-reference chunk
- keep the existing named-ID defaults unchanged and skip the new case before Rspack 2.2.1

## Review path

Start with the new integration case in `tests/rspack-plugin/plugin.test.ts`, then review the small test-runner hook in `tests/rspack-plugin/helpers/runRspackWithPlugin.js` that exposes the generated client runtime for the decode assertion.

## Verification

- Rspack 2.2.1: `yarn jest tests/rspack-plugin/plugin.test.ts` — 82 passed
- Rspack 2.2.1: `yarn build` — passed
- Rspack 2.2.1: `yarn test` — 12 RSC suites / 27 tests and 27 non-RSC suites / 279 tests passed
- locked Rspack 2.1.2: `yarn jest tests/rspack-plugin/plugin.test.ts` — 81 passed, 1 intentionally skipped
- independent QA review — no findings; scope, version gate, manifest assertions, runtime loading, and default preservation verified

## Agent details

- Decision: retain named IDs as the test runner default; opt into `compact-hashed` only in the new scenario.
- Decision: gate at Rspack 2.2.1 to preserve the supported 1.x and older 2.x matrix.
- Decision: omit a changelog entry because this adds coverage without changing package behavior.
- Churn: one implementation commit; no review-fix pushes.

Closes #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added compatibility testing for compact hashed module and chunk IDs across client and server builds.
  * Added end-to-end validation of React Server Components rendering, manifest parity, and payload decoding.
  * Improved test configuration for exposing client runtime entries and merging output settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->