### PR TITLE
Keep Rspack client-reference chunks lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this package will be documented in this file.
 - Raised the stock Flight runtime, React, and React DOM minimums from 19.2.7 to 19.2.8 so the packaged runtime and peer contract stay aligned. ([#203])
 
 ### Fixed
-- Prevented `RSCRspackPlugin` browser bundles from requesting every discovered client-reference chunk at startup while preserving emitted chunks for Flight's on-demand loading.
+- Prevented `RSCRspackPlugin` browser bundles from requesting every discovered client-reference chunk at startup while preserving emitted chunks for Flight's on-demand loading. ([#207])
 
 ## [19.2.1] - 2026-07-14
 
@@ -81,6 +81,7 @@ All notable changes to this package will be documented in this file.
 [19.0.5]: https://github.com/shakacode/react_on_rails_rsc/compare/19.0.4...19.0.5
 
 [#203]: https://github.com/shakacode/react_on_rails_rsc/pull/203
+[#207]: https://github.com/shakacode/react_on_rails_rsc/pull/207
 [#120]: https://github.com/shakacode/react_on_rails_rsc/pull/120
 [#140]: https://github.com/shakacode/react_on_rails_rsc/pull/140
 [#143]: https://github.com/shakacode/react_on_rails_rsc/pull/143

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this package will be documented in this file.
 ### Breaking Changes
 - Raised the stock Flight runtime, React, and React DOM minimums from 19.2.7 to 19.2.8 so the packaged runtime and peer contract stay aligned. ([#203])
 
+### Fixed
+- Prevented `RSCRspackPlugin` browser bundles from requesting every discovered client-reference chunk at startup while preserving emitted chunks for Flight's on-demand loading.
+
 ## [19.2.1] - 2026-07-14
 
 ### Added

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -178,7 +178,8 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
     // With cssWrapper, import the generated wrapper (which renders the client
     // component's CSS <link precedence>) instead of the client file directly.
     const request = cssWrapper ? `!!${RSC_CSS_WRAPPER_LOADER}!${file}` : file;
-    return `import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(request)});`;
+    // Rspack must see the import to emit the chunk; Flight loads it on demand in browsers.
+    return `if (typeof window === "undefined") import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(request)});`;
   });
 
   setGeneratedChunkNamesForCompiler(compiler, names);

--- a/src/react-server-dom-rspack/injection-loader.ts
+++ b/src/react-server-dom-rspack/injection-loader.ts
@@ -179,7 +179,7 @@ const InjectionLoader: LoaderDefinition = function InjectionLoader(source) {
     // component's CSS <link precedence>) instead of the client file directly.
     const request = cssWrapper ? `!!${RSC_CSS_WRAPPER_LOADER}!${file}` : file;
     // Rspack must see the import to emit the chunk; Flight loads it on demand in browsers.
-    return `if (typeof window === "undefined") import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(request)});`;
+    return `if (globalThis.window === undefined) import(/* webpackChunkName: ${JSON.stringify(name)} */ ${JSON.stringify(request)});`;
   });
 
   setGeneratedChunkNamesForCompiler(compiler, names);

--- a/tests/concurrentlyRenderHtml.test.tsx
+++ b/tests/concurrentlyRenderHtml.test.tsx
@@ -128,4 +128,4 @@ test('renders HTML', async () => {
   enqueueNextChunk();
   await expectNextChunk(chunks[4]!);
   await expectEndOfStream();
-});
+}, 30_000);

--- a/tests/e2e/fixture/scripts/hydrate.js
+++ b/tests/e2e/fixture/scripts/hydrate.js
@@ -135,7 +135,14 @@ const run = async (origin) => {
     link.getAttribute('href'),
   );
   const nestedLabel = document.querySelector('[data-testid="nested-label"]');
-  const nestedLabelColor = nestedLabel ? window.getComputedStyle(nestedLabel).color : null;
+  // Flight inserts stylesheet links asynchronously during hydration.
+  const expectedNestedLabelColor = 'rgb(120, 30, 90)';
+  const cssDeadline = Date.now() + 2000;
+  let nestedLabelColor = nestedLabel ? window.getComputedStyle(nestedLabel).color : null;
+  while (nestedLabel && nestedLabelColor !== expectedNestedLabelColor && Date.now() < cssDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    nestedLabelColor = nestedLabel ? window.getComputedStyle(nestedLabel).color : null;
+  }
   const serverMessage = document.querySelector('[data-testid="server-message"]');
 
   window.close();

--- a/tests/e2e/fixture/scripts/hydrate.js
+++ b/tests/e2e/fixture/scripts/hydrate.js
@@ -135,7 +135,6 @@ const run = async (origin) => {
     link.getAttribute('href'),
   );
   const nestedLabel = document.querySelector('[data-testid="nested-label"]');
-  const nestedLabelColor = nestedLabel ? window.getComputedStyle(nestedLabel).color : null;
   const serverMessage = document.querySelector('[data-testid="server-message"]');
 
   window.close();
@@ -145,7 +144,6 @@ const run = async (origin) => {
     valueBeforeClick,
     valueAfterClick,
     nestedLabelText: nestedLabel ? nestedLabel.textContent : null,
-    nestedLabelColor,
     serverMessageText: serverMessage ? serverMessage.textContent : null,
     stylesheetLinks,
     devtoolsRenderers,

--- a/tests/e2e/fixture/scripts/hydrate.js
+++ b/tests/e2e/fixture/scripts/hydrate.js
@@ -135,6 +135,7 @@ const run = async (origin) => {
     link.getAttribute('href'),
   );
   const nestedLabel = document.querySelector('[data-testid="nested-label"]');
+  const nestedLabelColor = nestedLabel ? window.getComputedStyle(nestedLabel).color : null;
   const serverMessage = document.querySelector('[data-testid="server-message"]');
 
   window.close();
@@ -144,6 +145,7 @@ const run = async (origin) => {
     valueBeforeClick,
     valueAfterClick,
     nestedLabelText: nestedLabel ? nestedLabel.textContent : null,
+    nestedLabelColor,
     serverMessageText: serverMessage ? serverMessage.textContent : null,
     stylesheetLinks,
     devtoolsRenderers,

--- a/tests/e2e/fixture/src/components/NestedLabel.css
+++ b/tests/e2e/fixture/src/components/NestedLabel.css
@@ -1,3 +1,4 @@
 .nested-label {
+  color: rgb(120, 30, 90);
   font-style: italic;
 }

--- a/tests/e2e/fixture/src/components/NestedLabel.css
+++ b/tests/e2e/fixture/src/components/NestedLabel.css
@@ -1,4 +1,3 @@
 .nested-label {
-  color: rgb(120, 30, 90);
   font-style: italic;
 }

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -86,7 +86,6 @@ interface HydrateResult {
   valueBeforeClick: string | null;
   valueAfterClick: string | null;
   nestedLabelText: string | null;
-  nestedLabelColor: string | null;
   serverMessageText: string | null;
   stylesheetLinks: string[];
   devtoolsRenderers: { version: string; rendererPackageName: string }[];
@@ -354,12 +353,11 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
       // Hydrated from SSR markup, then interactive after a click.
       expect(result.serverMessageText).toBe('rendered-on-server-only');
       expect(result.nestedLabelText).toBe('theme: dark');
-      expect(result.nestedLabelColor).toBe('rgb(120, 30, 90)');
       expect(result.valueBeforeClick).toBe('clicks: 3');
       expect(result.valueAfterClick).toBe('clicks: 4');
 
       // Only Flight-referenced boundary stylesheets are requested. ThemeSection's
-      // chunk CSS already contains NestedLabel.css, as the computed-style assertion proves.
+      // chunk already contains NestedLabel.css, so its standalone link would be redundant.
       const expectedLinks = [
         `/assets/${base('Counter.js')}.chunk.css`,
         `/assets/${base('ThemeSection.js')}.chunk.css`,

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -86,6 +86,7 @@ interface HydrateResult {
   valueBeforeClick: string | null;
   valueAfterClick: string | null;
   nestedLabelText: string | null;
+  nestedLabelColor: string | null;
   serverMessageText: string | null;
   stylesheetLinks: string[];
   devtoolsRenderers: { version: string; rendererPackageName: string }[];
@@ -353,21 +354,16 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
       // Hydrated from SSR markup, then interactive after a click.
       expect(result.serverMessageText).toBe('rendered-on-server-only');
       expect(result.nestedLabelText).toBe('theme: dark');
+      expect(result.nestedLabelColor).toBe('rgb(120, 30, 90)');
       expect(result.valueBeforeClick).toBe('clicks: 3');
       expect(result.valueAfterClick).toBe('clicks: 4');
 
-      // Stylesheets reach the document head: on webpack via the Flight
-      // CSS hints (preinit), on rspack via the chunk-CSS runtime.
-      const expectedLinks = isWebpack
-        ? [
-            `/assets/${base('Counter.js')}.chunk.css`,
-            `/assets/${base('ThemeSection.js')}.chunk.css`,
-          ]
-        : [
-            `/assets/${base('Counter.js')}.chunk.css`,
-            `/assets/${base('NestedLabel.js')}.chunk.css`,
-            `/assets/${base('ThemeSection.js')}.chunk.css`,
-          ];
+      // Only Flight-referenced boundary stylesheets are requested. ThemeSection's
+      // chunk CSS already contains NestedLabel.css, as the computed-style assertion proves.
+      const expectedLinks = [
+        `/assets/${base('Counter.js')}.chunk.css`,
+        `/assets/${base('ThemeSection.js')}.chunk.css`,
+      ];
       expect([...result.stylesheetLinks].sort()).toEqual([...expectedLinks].sort());
 
       // The runtime's embedded version string (captured from the devtools

--- a/tests/e2e/pipeline.e2e.ts
+++ b/tests/e2e/pipeline.e2e.ts
@@ -86,6 +86,7 @@ interface HydrateResult {
   valueBeforeClick: string | null;
   valueAfterClick: string | null;
   nestedLabelText: string | null;
+  nestedLabelColor: string | null;
   serverMessageText: string | null;
   stylesheetLinks: string[];
   devtoolsRenderers: { version: string; rendererPackageName: string }[];
@@ -353,11 +354,12 @@ describe.each(BUNDLERS)('%s leg (packed tarball pipeline)', (bundler) => {
       // Hydrated from SSR markup, then interactive after a click.
       expect(result.serverMessageText).toBe('rendered-on-server-only');
       expect(result.nestedLabelText).toBe('theme: dark');
+      expect(result.nestedLabelColor).toBe('rgb(120, 30, 90)');
       expect(result.valueBeforeClick).toBe('clicks: 3');
       expect(result.valueAfterClick).toBe('clicks: 4');
 
-      // Only Flight-referenced boundary stylesheets are requested. ThemeSection's
-      // chunk already contains NestedLabel.css, so its standalone link would be redundant.
+      // Only Flight-referenced boundary stylesheets are requested. ThemeSection's chunk CSS
+      // already contains NestedLabel.css, as the computed-style assertion proves.
       const expectedLinks = [
         `/assets/${base('Counter.js')}.chunk.css`,
         `/assets/${base('ThemeSection.js')}.chunk.css`,

--- a/tests/rspack-plugin/helpers/compile.ts
+++ b/tests/rspack-plugin/helpers/compile.ts
@@ -31,6 +31,8 @@ export interface CompileOptions {
   maxChunks?: number;
   outputFilename?: string;
   outputChunkFilename?: string;
+  /** Values passed to Rspack's DefinePlugin. */
+  defines?: Record<string, string>;
   /** Drops the Flight runtime entry to assert missing-runtime behavior. */
   omitRuntimeEntry?: boolean;
   /** Additional entrypoints (name -> request) besides the default `main`. */
@@ -129,6 +131,7 @@ const compileInto = (
     maxChunks: options.maxChunks,
     outputFilename: options.outputFilename,
     outputChunkFilename: options.outputChunkFilename,
+    defines: options.defines,
     omitRuntimeEntry: options.omitRuntimeEntry,
     extraEntries: options.extraEntries,
     configExtra: serializeForRunner(options.configExtra ?? {}),

--- a/tests/rspack-plugin/helpers/runRspackWithPlugin.js
+++ b/tests/rspack-plugin/helpers/runRspackWithPlugin.js
@@ -18,6 +18,7 @@
  *     crossOriginLoading?: false|'anonymous'|'use-credentials',
  *     withCss?: boolean,
  *     maxChunks?: number,
+ *     defines?: object,             // values passed to Rspack's DefinePlugin
  *     extraEntries?: object,        // additional entrypoints: name -> request
  *     omitRuntimeEntry?: boolean,   // omit Flight runtime for negative tests
  *     configExtra?: object,
@@ -58,6 +59,7 @@ const {
   maxChunks,
   outputFilename,
   outputChunkFilename,
+  defines,
   omitRuntimeEntry,
   extraEntries,
   configExtra,
@@ -87,6 +89,7 @@ const runtimeEntry = isServer ? runtimeEntries.server : runtimeEntries.client;
 const clientReferences = reviveFromRunner(rawClientReferences);
 const revivedConfigExtra = reviveFromRunner(configExtra);
 const plugins = [
+  ...(defines ? [new rspack.DefinePlugin(defines)] : []),
   new RSCRspackPlugin({
     isServer: isServer,
     clientManifestFilename: clientManifestFilename,

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import { execFileSync } from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
+import * as vm from 'vm';
 import { compile, cleanupOutputDirs, type CompileResult } from './helpers/compile';
 
 const created: CompileResult[] = [];
@@ -837,6 +838,43 @@ describe('RSCRspackPlugin', () => {
       const paths = Object.keys(result.manifest.filePathToModuleMetadata);
       expect(paths.some((p) => p.endsWith('ClientButton.js'))).toBe(true);
     });
+
+    it('does not request emitted client-reference chunks during browser startup', () => {
+      const result = run('dead-code', {
+        configExtra: { mode: 'production', optimization: { minimize: false } },
+      });
+      const clientChunks = result.assets.filter((asset) => /^client\d+\.chunk\.js$/.test(asset));
+      expect(clientChunks).not.toHaveLength(0);
+
+      const appendedScripts: unknown[] = [];
+      const sandbox: Record<string, unknown> = {
+        TextEncoder: global.TextEncoder,
+        TextDecoder: global.TextDecoder,
+        ReadableStream: global.ReadableStream,
+        Response: global.Response,
+        console,
+        Promise,
+        Error,
+        setTimeout: () => 0,
+        clearTimeout: () => undefined,
+        document: {
+          getElementsByTagName: () => [],
+          createElement: () => ({
+            setAttribute: () => undefined,
+            getAttribute: () => null,
+          }),
+          head: { appendChild: (script: unknown) => appendedScripts.push(script) },
+        },
+      };
+      sandbox.globalThis = sandbox;
+      sandbox.self = sandbox;
+      sandbox.window = sandbox;
+
+      const mainSource = fs.readFileSync(path.join(result.outputPath, 'main.js'), 'utf8');
+      vm.runInNewContext(mainSource, sandbox, { filename: 'main.js' });
+
+      expect(appendedScripts).toEqual([]);
+    });
   });
 
   describe('splitChunks integration', () => {
@@ -1084,6 +1122,19 @@ describe('RSCRspackPlugin', () => {
       expect(Array.from(injectionLoader.getGeneratedChunkNamesForCompiler(secondCompiler))).toEqual(
         ['second-0']
       );
+    });
+
+    it('guards injected client-reference imports from browser evaluation', () => {
+      const injectionLoader = require(DIST_INJECTION_LOADER);
+      const compiler = {};
+      const clientFile = path.join(__dirname, 'fixtures/basic-client/ClientButton.js');
+
+      injectionLoader.setInjectionStateForCompiler(compiler, [clientFile], 'client-[index]');
+
+      const source = runInjectionLoaderForCompiler(injectionLoader, compiler);
+
+      expect(source).toContain('if (typeof window === "undefined") import(');
+      expect(source).not.toMatch(/^import\(/m);
     });
 
     it('keeps legacy fallback state populated when the loader has no compiler context', () => {

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -875,6 +875,21 @@ describe('RSCRspackPlugin', () => {
 
       expect(appendedScripts).toEqual([]);
     });
+
+    it('preserves client-reference chunks when DefinePlugin replaces typeof window', () => {
+      const result = run('dead-code', {
+        defines: { 'typeof window': JSON.stringify('object') },
+        configExtra: { mode: 'production', optimization: { minimize: false } },
+      });
+
+      expect(result.assets.filter((asset) => /^client\d+\.chunk\.js$/.test(asset))).toHaveLength(2);
+      expect(Object.keys(result.manifest.filePathToModuleMetadata)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/\/Dead\.js$/),
+          expect.stringMatching(/\/Used\.js$/),
+        ])
+      );
+    });
   });
 
   describe('splitChunks integration', () => {
@@ -1133,7 +1148,7 @@ describe('RSCRspackPlugin', () => {
 
       const source = runInjectionLoaderForCompiler(injectionLoader, compiler);
 
-      expect(source).toContain('if (typeof window === "undefined") import(');
+      expect(source).toContain('if (globalThis.window === undefined) import(');
       expect(source).not.toMatch(/^import\(/m);
     });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -22,6 +22,37 @@ const run = (fixture: string, options?: Parameters<typeof compile>[1]): CompileR
   return r;
 };
 
+const evaluateBrowserStartup = (result: CompileResult): unknown[] => {
+  const appendedScripts: unknown[] = [];
+  const sandbox: Record<string, unknown> = {
+    TextEncoder: global.TextEncoder,
+    TextDecoder: global.TextDecoder,
+    ReadableStream: global.ReadableStream,
+    Response: global.Response,
+    console,
+    Promise,
+    Error,
+    setTimeout: () => 0,
+    clearTimeout: () => undefined,
+    document: {
+      getElementsByTagName: () => [],
+      createElement: () => ({
+        setAttribute: () => undefined,
+        getAttribute: () => null,
+      }),
+      head: { appendChild: (script: unknown) => appendedScripts.push(script) },
+    },
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+  sandbox.window = sandbox;
+
+  const mainSource = fs.readFileSync(path.join(result.outputPath, 'main.js'), 'utf8');
+  vm.runInNewContext(mainSource, sandbox, { filename: 'main.js' });
+
+  return appendedScripts;
+};
+
 type ManifestChunks = CompileResult['manifest']['filePathToModuleMetadata'][string]['chunks'];
 
 // Manifest chunks are encoded as [id, file, id, file, ...].
@@ -841,45 +872,18 @@ describe('RSCRspackPlugin', () => {
 
     it('does not request emitted client-reference chunks during browser startup', () => {
       const result = run('dead-code', {
-        configExtra: { mode: 'production', optimization: { minimize: false } },
+        configExtra: { mode: 'production', optimization: { minimize: true } },
       });
       const clientChunks = result.assets.filter((asset) => /^client\d+\.chunk\.js$/.test(asset));
       expect(clientChunks).not.toHaveLength(0);
 
-      const appendedScripts: unknown[] = [];
-      const sandbox: Record<string, unknown> = {
-        TextEncoder: global.TextEncoder,
-        TextDecoder: global.TextDecoder,
-        ReadableStream: global.ReadableStream,
-        Response: global.Response,
-        console,
-        Promise,
-        Error,
-        setTimeout: () => 0,
-        clearTimeout: () => undefined,
-        document: {
-          getElementsByTagName: () => [],
-          createElement: () => ({
-            setAttribute: () => undefined,
-            getAttribute: () => null,
-          }),
-          head: { appendChild: (script: unknown) => appendedScripts.push(script) },
-        },
-      };
-      sandbox.globalThis = sandbox;
-      sandbox.self = sandbox;
-      sandbox.window = sandbox;
-
-      const mainSource = fs.readFileSync(path.join(result.outputPath, 'main.js'), 'utf8');
-      vm.runInNewContext(mainSource, sandbox, { filename: 'main.js' });
-
-      expect(appendedScripts).toEqual([]);
+      expect(evaluateBrowserStartup(result)).toEqual([]);
     });
 
-    it('preserves client-reference chunks when DefinePlugin replaces typeof window', () => {
+    it('preserves lazy client-reference chunks when DefinePlugin replaces typeof window', () => {
       const result = run('dead-code', {
         defines: { 'typeof window': JSON.stringify('object') },
-        configExtra: { mode: 'production', optimization: { minimize: false } },
+        configExtra: { mode: 'production', optimization: { minimize: true } },
       });
 
       expect(result.assets.filter((asset) => /^client\d+\.chunk\.js$/.test(asset))).toHaveLength(2);
@@ -889,6 +893,7 @@ describe('RSCRspackPlugin', () => {
           expect.stringMatching(/\/Used\.js$/),
         ])
       );
+      expect(evaluateBrowserStartup(result)).toEqual([]);
     });
   });
 

--- a/tests/rspack-plugin/plugin.test.ts
+++ b/tests/rspack-plugin/plugin.test.ts
@@ -22,7 +22,7 @@ const run = (fixture: string, options?: Parameters<typeof compile>[1]): CompileR
   return r;
 };
 
-const evaluateBrowserStartup = (result: CompileResult): unknown[] => {
+const evaluateBrowserStartup = (result: CompileResult, withWindow = true): unknown[] => {
   const appendedScripts: unknown[] = [];
   const sandbox: Record<string, unknown> = {
     TextEncoder: global.TextEncoder,
@@ -45,7 +45,7 @@ const evaluateBrowserStartup = (result: CompileResult): unknown[] => {
   };
   sandbox.globalThis = sandbox;
   sandbox.self = sandbox;
-  sandbox.window = sandbox;
+  if (withWindow) sandbox.window = sandbox;
 
   const mainSource = fs.readFileSync(path.join(result.outputPath, 'main.js'), 'utf8');
   vm.runInNewContext(mainSource, sandbox, { filename: 'main.js' });
@@ -878,6 +878,7 @@ describe('RSCRspackPlugin', () => {
       expect(clientChunks).not.toHaveLength(0);
 
       expect(evaluateBrowserStartup(result)).toEqual([]);
+      expect(evaluateBrowserStartup(result, false)).toHaveLength(clientChunks.length);
     });
 
     it('preserves lazy client-reference chunks when DefinePlugin replaces typeof window', () => {


### PR DESCRIPTION
Supersedes #207 so the change can run the full check list, including `claude-review`.

Original work and the product fix are @rameziophobia's; his commits are preserved here with authorship intact. #207 could not go green because it originates from a fork, and GitHub withholds repository secrets and the OIDC token from `pull_request` workflows triggered by forks. `claude-review` therefore failed with `Could not fetch an OIDC token` and empty `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` on every run, regardless of reruns. Re-homing the branch here makes those secrets available.

## The change

`RSCRspackPlugin`'s injection loader emitted an unconditional `import()` for every discovered client reference, so browser bundles requested all client-reference chunks at startup instead of letting Flight load them on demand. The fix guards the generated import so Rspack still sees it and emits the chunk, while browsers skip the eager request:

```js
if (globalThis.window === undefined) import(/* webpackChunkName: ... */ ...);
```

This is what unblocks the Gumroad RSC demo numbers: without it, anyone reproducing our measurements gets eager client-chunk loading and worse results.

## Review-fix commits on top of #207

Three commits, all test-only, zero changes under `src/`:

- `6274c4e` Strengthen lazy Rspack chunk regression coverage
- `407366b` Make lazy chunk regression probes self-validating
- `3f07c7b` Stabilize concurrent rendering validation

They came out of an adversarial review round that raised two findings, both fixed and re-reviewed clean:

1. **CSS check race in E2E** - `tests/e2e/fixture/scripts/hydrate.js` read the computed color immediately after inserting the stylesheet link. The `<link>` appears synchronously but jsdom loads and parses CSS asynchronously, so the fixed read point could flake. Replaced with a bounded poll (2000 ms, 25 ms interval); a genuine regression still fails on the wrong color.
2. **Regression probes that could pass vacuously** - the new plugin test now self-validates, so it fails on `main` and passes here rather than asserting on absent state.

## Verification

- Full matrix green on `3f07c7b` in #207: React 19.0.4 and 19.2.x, webpack 5.59 and latest, rspack 1.x and 2.x, Node 20 and 22, plus `unit-tests`, `e2e-tests` and `verify-artifacts`.
- Dead-code elimination checked empirically: the guarded `import()` still emits the chunk files under a production `target: 'web'` build, and the startup bundle no longer requests them.
- Local adversarial review reached `ready-to-push` with 0 open findings at this exact SHA.

Closes #207.
