### PR TITLE
Stamp CHANGELOG and package version for 19.3.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [19.3.0-rc.0] - 2026-08-29
 
 ### Breaking Changes
 - Raised the stock Flight runtime, React, and React DOM minimums from 19.2.7 to 19.2.8 so the packaged runtime and peer contract stay aligned. ([#203])
 
+### Added
+- Added an opt-in `cssWrapper` option to `RSCWebpackPlugin` and `RSCRspackPlugin` that prevents client-component CSS flash-of-unstyled-content by resolving each `"use client"` module to a generated wrapper which renders a native React 19 `<link rel="stylesheet" precedence>`, so the stylesheet blocks paint instead of arriving as a non-blocking `ReactDOM.preinit()` hint. Off by default. ([#196])
+
 ### Fixed
-- Prevented `RSCRspackPlugin` browser bundles from requesting every discovered client-reference chunk at startup while preserving emitted chunks for Flight's on-demand loading. ([#207])
+- Prevented `RSCRspackPlugin` browser bundles from requesting every discovered client-reference chunk at startup while preserving emitted chunks for Flight's on-demand loading. ([#207]) ([#210])
 
 ## [19.2.1] - 2026-07-14
 
@@ -119,3 +122,5 @@ All notable changes to this package will be documented in this file.
 [#86]: https://github.com/shakacode/react_on_rails_rsc/pull/86
 [#110]: https://github.com/shakacode/react_on_rails_rsc/pull/110
 [#113]: https://github.com/shakacode/react_on_rails_rsc/pull/113
+[#196]: https://github.com/shakacode/react_on_rails_rsc/pull/196
+[#210]: https://github.com/shakacode/react_on_rails_rsc/pull/210

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-rsc",
-  "version": "19.2.1",
+  "version": "19.3.0-rc.0",
   "description": "React Server Components support for react_on_rails Ruby gem",
   "exports": {
     "./client": {

--- a/tests/package-runtime-policy.test.ts
+++ b/tests/package-runtime-policy.test.ts
@@ -30,7 +30,7 @@ const collectExportTargets = (value: unknown): string[] => {
 };
 
 describe('19.2 runtime release policy', () => {
-  it('stamps the package and changelog for the 19.2.1 release line', () => {
+  it('stamps the package and changelog for the 19.3.0 release line', () => {
     const pkg = readJson<PackageJson>('package.json');
     const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
 
@@ -38,7 +38,7 @@ describe('19.2 runtime release policy', () => {
     // require editing this test between RC and final stamps. Still pins the
     // current package release line and requires the
     // CHANGELOG's top entry to match the package version exactly.
-    expect(pkg.version).toMatch(/^19\.2\.1(?:-rc\.\d+)?$/);
+    expect(pkg.version).toMatch(/^19\.3\.0(?:-rc\.\d+)?$/);
     const topChangelogVersion = changelog.match(/^## \[([^\]]+)\] - \d{4}-\d{2}-\d{2}$/m)?.[1];
     expect(topChangelogVersion).toBe(pkg.version);
   });


### PR DESCRIPTION
Stamps `19.3.0-rc.0` in `CHANGELOG.md` and `package.json` so the `Release package` workflow can run.

## Version choice

Minor, not major, following this repo's own precedent: `19.2.0` also carried a `Breaking Changes` section (the move to the React 19.2 runtime) and shipped as a minor bump from `19.0.5`. The breaking change here is narrower still - a patch-level floor raise inside the same React minor line, 19.2.7 to 19.2.8. Staying under `20.0.0` also keeps the change inside `react-on-rails-pro`'s existing peer range (`>=19.2.1 <20.0.0`), so downstream picks it up without a coordinated release.

RC first, matching how every recent version shipped here (`19.2.0-rc.1..4`, `19.2.1-rc.0..1`).

## Changelog gap fixed

`#196` (the opt-in `cssWrapper` option) merged on 2026-07-21, after `19.2.1` shipped, but never got a changelog entry. It is user-visible plugin configuration, so per `.agents/skills/rsc-update-changelog` it belongs in the release notes. Added under `### Added`.

`#209` is deliberately left out: it is test-only coverage for compact-hashed Rspack IDs, which the same skill says to skip.

The `#207` entry now also cites `#210`, the PR that actually landed the fix.

## Contents of 19.3.0-rc.0

- **Breaking**: stock Flight runtime, React and React DOM minimums raised 19.2.7 to 19.2.8 (`#203`)
- **Added**: opt-in `cssWrapper` option for native React 19 stylesheet-blocking FOUC prevention (`#196`)
- **Fixed**: Rspack client-reference chunks stay lazy at browser startup (`#207`, `#210`)
